### PR TITLE
chore: reuse reqwest::Client

### DIFF
--- a/src/ui/network.rs
+++ b/src/ui/network.rs
@@ -1,6 +1,6 @@
 use dirs::home_dir;
 use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::Error;
+use reqwest::{Client, Error};
 use serde_json::json;
 use serde_json::Value;
 use serde_yaml::to_string;
@@ -33,13 +33,18 @@ pub fn runtime() -> &'static Runtime {
                                             .expect("Failed to create runtime"))
 }
 
+fn client() -> &'static Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| ReqClient::new())
+}
+
 pub async fn login(
     domain: String,
     username: String,
     password: String,
     port: String,
 ) -> Result<(), Error> {
-    let client = ReqClient::new();
+    let client = client();
 
     let mut headers = HeaderMap::new();
     headers.insert("X-Emby-Client", HeaderValue::from_static("Tsukimi"));
@@ -124,7 +129,7 @@ pub(crate) async fn search(searchinfo: String) -> Result<Vec<SearchResult>, Erro
     };
     let server_info = config::set_config();
 
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/Items",
         server_info.domain, server_info.port, server_info.user_id
@@ -179,7 +184,7 @@ pub struct SeriesInfo {
 
 pub async fn get_series_info(id: String) -> Result<Vec<SeriesInfo>, Error> {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Shows/{}/Episodes",
         server_info.domain, server_info.port, id
@@ -300,7 +305,7 @@ pub struct Urls {
 
 pub async fn get_item_overview(id: String) -> Result<Item, Error> {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/Items/{}",
         server_info.domain, server_info.port, server_info.user_id, id
@@ -322,7 +327,7 @@ pub async fn get_item_overview(id: String) -> Result<Item, Error> {
 
 pub async fn _markwatched(id: String, sourceid: String) -> Result<String, Error> {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/PlayingItems/{}",
         server_info.domain, server_info.port, server_info.user_id, id
@@ -393,7 +398,7 @@ pub(crate) async fn resume() -> Result<Vec<Resume>, Error> {
     let mut model = ResumeModel { resume: Vec::new() };
     let server_info = config::set_config();
 
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/Items/Resume",
         server_info.domain, server_info.port, server_info.user_id
@@ -605,7 +610,7 @@ pub async fn get_logoimage(id: String) -> Result<String, Error> {
 
 pub async fn get_mediainfo(id: String) -> Result<Media, Error> {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/Items/{}",
         server_info.domain, server_info.port, server_info.user_id, id
@@ -627,7 +632,7 @@ pub async fn get_mediainfo(id: String) -> Result<Media, Error> {
 
 pub async fn get_playbackinfo(id: String) -> Result<Media, Error> {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Items/{}/PlaybackInfo",
         server_info.domain, server_info.port, id
@@ -663,7 +668,7 @@ pub async fn get_playbackinfo(id: String) -> Result<Media, Error> {
 
 pub async fn get_sub(id: String,sourceid: String) -> Result<Media, Error> {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Items/{}/PlaybackInfo",
         server_info.domain, server_info.port, id
@@ -710,7 +715,7 @@ pub struct View {
 
 pub async fn get_library() -> Result<Vec<View>, Error>{
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/Views",
         server_info.domain, server_info.port, server_info.user_id
@@ -750,7 +755,7 @@ pub struct Latest {
 
 pub async fn get_latest(id: String) -> Result<Vec<Latest>, Error> {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/Items/Latest",
         server_info.domain, server_info.port, server_info.user_id
@@ -782,7 +787,7 @@ pub async fn get_latest(id: String) -> Result<Vec<Latest>, Error> {
 pub async fn get_list(id: String,start: String,mutex: std::sync::Arc<tokio::sync::Mutex<()>>) -> Result<List, Error> {
     let _ = mutex.lock().await;
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Users/{}/Items",
         server_info.domain, server_info.port, server_info.user_id
@@ -843,7 +848,7 @@ pub struct Back {
 
 pub async fn positionback(back:Back) {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Sessions/Playing/Progress",
         server_info.domain, server_info.port
@@ -868,7 +873,7 @@ pub async fn positionback(back:Back) {
 
 pub async fn positionstop(back:Back) {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Sessions/Playing/Stopped",
         server_info.domain, server_info.port
@@ -893,7 +898,7 @@ pub async fn positionstop(back:Back) {
 
 pub async fn playstart(back:Back) {
     let server_info = config::set_config();
-    let client = ReqClient::new();
+    let client = client();
     let url = format!(
         "{}:{}/emby/Sessions/Playing",
         server_info.domain, server_info.port


### PR DESCRIPTION
`ReqClient::new()` 会构造 `reqwest::Client` 实例。参考 [reqwest::Client 文档页](https://docs.rs/reqwest/latest/reqwest/struct.Client.html)：
> The Client holds a connection pool internally, **so it is advised that you create one and reuse it.**
>
> You do not have to wrap the Client in an [Rc](https://doc.rust-lang.org/nightly/alloc/rc/struct.Rc.html) or [Arc](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) to reuse it, because it already uses an [Arc](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) internally.

可以直接 clone 或者全局单例以复用 Client，因此参考上面的 runtime 实现 client 单例。