### PR TITLE
修复macOS构建错误

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -36,11 +36,16 @@ jobs:
           brew install libadwaita
           brew install dylibbundler
           brew install mpv
+          brew install glib
           rustup target add ${{matrix.target}}
           cargo build --release --locked
 
       - name: Make MacOS package
         run: |
+          mkdir -p Tsukimi.app/Contents/Resources/glib-2.0/schemas
+          cp *.gschema.xml Tsukimi.app/Contents/Resources/glib-2.0/schemas/
+          glib-compile-schemas Tsukimi.app/Contents/Resources/glib-2.0/schemas/
+          
           mkdir -p Tsukimi.app/Contents/MacOS
           mkdir -p Tsukimi.app/Contents/Resources
           cp share/macos/Info.plist Tsukimi.app/Contents/

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           brew install gtk4
           brew install libadwaita
+          brew install dylibbundler
           rustup target add ${{matrix.target}}
           cargo build --release --locked
 
@@ -44,6 +45,7 @@ jobs:
           cp share/macos/Info.plist Tsukimi.app/Contents/
           cp share/macos/AppIcon.icns Tsukimi.app/Contents/Resources/
           mv target/release/tsukimi Tsukimi.app/Contents/MacOS/
+          dylibbundler -od -b -x ./Tsukimi.app/Contents/MacOS/tsukimi -d ./Tsukimi.app/Contents/Frameworks -p @executable_path/../Frameworks/
           tar -czf tsukimi-x86_64-apple-darwin.tar.gz Tsukimi.app/
 
       - name: Upload artifact

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -35,6 +35,7 @@ jobs:
           brew install gtk4
           brew install libadwaita
           brew install dylibbundler
+          brew install mpv
           rustup target add ${{matrix.target}}
           cargo build --release --locked
 

--- a/share/macos/Info.plist
+++ b/share/macos/Info.plist
@@ -20,6 +20,12 @@
     <key>LSMinimumSystemVersion</key>
     <string>12.7.3</string>
 
+    <key>LSEnvironment</key>
+    <dict>
+        <key>GSETTINGS_SCHEMA_DIR</key>
+        <string>/Applications/Tsukimi.app/Contents/Resources/glib-2.0/schemas</string>
+    </dict>
+
     <!-- 网络权限 -->
     <key>NSAppTransportSecurity</key>
     <dict>


### PR DESCRIPTION
1. 将必要动态库打包
2. 修复构建阶段找不到 libmpv（但是看其他pull requests似乎并不想将mpv一起打包进软件内）
3. 编译 GSettings 相关模式文件
4. 在 Info.plist 中添加GSETTINGS_SCHEMA_DIR环境变量，解决启动时找不到对应编译后的模式文件