### PR TITLE
Fix invalid UTF-8 string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,20 +34,28 @@ fn locale_dir() -> &'static str {
         #[cfg(target_os = "windows")]
         {
             let exe_path = std::env::current_exe().expect("Can not get locale dir");
-            let locale_path = exe_path.ancestors().nth(2).expect("Can not get locale dir").join(WINDOWS_LOCALEDIR);
-            Box::leak(locale_path.into_boxed_str())
+            let locale_path = exe_path
+                .ancestors()
+                .nth(2)
+                .expect("Can not get locale dir")
+                .join(WINDOWS_LOCALEDIR);
+            Box::leak(locale_path.into_boxed_path())
+                .to_str()
+                .unwrap_or("")
         }
     })
 }
 
 fn main() -> glib::ExitCode {
-
     // Initialize gettext
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     {
         setlocale(LocaleCategory::LcAll, "");
+        bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8")
+            .expect("Failed to set textdomain codeset");
         bindtextdomain(GETTEXT_PACKAGE, locale_dir())
             .expect("Invalid argument passed to bindtextdomain");
+
         textdomain(GETTEXT_PACKAGE).expect("Invalid string passed to textdomain");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn locale_dir() -> &'static str {
                 .join(WINDOWS_LOCALEDIR);
             Box::leak(locale_path.into_boxed_path())
                 .to_str()
-                .unwrap_or("")
+                .expect("Can not get locale dir")
         }
     })
 }


### PR DESCRIPTION
`into_boxed_str()` 方法不存在，改为 `into_boxed_path()`

必须加上 `bind_textdomain_codeset()` 显式的指定编码，gettext-rs只支持UTF-8编码，而Windows上如果是中文系统则直接闪退