### PR TITLE
fix: proxy under AutoConfigUrl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -46,6 +46,8 @@ fn main() {
     #[cfg(windows)]
     {
         println!("cargo:rerun-if-changed=tsukimi-manifest.rc");
-        embed_resource::compile("./tsukimi_manifest.rc", embed_resource::NONE);
+        embed_resource::compile("./tsukimi_manifest.rc", embed_resource::NONE)
+            .manifest_optional()
+            .unwrap();
     }
 }

--- a/src/client/proxy.rs
+++ b/src/client/proxy.rs
@@ -44,7 +44,7 @@ impl ReqClient {
 
             client_builder.build().expect("failed to initialize client")
         };
-        
+
         tower::ServiceBuilder::new()
             .concurrency_limit(SETTINGS.threads() as usize)
             .service(client)
@@ -67,6 +67,16 @@ pub fn get_proxy_settings() -> Option<String> {
             && !proxy_config.lpszProxy.is_null()
         {
             let proxy = PCWSTR(proxy_config.lpszProxy.0).to_string().unwrap();
+            return Some(proxy);
+        } else if WinHttpGetIEProxyConfigForCurrentUser(&mut proxy_config).is_ok()
+            && !proxy_config.lpszAutoConfigUrl.is_null()
+        {
+            let proxy_url = PCWSTR(proxy_config.lpszAutoConfigUrl.0)
+                .to_string()
+                .unwrap();
+            let proxy = proxy_url.split('/').collect::<Vec<_>>()[..3]
+                .join("/")
+                .to_string();
             return Some(proxy);
         }
     }


### PR DESCRIPTION
Related issue: #244 
尝试修复使用pac模式自动配置系统代理的情况下，无法正确获取代理地址的问题。