### PR TITLE
AMD/Intel hardware decoding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk4-wayland"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd34518488cd624a85e75e82540bc24c72cfeb0aea6bad7faed683ca3977dba0"
+dependencies = [
+ "gdk4",
+ "gdk4-wayland-sys",
+ "gio",
+ "glib",
+ "libc",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "gdk4-wayland-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7a0f2332c531d62ee3f14f5e839ac1abac59e9b052adf1495124c00d89a34b"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps 7.0.5",
+]
+
+[[package]]
+name = "gdk4-x11"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3e7380a9a206b170e1b52b5f25581406db816c68f4e7140dbef89a9e5b52ac"
+dependencies = [
+ "gdk4",
+ "gdk4-x11-sys",
+ "gio",
+ "glib",
+ "libc",
+ "x11",
+]
+
+[[package]]
+name = "gdk4-x11-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "070bd50a053f90d7fdf6be1d75672ea0f97c0e5da3a10dc6d02e5defcb0db32f"
+dependencies = [
+ "gdk4-sys",
+ "glib-sys",
+ "libc",
+ "system-deps 7.0.5",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5095,6 +5147,8 @@ dependencies = [
  "epoxy",
  "flume",
  "fnv",
+ "gdk4-wayland",
+ "gdk4-x11",
  "gettext-rs",
  "glib-build-tools",
  "glow",
@@ -6319,6 +6373,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "x11-dl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,14 @@ license = "GPL-3.0"
 
 [dependencies]
 gtk = { version = "0.9", package = "gtk4", features = ["v4_18"] }
+gdk-x11 = { version = "0.9", package = "gdk4-x11", features = [
+  "v4_18",
+  "xlib",
+] }
+gdk-wayland = { version = "0.9", package = "gdk4-wayland", features = [
+  "v4_18",
+  "wayland_crate",
+] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.46", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,6 @@ license = "GPL-3.0"
 
 [dependencies]
 gtk = { version = "0.9", package = "gtk4", features = ["v4_18"] }
-gdk-x11 = { version = "0.9", package = "gdk4-x11", features = [
-  "v4_18",
-  "xlib",
-] }
-gdk-wayland = { version = "0.9", package = "gdk4-wayland", features = [
-  "v4_18",
-  "wayland_crate",
-] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.46", features = ["full"] }
@@ -71,6 +63,14 @@ build_libmpv = []                 # build libmpv automatically, provided MPV_SOU
 
 [target.'cfg(target_os = "linux")'.dependencies]
 xattr = { version = "1.5.1" }
+gdk-x11 = { version = "0.9", package = "gdk4-x11", features = [
+  "v4_18",
+  "xlib",
+] }
+gdk-wayland = { version = "0.9", package = "gdk4-wayland", features = [
+  "v4_18",
+  "wayland_crate",
+] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libproxy = { version = "0.1.1" }

--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -146,6 +146,7 @@ mod imp {
             // displays.
             //
             // https://github.com/mpv-player/mpv/blob/86e12929aa0bbc61946d3804982acf887786a7cb/include/mpv/render_gl.h#L91
+            #[cfg(target_os = "linux")]
             if let Some(display_wrapper) = display.clone().downcast::<X11Display>().ok() {
                 render_params.push(RenderParam::X11Display(
                     unsafe { display_wrapper.xdisplay() } as *const c_void,

--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -19,11 +19,15 @@ use crate::{
 mod imp {
     use std::ffi::c_void;
 
+    #[cfg(target_os = "linux")]
     use gdk_wayland::{
         WaylandDisplay,
         wayland_client::Proxy,
     };
+
+    #[cfg(target_os = "linux")]
     use gdk_x11::X11Display;
+
     use gettextrs::gettext;
     use glow::HasContext;
     use gtk::{


### PR DESCRIPTION
Apparently mpv needs special parameters to do AMD/Intel hardware decoding on X11 and Wayland. 

See here: https://github.com/mpv-player/mpv/blob/86e12929aa0bbc61946d3804982acf887786a7cb/include/mpv/render_gl.h#L91.

This code should detect when a display is X11 or Wayland and pass in the necessary pointers to mpv.

Tested it works on X11 and Wayland. Did not test it doesn't break anything on Windows or Mac because I don't have Windows or Mac.

