### PR TITLE
Improve UI icon choices to match other LibAdwaita apps and enhance ux

### DIFF
--- a/resources/ui/hortu_scrolled.ui
+++ b/resources/ui/hortu_scrolled.ui
@@ -43,7 +43,7 @@
                     <property name="halign">end</property>
                     <property name="valign">center</property>
                     <property name="margin-end">12</property>
-                    <property name="icon-name">view-more-symbolic</property>
+                    <property name="icon-name">view-more-horizontal-symbolic</property>
                     <style>
                       <class name="circular" />
                       <class name="flat" />

--- a/resources/ui/item.ui
+++ b/resources/ui/item.ui
@@ -302,7 +302,7 @@
                         </child>
                         <child>
                           <object class="GtkButton">
-                            <property name="icon-name">view-more-symbolic</property>
+                            <property name="icon-name">view-more-horizontal-symbolic</property>
                             <property name="halign">start</property>
                             <signal name="clicked" handler="on_season_view_more_clicked" swapped="yes"/>
                             <property name="tooltip-text" translatable="yes">View this season</property>
@@ -310,7 +310,7 @@
                         </child>
                         <child>
                           <object class="EpisodeSwitcher" id="episode_switcher">
-                            
+
                           </object>
                         </child>
                         <style>

--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -111,7 +111,7 @@
                               <object class="AdwHeaderBar">
                                 <child type="end">
                                   <object class="GtkMenuButton">
-                                    <property name="icon-name">view-more-symbolic</property>
+                                    <property name="icon-name">open-menu-symbolic</property>
                                     <property name="menu-model">sel-menu</property>
                                   </object>
                                 </child>
@@ -466,7 +466,7 @@
                                         </child>
                                         <child type="end">
                                           <object class="GtkMenuButton">
-                                            <property name="icon-name">view-more-symbolic</property>
+                                            <property name="icon-name">open-menu-symbolic</property>
                                             <property name="popover">
                                               <object class="GtkPopoverMenu">
                                                 <property name="menu-model">main-menu</property>


### PR DESCRIPTION
### Replace menu icon to match other LibAdwaita apps
This improves consistency across applications and reduces confusion with the expand icons.
### Distinguish 'view more' icons from action icons
'View more' icons will now be horizontal to better differentiate them from icons that open action menus.

Before:
<img width="1424" height="859" alt="Bildschirmfoto vom 2025-08-27 17-21-45" src="https://github.com/user-attachments/assets/4af8f074-0c17-4d53-912e-91b68f1eba17" />
After:
<img width="1095" height="778" alt="Bildschirmfoto vom 2025-08-27 17-21-05" src="https://github.com/user-attachments/assets/55fa8dbb-5823-4c9e-9cb3-110d193aecd1" />
