### PR TITLE
添加自定义 danmaku appid和 app secret 的功能。

### DIFF
--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -222,5 +222,13 @@
       <summary>Whether the danmaku is enabled</summary>
       <default>false</default>
     </key>
+    <key name="danmaku-appid" type="s">
+      <summary>Danmaku custom app id</summary>
+      <default>""</default>
+    </key>
+    <key name="danmaku-appsecret" type="s">
+      <summary>Danmaku custom app secret</summary>
+      <default>""</default>
+    </key>
   </schema>
 </schemalist>

--- a/resources/ui/mpvpage.ui
+++ b/resources/ui/mpvpage.ui
@@ -638,7 +638,21 @@
                     </child>
                     <child>
                       <object class="AdwPreferencesGroup">
-                        <property name="description" translatable="yes">API from DanDanPlay</property>
+                        <property name="title" translatable="yes">DanDanPlay API (Optional)</property>
+                        <property name="description" translatable="yes">Leave empty to use built-in defaults. Credentials are auto-saved when both fields are filled.</property>
+                        <property name="sensitive" bind-source="danmaku_switch" bind-property="active" bind-flags="sync-create"/>
+                        <child>
+                          <object class="AdwEntryRow" id="danmaku_appid_row">
+                            <property name="title">App ID</property>
+                            <signal name="changed" handler="on_danmaku_appid_changed" swapped="yes"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="AdwPasswordEntryRow" id="danmaku_appsecret_row">
+                            <property name="title">App Secret</property>
+                            <signal name="changed" handler="on_danmaku_appsecret_changed" swapped="yes"/>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <style>

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -61,6 +61,18 @@ impl Settings {
     const KEY_IS_MAXIMIZED: &'static str = "is-maximized"; // bool
     const KEY_IS_FULLSCREEN: &'static str = "is-fullscreen"; // bool
     const KEY_IS_DANMAKU_ENABLED: &'static str = "is-danmaku-enabled"; // bool
+    const KEY_DANMAKU_APPID: &'static str = "danmaku-appid"; // String
+    const KEY_DANMAKU_APPSECRET: &'static str = "danmaku-appsecret"; // String
+
+    fn has_key(&self, key: &str) -> bool {
+        self.settings_schema()
+            .as_ref()
+            .is_some_and(|schema| schema.has_key(key))
+    }
+
+    pub fn has_danmaku_custom_credentials_keys(&self) -> bool {
+        self.has_key(Self::KEY_DANMAKU_APPID) && self.has_key(Self::KEY_DANMAKU_APPSECRET)
+    }
 
     pub fn is_danmaku_enabled(&self) -> bool {
         self.boolean(Self::KEY_IS_DANMAKU_ENABLED)
@@ -68,6 +80,20 @@ impl Settings {
 
     pub fn set_danmaku_enabled(&self, is_danmaku_enabled: bool) -> Result<(), glib::BoolError> {
         self.set_boolean(Self::KEY_IS_DANMAKU_ENABLED, is_danmaku_enabled)
+    }
+
+    pub fn set_danmaku_appid(&self, appid: &str) -> Result<(), glib::BoolError> {
+        if !self.has_key(Self::KEY_DANMAKU_APPID) {
+            return Ok(());
+        }
+        self.set_string(Self::KEY_DANMAKU_APPID, appid)
+    }
+
+    pub fn set_danmaku_appsecret(&self, appsecret: &str) -> Result<(), glib::BoolError> {
+        if !self.has_key(Self::KEY_DANMAKU_APPSECRET) {
+            return Ok(());
+        }
+        self.set_string(Self::KEY_DANMAKU_APPSECRET, appsecret)
     }
 
     #[cfg(target_os = "windows")]

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -196,6 +196,12 @@ mod imp {
         pub danmaku_switch: TemplateChild<gtk::Switch>,
 
         #[template_child]
+        pub danmaku_appid_row: TemplateChild<adw::EntryRow>,
+
+        #[template_child]
+        pub danmaku_appsecret_row: TemplateChild<adw::PasswordEntryRow>,
+
+        #[template_child]
         pub danmaku_top_padding_adj: TemplateChild<gtk::Adjustment>,
 
         #[template_child]
@@ -319,6 +325,24 @@ mod imp {
             SETTINGS
                 .bind("is-danmaku-enabled", &self.danmaku_switch.get(), "active")
                 .build();
+
+            if SETTINGS.has_danmaku_custom_credentials_keys() {
+                SETTINGS
+                    .bind("danmaku-appid", &self.danmaku_appid_row.get(), "text")
+                    .build();
+
+                SETTINGS
+                    .bind(
+                        "danmaku-appsecret",
+                        &self.danmaku_appsecret_row.get(),
+                        "text",
+                    )
+                    .build();
+            } else {
+                tracing::warn!(
+                    "GSettings keys danmaku-appid/danmaku-appsecret not found, custom DanDan credentials disabled"
+                );
+            }
 
             self.danmaku_area
                 .set_enable_danmaku(SETTINGS.is_danmaku_enabled());
@@ -444,19 +468,36 @@ mod imp {
             self.paused.set(paused);
         }
 
-        fn init_dandanapi_client(&self) {
+        pub(super) fn init_dandanapi_client(&self) {
             use crate::client::*;
             use dandanapi::*;
 
-            let generator = SecretGenerator::new(
-                include_bytes!("../../../secret/secret").to_vec(),
-                SECRETE_KEY.to_string(),
-            );
+            // Prefer live UI input to avoid race with Settings binding propagation.
+            let appid_text = self.danmaku_appid_row.text().trim().to_string();
+            let appsecret_text = self.danmaku_appsecret_row.text().trim().to_string();
+            let has_custom_appid = !appid_text.is_empty();
+            let has_custom_appsecret = !appsecret_text.is_empty();
 
-            let Ok(()) = DanDanClient::init(X_APPID.to_string(), generator) else {
-                self.danmaku_page
-                    .set_description(&gettext("Danmaku feature requires an official build"));
-                self.danmaku_popover.set_sensitive(false);
+            let init_result = if has_custom_appid && has_custom_appsecret {
+                DanDanClient::init(appid_text, appsecret_text)
+            } else if !has_custom_appid && !has_custom_appsecret {
+                let generator = SecretGenerator::new(
+                    include_bytes!("../../../secret/secret").to_vec(),
+                    SECRETE_KEY.to_string(),
+                );
+                DanDanClient::init(X_APPID.to_string(), generator)
+            } else {
+                self.danmaku_page.set_description(&gettext(
+                    "Please fill both App ID and App Secret, or leave both empty.",
+                ));
+                self.obj().set_key_vaild(false);
+                return;
+            };
+
+            let Ok(()) = init_result else {
+                self.danmaku_page.set_description(&gettext(
+                    "Danmaku credential is invalid. Set App ID and App Secret to continue.",
+                ));
                 self.obj().set_key_vaild(false);
                 return;
             };
@@ -1342,6 +1383,9 @@ impl MPVPage {
 
     pub async fn load_danmaku(&self) {
         if !self.key_vaild() {
+            self.imp().danmaku_page.set_description(&gettext(
+                "Danmaku credential is invalid. Set App ID and App Secret to continue.",
+            ));
             return;
         }
 
@@ -1464,6 +1508,98 @@ impl MPVPage {
         let _ = SETTINGS.set_danmaku_enabled(state);
 
         false
+    }
+
+    #[template_callback]
+    pub fn on_danmaku_appid_changed(&self, _entry: &adw::EntryRow) {
+        self.auto_save_danmaku_credentials();
+    }
+
+    #[template_callback]
+    pub fn on_danmaku_appsecret_changed(&self, _entry: &adw::PasswordEntryRow) {
+        self.auto_save_danmaku_credentials();
+    }
+
+    fn auto_save_danmaku_credentials(&self) {
+        if !SETTINGS.has_danmaku_custom_credentials_keys() {
+            self.imp().danmaku_page.set_description(&gettext(
+                "Runtime schema is outdated. Please update schema first.",
+            ));
+            return;
+        }
+
+        let appid_text = self.imp().danmaku_appid_row.text().trim().to_string();
+        let appsecret_text = self.imp().danmaku_appsecret_row.text().trim().to_string();
+        let has_appid = !appid_text.is_empty();
+        let has_appsecret = !appsecret_text.is_empty();
+
+        if has_appid ^ has_appsecret {
+            return;
+        }
+
+        if SETTINGS.set_danmaku_appid(&appid_text).is_err()
+            || SETTINGS.set_danmaku_appsecret(&appsecret_text).is_err()
+        {
+            self.imp()
+                .danmaku_page
+                .set_description(&gettext("Failed to save danmaku credentials."));
+            return;
+        }
+
+        self.imp().init_dandanapi_client();
+
+        if !self.key_vaild() {
+            self.toast(gettext("Danmaku credentials are invalid."));
+            return;
+        }
+
+        let client = self
+            .imp()
+            .danmaku_client
+            .get()
+            .cloned()
+            .unwrap_or_else(dandanapi::DanDanClient::instance);
+
+        spawn(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            async move {
+                let verify_result = {
+                    let route = client.route(dandanapi::Episodes(dandanapi::RequestEpisodes {
+                        anime: "CredentialCheck".to_string(),
+                        episode: "1".to_string(),
+                        tmdb_id: None,
+                    }));
+                    spawn_tokio(async move {
+                        route.await?;
+                        Ok::<(), anyhow::Error>(())
+                    })
+                    .await
+                };
+
+                match verify_result {
+                    Ok(()) => {
+                        obj.toast(gettext("Danmaku credentials saved and verified."));
+                    }
+                    Err(_) => {
+                        obj.set_key_vaild(false);
+                        obj.toast(gettext(
+                            "Danmaku credentials are invalid (or network is unavailable).",
+                        ));
+                    }
+                }
+            }
+        ));
+
+        if self.key_vaild() && SETTINGS.is_danmaku_enabled() {
+            spawn(glib::clone!(
+                #[weak(rename_to = obj)]
+                self,
+                async move {
+                    obj.load_danmaku().await;
+                }
+            ));
+        }
     }
 
     pub fn notify_has_chapters(&self, has_chapters: bool) {


### PR DESCRIPTION
大部分是AI帮忙写的，我在本地测试过，需要先合并 https://github.com/tsukinaha/dandanapi/pull/1

没有填写就用软件内置的（需要官方版），填写了就用用户自己的。

<img width="769" height="978" alt="image" src="https://github.com/user-attachments/assets/7ee3edf9-bbcf-4a82-8010-72c29c1e68d1" />
