### PR TITLE
fix: add item stream URL retrieval and update playback handling

### DIFF
--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -405,7 +405,7 @@ impl JellyfinClient {
     }
 
     pub async fn get_item_stream_url(
-        &self,container: &str,item_id: &str,media_source_id: &str,
+        &self, container: &str, item_id: &str, media_source_id: &str,
     ) -> Result<String> {
         let (mut url, _) = self.get_url_and_headers().await?;
         url.path_segments_mut()

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -404,6 +404,33 @@ impl JellyfinClient {
         url.to_string()
     }
 
+    pub async fn get_item_stream_url(
+        &self, container: &str, item_id: &str, media_source_id: Option<&str>,
+        play_session_id: Option<&str>, etag: Option<&str>,
+    ) -> String {
+        let mut url = self.url.lock().await.as_ref().unwrap().to_owned();
+        url.path_segments_mut().unwrap().pop();
+        let path = format!("Videos/{item_id}/stream.{container}");
+        let mut url = url.join(&path).unwrap();
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs
+                .append_pair("Static", "true")
+                .append_pair("deviceId", &DEVICE_ID)
+                .append_pair("api_key", self.user_access_token.lock().await.as_str());
+            if let Some(media_source_id) = media_source_id.filter(|v| !v.is_empty()) {
+                pairs.append_pair("MediaSourceId", media_source_id);
+            }
+            if let Some(play_session_id) = play_session_id.filter(|v| !v.is_empty()) {
+                pairs.append_pair("PlaySessionId", play_session_id);
+            }
+            if let Some(etag) = etag.filter(|v| !v.is_empty()) {
+                pairs.append_pair("Tag", etag);
+            }
+        }
+        url.to_string()
+    }
+
     pub async fn search(
         &self, query: &str, filter: &[&str], start_index: &str, filters_list: &FiltersList,
     ) -> Result<List> {

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -405,30 +405,25 @@ impl JellyfinClient {
     }
 
     pub async fn get_item_stream_url(
-        &self, container: &str, item_id: &str, media_source_id: Option<&str>,
-        play_session_id: Option<&str>, etag: Option<&str>,
-    ) -> String {
-        let mut url = self.url.lock().await.as_ref().unwrap().to_owned();
-        url.path_segments_mut().unwrap().pop();
-        let path = format!("Videos/{item_id}/stream.{container}");
-        let mut url = url.join(&path).unwrap();
+        &self,container: &str,item_id: &str,media_source_id: &str,
+    ) -> Result<String> {
+        let (mut url, _) = self.get_url_and_headers().await?;
+        url.path_segments_mut()
+            .map_err(|_| anyhow!("Failed to build item stream URL path"))?
+            .pop();
+        let path = format!("Videos/{}/stream.{}", item_id, container);
+        let mut url = url
+            .join(&path)
+            .map_err(|e| anyhow!("Failed to build item stream URL: {}", e))?;
         {
             let mut pairs = url.query_pairs_mut();
             pairs
                 .append_pair("Static", "true")
                 .append_pair("deviceId", &DEVICE_ID)
-                .append_pair("api_key", self.user_access_token.lock().await.as_str());
-            if let Some(media_source_id) = media_source_id.filter(|v| !v.is_empty()) {
-                pairs.append_pair("MediaSourceId", media_source_id);
-            }
-            if let Some(play_session_id) = play_session_id.filter(|v| !v.is_empty()) {
-                pairs.append_pair("PlaySessionId", play_session_id);
-            }
-            if let Some(etag) = etag.filter(|v| !v.is_empty()) {
-                pairs.append_pair("Tag", etag);
-            }
+                .append_pair("api_key", self.user_access_token.lock().await.as_str())
+                .append_pair("MediaSourceId", media_source_id);
         }
-        url.to_string()
+        Ok(url.to_string())
     }
 
     pub async fn search(

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -652,11 +652,16 @@ impl MPVPage {
 
                 imp.suburl.replace(sub_url);
 
-                let Some(video_url) =
-                    extract_url(&id, play_session_id.as_deref(), media_source).await
-                else {
-                    obj.toast(gettext("No media source found"));
-                    return;
+                let video_url = match extract_url(media_source).await {
+                    Ok(Some(video_url)) => video_url,
+                    Ok(None) => {
+                        obj.toast(gettext("No media source found"));
+                        return;
+                    }
+                    Err(e) => {
+                        obj.toast(e.to_user_facing());
+                        return;
+                    }
                 };
 
                 imp.video.play(&video_url, per);
@@ -1496,20 +1501,15 @@ impl MPVPage {
 }
 
 pub async fn direct_stream_url(
-    item_id: &str, play_session_id: Option<&str>, source: &MediaSource,
-) -> Option<String> {
-    let container = source.container.to_owned()?;
-    Some(
-        JELLYFIN_CLIENT
-            .get_item_stream_url(
-                &container,
-                item_id,
-                Some(source.id.as_str()),
-                play_session_id,
-                source.etag.as_deref(),
-            )
-            .await,
-    )
+    source: &MediaSource,
+) -> Result<Option<String>> {
+    let Some(container) = source.container.as_deref() else {
+        return Ok(None);
+    };
+    JELLYFIN_CLIENT
+        .get_item_stream_url(container, source.id.as_str(), &source.id.to_owned())
+        .await
+        .map(Some)
 }
 
 pub async fn media_source_stream_url(source: &MediaSource) -> Option<String> {
@@ -1523,17 +1523,10 @@ pub async fn media_source_stream_url(source: &MediaSource) -> Option<String> {
 }
 
 pub async fn extract_url(
-    item_id: &str, play_session_id: Option<&str>, source: &MediaSource,
-) -> Option<String> {
-    if let Some(url) = source.direct_stream_url.as_ref() {
-        return Some(url.to_string());
-    }
-
-    if let Some(url) = source.transcoding_url.as_ref() {
-        return Some(url.to_string());
-    }
-
-    direct_stream_url(item_id, play_session_id, source)
-        .await
-        .or(media_source_stream_url(source).await)
+    source: &MediaSource,
+) -> Result<Option<String>> {
+        if let Some(url) = media_source_stream_url(source).await {
+            return Ok(Some(url));
+        }
+        direct_stream_url(source).await
 }

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -653,13 +653,9 @@ impl MPVPage {
                 imp.suburl.replace(sub_url);
 
                 let video_url = match extract_url(media_source).await {
-                    Ok(Some(video_url)) => video_url,
-                    Ok(None) => {
+                    Some(video_url) => video_url,
+                    None => {
                         obj.toast(gettext("No media source found"));
-                        return;
-                    }
-                    Err(e) => {
-                        obj.toast(e.to_user_facing());
                         return;
                     }
                 };
@@ -1500,16 +1496,12 @@ impl MPVPage {
     }
 }
 
-pub async fn direct_stream_url(
-    source: &MediaSource,
-) -> Result<Option<String>> {
-    let Some(container) = source.container.as_deref() else {
-        return Ok(None);
-    };
+pub async fn direct_stream_url(source: &MediaSource) -> Option<String> {
+    let container = source.container.as_deref()?;
     JELLYFIN_CLIENT
         .get_item_stream_url(container, source.id.as_str(), &source.id.to_owned())
         .await
-        .map(Some)
+        .ok()
 }
 
 pub async fn media_source_stream_url(source: &MediaSource) -> Option<String> {
@@ -1522,11 +1514,9 @@ pub async fn media_source_stream_url(source: &MediaSource) -> Option<String> {
     )
 }
 
-pub async fn extract_url(
-    source: &MediaSource,
-) -> Result<Option<String>> {
-        if let Some(url) = media_source_stream_url(source).await {
-            return Ok(Some(url));
-        }
-        direct_stream_url(source).await
+pub async fn extract_url(source: &MediaSource) -> Option<String> {
+    if let Some(url) = media_source_stream_url(source).await {
+        return Some(url);
+    }
+    direct_stream_url(source).await
 }

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -595,9 +595,10 @@ impl MPVPage {
                     return;
                 };
 
+                let play_session_id = playback_info.play_session_id.to_owned();
                 let back = Back {
                     id: id.to_owned(),
-                    playsessionid: playback_info.play_session_id,
+                    playsessionid: play_session_id.to_owned(),
                     mediasourceid: media_source.id.to_owned(),
                     tick: media_source.run_time_ticks.unwrap_or(0),
                     start_tick: glib::DateTime::now_local().unwrap().to_unix() as u64,
@@ -639,7 +640,7 @@ impl MPVPage {
                             println!("External Subtitle without selected source");
                             imp.obj()
                                 .external_sub_url_without_selected_source(
-                                    id,
+                                    id.to_owned(),
                                     stream,
                                     media_source.id.to_owned(),
                                 )
@@ -651,7 +652,9 @@ impl MPVPage {
 
                 imp.suburl.replace(sub_url);
 
-                let Some(video_url) = extract_url(media_source).await else {
+                let Some(video_url) =
+                    extract_url(&id, play_session_id.as_deref(), media_source).await
+                else {
                     obj.toast(gettext("No media source found"));
                     return;
                 };
@@ -1492,7 +1495,24 @@ impl MPVPage {
     }
 }
 
-pub async fn direct_stream_url(source: &MediaSource) -> Option<String> {
+pub async fn direct_stream_url(
+    item_id: &str, play_session_id: Option<&str>, source: &MediaSource,
+) -> Option<String> {
+    let container = source.container.to_owned()?;
+    Some(
+        JELLYFIN_CLIENT
+            .get_item_stream_url(
+                &container,
+                item_id,
+                Some(source.id.as_str()),
+                play_session_id,
+                source.etag.as_deref(),
+            )
+            .await,
+    )
+}
+
+pub async fn media_source_stream_url(source: &MediaSource) -> Option<String> {
     let container = source.container.to_owned()?;
     let etag = source.etag.to_owned()?;
     Some(
@@ -1502,13 +1522,18 @@ pub async fn direct_stream_url(source: &MediaSource) -> Option<String> {
     )
 }
 
-pub async fn extract_url(source: &MediaSource) -> Option<String> {
-    source
-        .direct_stream_url
-        .as_ref()
-        .or(source
-            .transcoding_url
-            .as_ref()
-            .or(direct_stream_url(source).await.as_ref()))
-        .map(|url| url.to_string())
+pub async fn extract_url(
+    item_id: &str, play_session_id: Option<&str>, source: &MediaSource,
+) -> Option<String> {
+    if let Some(url) = source.direct_stream_url.as_ref() {
+        return Some(url.to_string());
+    }
+
+    if let Some(url) = source.transcoding_url.as_ref() {
+        return Some(url.to_string());
+    }
+
+    direct_stream_url(item_id, play_session_id, source)
+        .await
+        .or(media_source_stream_url(source).await)
 }

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -457,10 +457,9 @@ impl ItemPage {
             }
         };
 
-        self.set_dropdown(&intro_id, &playback).await;
-        self.set_play_session_id(playback.play_session_id.to_owned());
-
         self.set_current_item(Some(intro));
+        self.set_dropdown(&playback).await;
+        self.set_play_session_id(playback.play_session_id.to_owned());
 
         play_button.set_sensitive(true);
         spinner.set_visible(false);
@@ -694,9 +693,8 @@ impl ItemPage {
         }
     }
 
-    pub async fn set_dropdown(&self, item_id: &str, playbackinfo: &Media) {
+    pub async fn set_dropdown(&self, playbackinfo: &Media) {
         let playbackinfo = playbackinfo.to_owned();
-        let item_id = item_id.to_string();
         let imp = self.imp();
         let namedropdown = imp.namedropdown.get();
         let subdropdown = imp.subdropdown.get();
@@ -772,8 +770,13 @@ impl ItemPage {
                 .bit_rate
                 .map(|bit_rate| format!("{:.2} Kbps", bit_rate as f64 / 1_000.0))
                 .unwrap_or_default();
-            let play_url =
-                extract_url(&item_id, playbackinfo.play_session_id.as_deref(), media).await;
+            let play_url = match extract_url(media).await {
+                Ok(url) => url,
+                Err(e) => {
+                    self.toast(e.to_user_facing());
+                    None
+                }
+            };
             let Ok(dl) = DropdownListBuilder::default()
                 .line1(Some(media.name.to_owned()))
                 .line2(Some(line2))

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -770,13 +770,7 @@ impl ItemPage {
                 .bit_rate
                 .map(|bit_rate| format!("{:.2} Kbps", bit_rate as f64 / 1_000.0))
                 .unwrap_or_default();
-            let play_url = match extract_url(media).await {
-                Ok(url) => url,
-                Err(e) => {
-                    self.toast(e.to_user_facing());
-                    None
-                }
-            };
+            let play_url = extract_url(media).await;
             let Ok(dl) = DropdownListBuilder::default()
                 .line1(Some(media.name.to_owned()))
                 .line2(Some(line2))

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -17,7 +17,7 @@ use crate::{
         structs::*,
     },
     ui::{
-        mpv::page::direct_stream_url,
+        mpv::page::extract_url,
         provider::{
             dropdown_factory::{
                 DropdownList,
@@ -442,9 +442,10 @@ impl ItemPage {
         play_button.set_sensitive(false);
         spinner.set_visible(true);
 
+        let intro_id_clone = intro_id.to_owned();
         let playback = match spawn_tokio(async move {
             JELLYFIN_CLIENT
-                .get_playbackinfo(&intro_id, None, None, false)
+                .get_playbackinfo(&intro_id_clone, None, None, false)
                 .await
         })
         .await
@@ -456,7 +457,7 @@ impl ItemPage {
             }
         };
 
-        self.set_dropdown(&playback).await;
+        self.set_dropdown(&intro_id, &playback).await;
         self.set_play_session_id(playback.play_session_id.to_owned());
 
         self.set_current_item(Some(intro));
@@ -693,8 +694,9 @@ impl ItemPage {
         }
     }
 
-    pub async fn set_dropdown(&self, playbackinfo: &Media) {
+    pub async fn set_dropdown(&self, item_id: &str, playbackinfo: &Media) {
         let playbackinfo = playbackinfo.to_owned();
+        let item_id = item_id.to_string();
         let imp = self.imp();
         let namedropdown = imp.namedropdown.get();
         let subdropdown = imp.subdropdown.get();
@@ -770,11 +772,8 @@ impl ItemPage {
                 .bit_rate
                 .map(|bit_rate| format!("{:.2} Kbps", bit_rate as f64 / 1_000.0))
                 .unwrap_or_default();
-            let play_url = media
-                .direct_stream_url
-                .to_owned()
-                .or(media.transcoding_url.to_owned())
-                .or(direct_stream_url(media).await);
+            let play_url =
+                extract_url(&item_id, playbackinfo.play_session_id.as_deref(), media).await;
             let Ok(dl) = DropdownListBuilder::default()
                 .line1(Some(media.name.to_owned()))
                 .line2(Some(line2))


### PR DESCRIPTION
This pull request introduces significant improvements to how media stream URLs are constructed and used throughout the application. The main focus is on refactoring the logic for obtaining direct and transcoding stream URLs, ensuring that the appropriate parameters (such as `item_id` and `play_session_id`) are consistently provided, and streamlining the API for extracting URLs. These changes improve code maintainability and ensure more reliable playback behavior.

**Refactoring and API improvements for stream URL extraction:**

* Added a new method `get_item_stream_url` to `JellyfinClient` that constructs a stream URL using `item_id`, `container`, and optional parameters like `media_source_id`, `play_session_id`, and `etag` for more flexible and accurate URL generation.
* Refactored `direct_stream_url` and `extract_url` functions to require `item_id` and `play_session_id`, ensuring that all necessary context is available when building stream URLs. The `extract_url` function now tries direct, transcoding, and fallback stream URLs in order. [[1]](diffhunk://#diff-45039aeab7ae96515625f6731610e0b83dcf202382d2fb0792d8853f12af09d7L1495-R1515) [[2]](diffhunk://#diff-45039aeab7ae96515625f6731610e0b83dcf202382d2fb0792d8853f12af09d7L1505-R1538)
* Updated all call sites (in `mpv/page.rs` and `widgets/item.rs`) to pass the correct parameters (`item_id`, `play_session_id`) to the new `extract_url` function, replacing previous direct calls to `direct_stream_url`. [[1]](diffhunk://#diff-45039aeab7ae96515625f6731610e0b83dcf202382d2fb0792d8853f12af09d7L654-R657) [[2]](diffhunk://#diff-995cf8767ea2fd305ff3fed3dfa11a51f298efa0908997ebba887b7f2a3e68ffL20-R20) [[3]](diffhunk://#diff-995cf8767ea2fd305ff3fed3dfa11a51f298efa0908997ebba887b7f2a3e68ffL773-R776)
* Modified UI logic to ensure that cloned or owned values of `item_id` and `play_session_id` are passed where needed, preventing lifetime and ownership issues in async contexts. [[1]](diffhunk://#diff-45039aeab7ae96515625f6731610e0b83dcf202382d2fb0792d8853f12af09d7R598-R601) [[2]](diffhunk://#diff-45039aeab7ae96515625f6731610e0b83dcf202382d2fb0792d8853f12af09d7L642-R643) [[3]](diffhunk://#diff-995cf8767ea2fd305ff3fed3dfa11a51f298efa0908997ebba887b7f2a3e68ffR445-R448) [[4]](diffhunk://#diff-995cf8767ea2fd305ff3fed3dfa11a51f298efa0908997ebba887b7f2a3e68ffL459-R460) [[5]](diffhunk://#diff-995cf8767ea2fd305ff3fed3dfa11a51f298efa0908997ebba887b7f2a3e68ffL696-R699)

These changes collectively improve the reliability and maintainability of the code related to media playback URLs, reducing the risk of incorrect or incomplete URL construction and simplifying the codebase.