### PR TITLE
feat: add basic unify size logic for "latest xx" in homepage

### DIFF
--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -294,6 +294,8 @@ pub struct SimpleListItem {
     pub primary_image_item_id: Option<String>,
     #[serde(rename = "BackdropImageTags")]
     pub backdrop_image_tags: Option<Vec<String>>,
+    #[serde(rename = "PrimaryImageAspectRatio")]
+    pub primary_image_aspect_ratio: Option<f64>,
     #[serde(rename = "CommunityRating")]
     pub community_rating: Option<f32>,
     #[serde(rename = "CollectionType")]

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -5,7 +5,10 @@ use gettextrs::gettext;
 use glib::DateTime;
 use gtk::{
     gio,
-    glib::{self, subclass::prelude::*},
+    glib::{
+        self,
+        subclass::prelude::*,
+    },
 };
 
 use crate::{
@@ -13,7 +16,10 @@ use crate::{
     client::{
         error::UserFacingError,
         jellyfin_client::JELLYFIN_CLIENT,
-        structs::{SimpleListItem, SongWidgetView},
+        structs::{
+            SimpleListItem,
+            SongWidgetView,
+        },
     },
     ui::{
         GlobalToast,
@@ -23,12 +29,20 @@ use crate::{
             list::ListPage,
             music_album::AlbumPage,
             other::OtherPage,
-            single_grid::{SingleGrid, imp::ListType},
+            single_grid::{
+                SingleGrid,
+                imp::ListType,
+            },
             song_widget::SongWidget,
             window::Window,
         },
     },
-    utils::{CachePolicy, fetch_with_cache, spawn, spawn_tokio},
+    utils::{
+        CachePolicy,
+        fetch_with_cache,
+        spawn,
+        spawn_tokio,
+    },
 };
 
 #[derive(Default, Clone)]

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -5,10 +5,7 @@ use gettextrs::gettext;
 use glib::DateTime;
 use gtk::{
     gio,
-    glib::{
-        self,
-        subclass::prelude::*,
-    },
+    glib::{self, subclass::prelude::*},
 };
 
 use crate::{
@@ -16,10 +13,7 @@ use crate::{
     client::{
         error::UserFacingError,
         jellyfin_client::JELLYFIN_CLIENT,
-        structs::{
-            SimpleListItem,
-            SongWidgetView
-        },
+        structs::{SimpleListItem, SongWidgetView},
     },
     ui::{
         GlobalToast,
@@ -29,26 +23,27 @@ use crate::{
             list::ListPage,
             music_album::AlbumPage,
             other::OtherPage,
-            single_grid::{
-                SingleGrid,
-                imp::ListType,
-            },
+            single_grid::{SingleGrid, imp::ListType},
             song_widget::SongWidget,
             window::Window,
         },
     },
-    utils::{
-        CachePolicy,
-        fetch_with_cache,
-        spawn,
-        spawn_tokio,
-    },
+    utils::{CachePolicy, fetch_with_cache, spawn, spawn_tokio},
 };
 
 #[derive(Default, Clone)]
 struct AlbumArtist {
     name: String,
     id: String,
+}
+
+#[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
+#[repr(u32)]
+#[enum_type(name = "PreferSize")]
+pub enum PreferSize {
+    #[default]
+    Auto,
+    Video,
 }
 
 pub mod imp {
@@ -96,6 +91,8 @@ pub mod imp {
         poster: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         image_tags: RefCell<Option<crate::ui::provider::image_tags::ImageTags>>,
+        #[property(get, set, builder(PreferSize::default()))]
+        prefer_size: RefCell<PreferSize>,
         #[property(get, set, nullable)]
         role: RefCell<Option<String>>,
         #[property(get, set, nullable)]

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -5,10 +5,7 @@ use gettextrs::gettext;
 use glib::DateTime;
 use gtk::{
     gio,
-    glib::{
-        self,
-        subclass::prelude::*,
-    },
+    glib::{self, subclass::prelude::*},
 };
 
 use crate::{
@@ -16,10 +13,7 @@ use crate::{
     client::{
         error::UserFacingError,
         jellyfin_client::JELLYFIN_CLIENT,
-        structs::{
-            SimpleListItem,
-            SongWidgetView,
-        },
+        structs::{SimpleListItem, SongWidgetView},
     },
     ui::{
         GlobalToast,
@@ -29,20 +23,12 @@ use crate::{
             list::ListPage,
             music_album::AlbumPage,
             other::OtherPage,
-            single_grid::{
-                SingleGrid,
-                imp::ListType,
-            },
+            single_grid::{SingleGrid, imp::ListType},
             song_widget::SongWidget,
             window::Window,
         },
     },
-    utils::{
-        CachePolicy,
-        fetch_with_cache,
-        spawn,
-        spawn_tokio,
-    },
+    utils::{CachePolicy, fetch_with_cache, spawn, spawn_tokio},
 };
 
 #[derive(Default, Clone)]
@@ -58,6 +44,7 @@ pub enum PreferSize {
     #[default]
     Auto,
     Video,
+    Post,
 }
 
 pub mod imp {

--- a/src/ui/widgets/disc_box.rs
+++ b/src/ui/widgets/disc_box.rs
@@ -8,11 +8,16 @@ use gtk::{
 };
 
 use super::song_widget::SongWidget;
-use crate::{client::structs::SongWidgetView, ui::provider::tu_item::TuItem};
+use crate::{
+    client::structs::SongWidgetView,
+    ui::provider::tu_item::TuItem,
+};
 
 mod imp {
-    use std::sync::OnceLock;
-    use std::cell::OnceCell;
+    use std::{
+        cell::OnceCell,
+        sync::OnceLock,
+    };
 
     use glib::subclass::{
         InitializingObject,
@@ -92,8 +97,7 @@ impl DiscBox {
         let view_type = self.view_type();
         if view_type == SongWidgetView::MusicAlbumItem {
             disc_label.set_text(&format!("{} {}", &gettext("Disc"), disc));
-        }
-        else {
+        } else {
             disc_label.set_visible(false);
         }
     }

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -226,6 +226,8 @@ impl HomePage {
 
         hortu.set_moreview(true);
 
+        hortu.set_unify_size(true);
+
         hortu.set_title(format!("{} {}", gettext("Latest"), view.name));
 
         hortu.set_items(&results);

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -200,6 +200,9 @@ impl HortuScrolled {
     }
 
     fn evaluate_prefer_size(&self, items: &[SimpleListItem]) -> PreferSize {
+        if !self.unify_size() {
+            return PreferSize::Auto;
+        }
         let primary_ratio: Vec<_> = items
             .iter()
             .filter_map(|i| i.primary_image_aspect_ratio)

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -1,10 +1,21 @@
-use adw::{prelude::*, subclass::prelude::*};
-use gtk::{CompositeTemplate, gio, glib, template_callbacks};
+use adw::{
+    prelude::*,
+    subclass::prelude::*,
+};
+use gtk::{
+    CompositeTemplate,
+    gio,
+    glib,
+    template_callbacks,
+};
 
 use crate::{
     client::structs::SimpleListItem,
     ui::{
-        provider::{tu_item::PreferSize, tu_object::TuObject},
+        provider::{
+            tu_item::PreferSize,
+            tu_object::TuObject,
+        },
         widgets::fix::ScrolledWindowFixExt,
     },
 };
@@ -12,13 +23,22 @@ use crate::{
 pub const SHOW_BUTTON_ANIMATION_DURATION: u32 = 500;
 
 mod imp {
-    use std::cell::{OnceCell, RefCell};
+    use std::cell::{
+        OnceCell,
+        RefCell,
+    };
 
     use glib::subclass::InitializingObject;
-    use gtk::{SignalListItemFactory, gio};
+    use gtk::{
+        SignalListItemFactory,
+        gio,
+    };
 
     use super::*;
-    use crate::ui::widgets::{tu_list_item::imp::PosterType, utils::TuItemBuildExt};
+    use crate::ui::widgets::{
+        tu_list_item::imp::PosterType,
+        utils::TuItemBuildExt,
+    };
 
     #[derive(Debug, Default, CompositeTemplate, glib::Properties)]
     #[template(resource = "/moe/tsuna/tsukimi/ui/hortu_scrolled.ui")]
@@ -45,6 +65,9 @@ mod imp {
         pub moreview: RefCell<bool>,
         #[property(get, set)]
         pub title: RefCell<String>,
+
+        #[property(get, set, default_value = false)]
+        pub unify_size: RefCell<bool>,
 
         pub show_button_animation: OnceCell<adw::TimedAnimation>,
         pub hide_button_animation: OnceCell<adw::TimedAnimation>,
@@ -144,17 +167,21 @@ impl HortuScrolled {
 
         self.set_visible(true);
 
-        let primary_ratio: Vec<_> = items
-            .iter()
-            .filter_map(|i| i.primary_image_aspect_ratio)
-            .collect();
+        let prefer_size = if self.unify_size() {
+            let primary_ratio: Vec<_> = items
+                .iter()
+                .filter_map(|i| i.primary_image_aspect_ratio)
+                .collect();
 
-        let prefer_size = if !primary_ratio.is_empty()
-            && primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
-                / primary_ratio.len() as f64
-                > 0.8
-        {
-            PreferSize::Video
+            if !primary_ratio.is_empty()
+                && primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
+                    / primary_ratio.len() as f64
+                    > 0.8
+            {
+                PreferSize::Video
+            } else {
+                PreferSize::Auto
+            }
         } else {
             PreferSize::Auto
         };

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -1,18 +1,10 @@
-use adw::{
-    prelude::*,
-    subclass::prelude::*,
-};
-use gtk::{
-    CompositeTemplate,
-    gio,
-    glib,
-    template_callbacks,
-};
+use adw::{prelude::*, subclass::prelude::*};
+use gtk::{CompositeTemplate, gio, glib, template_callbacks};
 
 use crate::{
     client::structs::SimpleListItem,
     ui::{
-        provider::tu_object::TuObject,
+        provider::{tu_item::PreferSize, tu_object::TuObject},
         widgets::fix::ScrolledWindowFixExt,
     },
 };
@@ -20,22 +12,13 @@ use crate::{
 pub const SHOW_BUTTON_ANIMATION_DURATION: u32 = 500;
 
 mod imp {
-    use std::cell::{
-        OnceCell,
-        RefCell,
-    };
+    use std::cell::{OnceCell, RefCell};
 
     use glib::subclass::InitializingObject;
-    use gtk::{
-        SignalListItemFactory,
-        gio,
-    };
+    use gtk::{SignalListItemFactory, gio};
 
     use super::*;
-    use crate::ui::widgets::{
-        tu_list_item::imp::PosterType,
-        utils::TuItemBuildExt,
-    };
+    use crate::ui::widgets::{tu_list_item::imp::PosterType, utils::TuItemBuildExt};
 
     #[derive(Debug, Default, CompositeTemplate, glib::Properties)]
     #[template(resource = "/moe/tsuna/tsukimi/ui/hortu_scrolled.ui")]
@@ -161,11 +144,27 @@ impl HortuScrolled {
 
         self.set_visible(true);
 
+        let primary_ratio: Vec<_> = items
+            .iter()
+            .filter_map(|i| i.primary_image_aspect_ratio)
+            .collect();
+
+        let prefer_size = if !primary_ratio.is_empty()
+            && primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
+                / primary_ratio.len() as f64
+                > 0.8
+        {
+            PreferSize::Video
+        } else {
+            PreferSize::Auto
+        };
+
         let items = items
             .iter()
             .map(|item| {
                 let object = TuObject::from_simple(item, None);
                 object.item().set_is_resume(self.isresume());
+                object.item().set_prefer_size(prefer_size);
                 object
             })
             .collect::<Vec<_>>();

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -1,10 +1,21 @@
-use adw::{prelude::*, subclass::prelude::*};
-use gtk::{CompositeTemplate, gio, glib, template_callbacks};
+use adw::{
+    prelude::*,
+    subclass::prelude::*,
+};
+use gtk::{
+    CompositeTemplate,
+    gio,
+    glib,
+    template_callbacks,
+};
 
 use crate::{
     client::structs::SimpleListItem,
     ui::{
-        provider::{tu_item::PreferSize, tu_object::TuObject},
+        provider::{
+            tu_item::PreferSize,
+            tu_object::TuObject,
+        },
         widgets::fix::ScrolledWindowFixExt,
     },
 };
@@ -12,13 +23,22 @@ use crate::{
 pub const SHOW_BUTTON_ANIMATION_DURATION: u32 = 500;
 
 mod imp {
-    use std::cell::{OnceCell, RefCell};
+    use std::cell::{
+        OnceCell,
+        RefCell,
+    };
 
     use glib::subclass::InitializingObject;
-    use gtk::{SignalListItemFactory, gio};
+    use gtk::{
+        SignalListItemFactory,
+        gio,
+    };
 
     use super::*;
-    use crate::ui::widgets::{tu_list_item::imp::PosterType, utils::TuItemBuildExt};
+    use crate::ui::widgets::{
+        tu_list_item::imp::PosterType,
+        utils::TuItemBuildExt,
+    };
 
     #[derive(Debug, Default, CompositeTemplate, glib::Properties)]
     #[template(resource = "/moe/tsuna/tsukimi/ui/hortu_scrolled.ui")]

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -1,21 +1,10 @@
-use adw::{
-    prelude::*,
-    subclass::prelude::*,
-};
-use gtk::{
-    CompositeTemplate,
-    gio,
-    glib,
-    template_callbacks,
-};
+use adw::{prelude::*, subclass::prelude::*};
+use gtk::{CompositeTemplate, gio, glib, template_callbacks};
 
 use crate::{
     client::structs::SimpleListItem,
     ui::{
-        provider::{
-            tu_item::PreferSize,
-            tu_object::TuObject,
-        },
+        provider::{tu_item::PreferSize, tu_object::TuObject},
         widgets::fix::ScrolledWindowFixExt,
     },
 };
@@ -23,22 +12,13 @@ use crate::{
 pub const SHOW_BUTTON_ANIMATION_DURATION: u32 = 500;
 
 mod imp {
-    use std::cell::{
-        OnceCell,
-        RefCell,
-    };
+    use std::cell::{OnceCell, RefCell};
 
     use glib::subclass::InitializingObject;
-    use gtk::{
-        SignalListItemFactory,
-        gio,
-    };
+    use gtk::{SignalListItemFactory, gio};
 
     use super::*;
-    use crate::ui::widgets::{
-        tu_list_item::imp::PosterType,
-        utils::TuItemBuildExt,
-    };
+    use crate::ui::widgets::{tu_list_item::imp::PosterType, utils::TuItemBuildExt};
 
     #[derive(Debug, Default, CompositeTemplate, glib::Properties)]
     #[template(resource = "/moe/tsuna/tsukimi/ui/hortu_scrolled.ui")]
@@ -167,24 +147,7 @@ impl HortuScrolled {
 
         self.set_visible(true);
 
-        let prefer_size = if self.unify_size() {
-            let primary_ratio: Vec<_> = items
-                .iter()
-                .filter_map(|i| i.primary_image_aspect_ratio)
-                .collect();
-
-            if !primary_ratio.is_empty()
-                && primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
-                    / primary_ratio.len() as f64
-                    > 0.8
-            {
-                PreferSize::Video
-            } else {
-                PreferSize::Auto
-            }
-        } else {
-            PreferSize::Auto
-        };
+        let prefer_size = self.evaluate_prefer_size(items);
 
         let items = items
             .iter()
@@ -214,6 +177,23 @@ impl HortuScrolled {
 
         self.imp().left_button.opacity() >= 0.68
             || self.show_controls_animation().state() == adw::AnimationState::Playing
+    }
+
+    fn evaluate_prefer_size(&self, items: &[SimpleListItem]) -> PreferSize {
+        let primary_ratio: Vec<_> = items
+            .iter()
+            .filter_map(|i| i.primary_image_aspect_ratio)
+            .collect();
+        if primary_ratio.is_empty() {
+            return PreferSize::Auto;
+        }
+        let video_percentage =
+            primary_ratio.iter().filter(|i| **i > 1.0).count() as f64 / primary_ratio.len() as f64;
+        match video_percentage {
+            p if p > 0.8 => PreferSize::Video,
+            p if p < 0.2 => PreferSize::Post,
+            _ => PreferSize::Auto,
+        }
     }
 
     fn show_controls_animation(&self) -> &adw::TimedAnimation {

--- a/src/ui/widgets/music_album.rs
+++ b/src/ui/widgets/music_album.rs
@@ -17,8 +17,8 @@ use super::{
     song_widget::format_duration,
     utils::{
         GlobalToast,
-        run_time_ticks_to_label
-    }
+        run_time_ticks_to_label,
+    },
 };
 use crate::{
     bing_song_model,
@@ -27,7 +27,7 @@ use crate::{
         jellyfin_client::JELLYFIN_CLIENT,
         structs::{
             List,
-            SongWidgetView
+            SongWidgetView,
         },
     },
     ui::{
@@ -150,7 +150,11 @@ use crate::ui::widgets::disc_box::DiscBox;
 #[template_callbacks]
 impl AlbumPage {
     pub fn new(item: TuItem) -> Self {
-        let view_type = if &item.item_type() == "MusicAlbum" { SongWidgetView::MusicAlbumItem } else { SongWidgetView::PlaylistItem };
+        let view_type = if &item.item_type() == "MusicAlbum" {
+            SongWidgetView::MusicAlbumItem
+        } else {
+            SongWidgetView::PlaylistItem
+        };
         glib::Object::builder()
             .property("item", item)
             .property("view_type", view_type)
@@ -183,18 +187,13 @@ impl AlbumPage {
                 format_duration(duration as i64)
             );
             imp.released_label.set_text(&release);
-        }
-        else {
+        } else {
             imp.artist_label.set_text("...");
 
             let duration = item.run_time_ticks();
-            let release = format!(
-                "{}",
-                run_time_ticks_to_label(duration as u64)
-            );
+            let release = format!("{}", run_time_ticks_to_label(duration as u64));
             imp.released_label.set_text(&release);
         }
-
 
         let path = if let Some(image_tags) = item.primary_image_item_id() {
             get_image_with_cache(image_tags, "Primary".to_string(), None)
@@ -243,12 +242,11 @@ impl AlbumPage {
         };
 
         if view_type == SongWidgetView::PlaylistItem {
-            self.imp().artist_label
-                .set_text(
-                    &format!("{} {}",
-                        songs.items.len(),
-                        gettext("Songs"))
-                );
+            self.imp().artist_label.set_text(&format!(
+                "{} {}",
+                songs.items.len(),
+                gettext("Songs")
+            ));
         }
 
         let mut disc_boxes: BTreeMap<u32, super::disc_box::DiscBox> = BTreeMap::new();
@@ -258,7 +256,11 @@ impl AlbumPage {
         }
         for song in songs.items {
             let item = TuItem::from_simple(&song, None);
-            let parent_index_number = if view_type == SongWidgetView::MusicAlbumItem {item.parent_index_number()} else {0};
+            let parent_index_number = if view_type == SongWidgetView::MusicAlbumItem {
+                item.parent_index_number()
+            } else {
+                0
+            };
 
             let song_widget = disc_boxes.entry(parent_index_number).or_insert_with(|| {
                 let new_disc_box = super::disc_box::DiscBox::new(view_type.to_owned());

--- a/src/ui/widgets/song_widget.rs
+++ b/src/ui/widgets/song_widget.rs
@@ -10,12 +10,14 @@ use gtk::{
 
 use crate::{
     client::structs::SongWidgetView,
-    ui::provider::{
-        actions::HasLikeAction,
-        core_song::CoreSong,
-        tu_item::TuItem,
+    ui::{
+        provider::{
+            actions::HasLikeAction,
+            core_song::CoreSong,
+            tu_item::TuItem,
+        },
+        widgets::picture_loader::PictureLoader,
     },
-    ui::widgets::picture_loader::PictureLoader,
     utils::spawn,
 };
 
@@ -199,8 +201,7 @@ impl SongWidget {
 
         if view_type == SongWidgetView::MusicAlbumItem {
             imp.cover_container.set_visible(false);
-        }
-        else {
+        } else {
             let picture_loader = if let Some(image_tags) = item.primary_image_item_id() {
                 PictureLoader::new(&image_tags, "Primary", None)
             } else {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -3,54 +3,29 @@ use std::cell::RefCell;
 use adw::prelude::*;
 use gettextrs::gettext;
 use glib::Object;
-use gtk::{
-    gio,
-    glib,
-    glib::subclass::types::ObjectSubclassIsExt,
-    template_callbacks,
-};
+use gtk::{gio, glib, glib::subclass::types::ObjectSubclassIsExt, template_callbacks};
 use imp::PosterType;
 use tracing::warn;
 
 use super::{
     tu_item::{
-        TuItemBasic,
-        TuItemMenuPrelude,
-        TuItemOverlay,
-        TuItemOverlayPrelude,
-        TuItemProgressbarAnimation,
-        TuItemProgressbarAnimationPrelude,
+        TuItemBasic, TuItemMenuPrelude, TuItemOverlay, TuItemOverlayPrelude,
+        TuItemProgressbarAnimation, TuItemProgressbarAnimationPrelude,
     },
-    utils::{
-        GlobalToast,
-        TU_ITEM_POST_SIZE,
-        TU_ITEM_SQUARE_SIZE,
-        TU_ITEM_VIDEO_SIZE,
-    },
+    utils::{GlobalToast, TU_ITEM_POST_SIZE, TU_ITEM_SQUARE_SIZE, TU_ITEM_VIDEO_SIZE},
 };
 use crate::ui::provider::tu_item::TuItem;
 
 pub mod imp {
-    use std::cell::{
-        Cell,
-        RefCell,
-    };
+    use std::cell::{Cell, RefCell};
 
     use adw::subclass::prelude::*;
     use glib::subclass::InitializingObject;
-    use gtk::{
-        CompositeTemplate,
-        PopoverMenu,
-        glib,
-        prelude::*,
-    };
+    use gtk::{CompositeTemplate, PopoverMenu, glib, prelude::*};
 
     use crate::ui::{
         provider::tu_item::TuItem,
-        widgets::{
-            picture_loader::PictureLoader,
-            tu_item::TuItemAction,
-        },
+        widgets::{picture_loader::PictureLoader, tu_item::TuItemAction},
     };
 
     #[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
@@ -437,6 +412,15 @@ impl TuListItem {
                 self.set_picture();
                 warn!("Unknown item type: {}", item_type)
             }
+        }
+
+        match item.prefer_size() {
+            // if the item has a prefer size, use it to override the default size
+            crate::ui::provider::tu_item::PreferSize::Video => {
+                imp.overlay
+                    .set_size_request(TU_ITEM_VIDEO_SIZE.0, TU_ITEM_VIDEO_SIZE.1);
+            }
+            _ => {}
         }
 
         self.set_tooltip_text(Some(&item.name()));

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -3,29 +3,54 @@ use std::cell::RefCell;
 use adw::prelude::*;
 use gettextrs::gettext;
 use glib::Object;
-use gtk::{gio, glib, glib::subclass::types::ObjectSubclassIsExt, template_callbacks};
+use gtk::{
+    gio,
+    glib,
+    glib::subclass::types::ObjectSubclassIsExt,
+    template_callbacks,
+};
 use imp::PosterType;
 use tracing::warn;
 
 use super::{
     tu_item::{
-        TuItemBasic, TuItemMenuPrelude, TuItemOverlay, TuItemOverlayPrelude,
-        TuItemProgressbarAnimation, TuItemProgressbarAnimationPrelude,
+        TuItemBasic,
+        TuItemMenuPrelude,
+        TuItemOverlay,
+        TuItemOverlayPrelude,
+        TuItemProgressbarAnimation,
+        TuItemProgressbarAnimationPrelude,
     },
-    utils::{GlobalToast, TU_ITEM_POST_SIZE, TU_ITEM_SQUARE_SIZE, TU_ITEM_VIDEO_SIZE},
+    utils::{
+        GlobalToast,
+        TU_ITEM_POST_SIZE,
+        TU_ITEM_SQUARE_SIZE,
+        TU_ITEM_VIDEO_SIZE,
+    },
 };
 use crate::ui::provider::tu_item::TuItem;
 
 pub mod imp {
-    use std::cell::{Cell, RefCell};
+    use std::cell::{
+        Cell,
+        RefCell,
+    };
 
     use adw::subclass::prelude::*;
     use glib::subclass::InitializingObject;
-    use gtk::{CompositeTemplate, PopoverMenu, glib, prelude::*};
+    use gtk::{
+        CompositeTemplate,
+        PopoverMenu,
+        glib,
+        prelude::*,
+    };
 
     use crate::ui::{
         provider::tu_item::TuItem,
-        widgets::{picture_loader::PictureLoader, tu_item::TuItemAction},
+        widgets::{
+            picture_loader::PictureLoader,
+            tu_item::TuItemAction,
+        },
     };
 
     #[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -3,54 +3,29 @@ use std::cell::RefCell;
 use adw::prelude::*;
 use gettextrs::gettext;
 use glib::Object;
-use gtk::{
-    gio,
-    glib,
-    glib::subclass::types::ObjectSubclassIsExt,
-    template_callbacks,
-};
+use gtk::{gio, glib, glib::subclass::types::ObjectSubclassIsExt, template_callbacks};
 use imp::PosterType;
 use tracing::warn;
 
 use super::{
     tu_item::{
-        TuItemBasic,
-        TuItemMenuPrelude,
-        TuItemOverlay,
-        TuItemOverlayPrelude,
-        TuItemProgressbarAnimation,
-        TuItemProgressbarAnimationPrelude,
+        TuItemBasic, TuItemMenuPrelude, TuItemOverlay, TuItemOverlayPrelude,
+        TuItemProgressbarAnimation, TuItemProgressbarAnimationPrelude,
     },
-    utils::{
-        GlobalToast,
-        TU_ITEM_POST_SIZE,
-        TU_ITEM_SQUARE_SIZE,
-        TU_ITEM_VIDEO_SIZE,
-    },
+    utils::{GlobalToast, TU_ITEM_POST_SIZE, TU_ITEM_SQUARE_SIZE, TU_ITEM_VIDEO_SIZE},
 };
 use crate::ui::provider::tu_item::TuItem;
 
 pub mod imp {
-    use std::cell::{
-        Cell,
-        RefCell,
-    };
+    use std::cell::{Cell, RefCell};
 
     use adw::subclass::prelude::*;
     use glib::subclass::InitializingObject;
-    use gtk::{
-        CompositeTemplate,
-        PopoverMenu,
-        glib,
-        prelude::*,
-    };
+    use gtk::{CompositeTemplate, PopoverMenu, glib, prelude::*};
 
     use crate::ui::{
         provider::tu_item::TuItem,
-        widgets::{
-            picture_loader::PictureLoader,
-            tu_item::TuItemAction,
-        },
+        widgets::{picture_loader::PictureLoader, tu_item::TuItemAction},
     };
 
     #[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
@@ -438,12 +413,15 @@ impl TuListItem {
                 warn!("Unknown item type: {}", item_type)
             }
         }
-
+        // if the item has a prefer size, use it to override the default size
         match item.prefer_size() {
-            // if the item has a prefer size, use it to override the default size
             crate::ui::provider::tu_item::PreferSize::Video => {
                 imp.overlay
                     .set_size_request(TU_ITEM_VIDEO_SIZE.0, TU_ITEM_VIDEO_SIZE.1);
+            }
+            crate::ui::provider::tu_item::PreferSize::Post => {
+                imp.overlay
+                    .set_size_request(TU_ITEM_POST_SIZE.0, TU_ITEM_POST_SIZE.1);
             }
             _ => {}
         }


### PR DESCRIPTION
Jellyfin 接口会返回 primary_image_aspect_ratio 表示封面的长宽比，在上层可以根据 item 长宽比分布情况进行简单的 size 对齐，目前拍脑门使用 80% 作为阈值。

以 Jellyfin Web 作为样式基准：

<img width="1599" height="2132" alt="图片" src="https://github.com/user-attachments/assets/9184611f-4784-4b70-88c7-587a5e1efd52" />


### Before
新增单集 size 不统一导致错位：

<img width="1837" height="633" alt="图片" src="https://github.com/user-attachments/assets/54ad4497-43fb-460f-923a-8332a4883e8a" />

多数横屏封面的情况会强制裁剪：

<img width="1835" height="600" alt="图片" src="https://github.com/user-attachments/assets/094b1d81-9a47-46c8-aae0-82e85030d318" />

### After

~~单集理论上应该使用该剧集的封面，这个在后续 PR 改。~~

<img width="1960" height="2132" alt="图片" src="https://github.com/user-attachments/assets/0b8100bf-fbe2-4ddf-a9eb-40c19bb4ab8c" />
