### PR TITLE
feat: improve poster selection and extend unify size to more views

### DIFF
--- a/resources/ui/home.ui
+++ b/resources/ui/home.ui
@@ -22,6 +22,7 @@
                     <property name="title" translatable="yes">Continue Watching</property>
                     <property name="isresume">True</property>
                     <property name="prefer-poster">ParentVideo</property>
+                    <property name="unify-size">ForceVideo</property>
                   </object>
                 </child>
                 <child>

--- a/resources/ui/home.ui
+++ b/resources/ui/home.ui
@@ -21,6 +21,7 @@
                   <object class="HortuScrolled" id="hishortu">
                     <property name="title" translatable="yes">Continue Watching</property>
                     <property name="isresume">True</property>
+                    <property name="prefer-poster">ParentVideo</property>
                   </object>
                 </child>
                 <child>

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -296,6 +296,8 @@ pub struct SimpleListItem {
     pub backdrop_image_tags: Option<Vec<String>>,
     #[serde(rename = "PrimaryImageAspectRatio")]
     pub primary_image_aspect_ratio: Option<f64>,
+    #[serde(rename = "SeriesPrimaryImageTag")]
+    pub series_primary_image_tag: Option<String>,
     #[serde(rename = "CommunityRating")]
     pub community_rating: Option<f32>,
     #[serde(rename = "CollectionType")]
@@ -607,9 +609,12 @@ use adw::prelude::*;
 use gtk::glib;
 
 use super::jellyfin_client::JELLYFIN_CLIENT;
-use crate::ui::widgets::{
-    single_grid::SingleGrid,
-    window::Window,
+use crate::ui::{
+    provider::tu_item::PreferPoster,
+    widgets::{
+        single_grid::SingleGrid,
+        window::Window,
+    },
 };
 
 impl SGTitem {
@@ -620,23 +625,27 @@ impl SGTitem {
         let page = SingleGrid::new();
         let id = self.id.to_string();
         let list_type_clone = list_type.to_owned();
-        page.connect_sort_changed_tokio(false, move |sort_by, sort_order, filters_list| {
-            let id = id.to_owned();
-            let list_type_clone = list_type_clone.to_owned();
-            async move {
-                JELLYFIN_CLIENT
-                    .get_inlist(
-                        None,
-                        0,
-                        &list_type_clone,
-                        &id,
-                        &sort_order,
-                        &sort_by,
-                        &filters_list,
-                    )
-                    .await
-            }
-        });
+        page.connect_sort_changed_tokio(
+            false,
+            PreferPoster::Auto,
+            move |sort_by, sort_order, filters_list| {
+                let id = id.to_owned();
+                let list_type_clone = list_type_clone.to_owned();
+                async move {
+                    JELLYFIN_CLIENT
+                        .get_inlist(
+                            None,
+                            0,
+                            &list_type_clone,
+                            &id,
+                            &sort_order,
+                            &sort_by,
+                            &filters_list,
+                        )
+                        .await
+                }
+            },
+        );
         let id = self.id.to_string();
         let list_type = list_type.to_owned();
         page.connect_end_edge_overshot_tokio(move |sort_by, sort_order, n_items, filters_list| {

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -296,8 +296,6 @@ pub struct SimpleListItem {
     pub backdrop_image_tags: Option<Vec<String>>,
     #[serde(rename = "PrimaryImageAspectRatio")]
     pub primary_image_aspect_ratio: Option<f64>,
-    #[serde(rename = "SeriesPrimaryImageTag")]
-    pub series_primary_image_tag: Option<String>,
     #[serde(rename = "CommunityRating")]
     pub community_rating: Option<f32>,
     #[serde(rename = "CollectionType")]

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -612,6 +612,7 @@ use super::jellyfin_client::JELLYFIN_CLIENT;
 use crate::ui::{
     provider::tu_item::PreferPoster,
     widgets::{
+        hortu_scrolled::UnifySize,
         single_grid::SingleGrid,
         window::Window,
     },
@@ -628,6 +629,7 @@ impl SGTitem {
         page.connect_sort_changed_tokio(
             false,
             PreferPoster::Auto,
+            UnifySize::Majority,
             move |sort_by, sort_order, filters_list| {
                 let id = id.to_owned();
                 let list_type_clone = list_type_clone.to_owned();

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -624,12 +624,12 @@ impl SGTitem {
         T: gtk::prelude::WidgetExt + glib::clone::Downgrade,
     {
         let page = SingleGrid::new();
+        page.set_unify_size(UnifySize::Majority);
         let id = self.id.to_string();
         let list_type_clone = list_type.to_owned();
         page.connect_sort_changed_tokio(
             false,
             PreferPoster::Auto,
-            UnifySize::Majority,
             move |sort_by, sort_order, filters_list| {
                 let id = id.to_owned();
                 let list_type_clone = list_type_clone.to_owned();

--- a/src/ui/provider/image_tags.rs
+++ b/src/ui/provider/image_tags.rs
@@ -50,4 +50,12 @@ impl ImageTags {
     pub fn new() -> ImageTags {
         glib::object::Object::new()
     }
+
+    pub fn all_none(&self) -> bool {
+        let imp = self.imp();
+        imp.backdrop.borrow().is_none()
+            && imp.primary.borrow().is_none()
+            && imp.thumb.borrow().is_none()
+            && imp.banner.borrow().is_none()
+    }
 }

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -113,8 +113,6 @@ pub mod imp {
         parent_thumb_item_id: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         parent_backdrop_item_id: RefCell<Option<String>>,
-        #[property(get, set, nullable)]
-        series_primary_image_tag: RefCell<Option<String>>,
         #[property(get, set)]
         poster: RefCell<Option<String>>,
         #[property(get, set, nullable)]
@@ -224,7 +222,6 @@ impl TuItem {
         tu_item.set_parent_thumb_item_id(item.parent_thumb_item_id);
         tu_item.set_parent_backdrop_item_id(item.parent_backdrop_item_id);
         tu_item.set_series_name(item.series_name);
-        tu_item.set_series_primary_image_tag(item.series_primary_image_tag);
 
         if let Some(album_artist) = &item.album_artists {
             tu_item.set_albumartist_name(

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -300,13 +300,13 @@ impl TuItem {
             }
             "Tag" | "Genre" | "MusicGenre" => {
                 let page = SingleGrid::new();
+                page.set_unify_size(UnifySize::Majority);
                 let id = self.id();
                 let parent_id = parentid.to_owned();
                 let list_type = self.item_type();
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
-                    UnifySize::Majority,
                     move |sort_by, sort_order, filters_list| {
                         let id = id.to_owned();
                         let parent_id = parent_id.to_owned();
@@ -354,11 +354,11 @@ impl TuItem {
             "Folder" => {
                 let page = SingleGrid::new();
                 page.set_list_type(ListType::Folder);
+                page.set_unify_size(UnifySize::Majority);
                 let id = self.id();
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
-                    UnifySize::Majority,
                     move |sort_by, sort_order, filters_list| {
                         let id = id.to_owned();
                         async move {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -61,6 +61,16 @@ pub enum PreferSize {
     Post,
 }
 
+#[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
+#[repr(u32)]
+#[enum_type(name = "PreferPoster")]
+pub enum PreferPoster {
+    #[default]
+    Auto,
+    ParentPost,
+    ParentVideo,
+}
+
 pub mod imp {
     use glib::DateTime;
     use gtk::glib::Properties;
@@ -102,12 +112,16 @@ pub mod imp {
         parent_thumb_item_id: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         parent_backdrop_item_id: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        series_primary_image_tag: RefCell<Option<String>>,
         #[property(get, set)]
         poster: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         image_tags: RefCell<Option<crate::ui::provider::image_tags::ImageTags>>,
         #[property(get, set, builder(PreferSize::default()))]
         prefer_size: RefCell<PreferSize>,
+        #[property(get, set, builder(PreferPoster::default()))]
+        prefer_poster: RefCell<PreferPoster>,
         #[property(get, set, nullable)]
         role: RefCell<Option<String>>,
         #[property(get, set, nullable)]
@@ -209,6 +223,7 @@ impl TuItem {
         tu_item.set_parent_thumb_item_id(item.parent_thumb_item_id);
         tu_item.set_parent_backdrop_item_id(item.parent_backdrop_item_id);
         tu_item.set_series_name(item.series_name);
+        tu_item.set_series_primary_image_tag(item.series_primary_image_tag);
 
         if let Some(album_artist) = &item.album_artists {
             tu_item.set_albumartist_name(
@@ -287,24 +302,28 @@ impl TuItem {
                 let id = self.id();
                 let parent_id = parentid.to_owned();
                 let list_type = self.item_type();
-                page.connect_sort_changed_tokio(false, move |sort_by, sort_order, filters_list| {
-                    let id = id.to_owned();
-                    let parent_id = parent_id.to_owned();
-                    let list_type = list_type.to_owned();
-                    async move {
-                        JELLYFIN_CLIENT
-                            .get_inlist(
-                                parent_id,
-                                0,
-                                &list_type,
-                                &id,
-                                &sort_order,
-                                &sort_by,
-                                &filters_list,
-                            )
-                            .await
-                    }
-                });
+                page.connect_sort_changed_tokio(
+                    false,
+                    PreferPoster::Auto,
+                    move |sort_by, sort_order, filters_list| {
+                        let id = id.to_owned();
+                        let parent_id = parent_id.to_owned();
+                        let list_type = list_type.to_owned();
+                        async move {
+                            JELLYFIN_CLIENT
+                                .get_inlist(
+                                    parent_id,
+                                    0,
+                                    &list_type,
+                                    &id,
+                                    &sort_order,
+                                    &sort_by,
+                                    &filters_list,
+                                )
+                                .await
+                        }
+                    },
+                );
                 let id = self.id();
                 let parent_id = parentid.to_owned();
                 let list_type = self.item_type();
@@ -334,14 +353,18 @@ impl TuItem {
                 let page = SingleGrid::new();
                 page.set_list_type(ListType::Folder);
                 let id = self.id();
-                page.connect_sort_changed_tokio(false, move |sort_by, sort_order, filters_list| {
-                    let id = id.to_owned();
-                    async move {
-                        JELLYFIN_CLIENT
-                            .get_folder_include(&id, &sort_by, &sort_order, 0, &filters_list)
-                            .await
-                    }
-                });
+                page.connect_sort_changed_tokio(
+                    false,
+                    PreferPoster::Auto,
+                    move |sort_by, sort_order, filters_list| {
+                        let id = id.to_owned();
+                        async move {
+                            JELLYFIN_CLIENT
+                                .get_folder_include(&id, &sort_by, &sort_order, 0, &filters_list)
+                                .await
+                        }
+                    },
+                );
                 let id = self.id();
                 page.connect_end_edge_overshot_tokio(
                     move |sort_by, sort_order, n_items, filters_list| {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -25,6 +25,7 @@ use crate::{
         GlobalToast,
         provider::core_song::CoreSong,
         widgets::{
+            hortu_scrolled::UnifySize,
             item::ItemPage,
             list::ListPage,
             music_album::AlbumPage,
@@ -305,6 +306,7 @@ impl TuItem {
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
+                    UnifySize::Majority,
                     move |sort_by, sort_order, filters_list| {
                         let id = id.to_owned();
                         let parent_id = parent_id.to_owned();
@@ -356,6 +358,7 @@ impl TuItem {
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
+                    UnifySize::Majority,
                     move |sort_by, sort_order, filters_list| {
                         let id = id.to_owned();
                         async move {

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -20,7 +20,10 @@ use crate::{
     },
     fraction,
     fraction_reset,
-    ui::provider::tu_item::TuItem,
+    ui::provider::tu_item::{
+        PreferPoster,
+        TuItem,
+    },
     utils::{
         CachePolicy,
         fetch_with_cache,
@@ -227,6 +230,8 @@ impl HomePage {
         hortu.set_moreview(true);
 
         hortu.set_unify_size(true);
+
+        hortu.set_prefer_poster(PreferPoster::ParentPost);
 
         hortu.set_title(format!("{} {}", gettext("Latest"), view.name));
 

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -9,7 +9,10 @@ use gtk::{
 };
 
 use super::{
-    hortu_scrolled::HortuScrolled,
+    hortu_scrolled::{
+        HortuScrolled,
+        UnifySize,
+    },
     utils::GlobalToast,
 };
 use crate::{
@@ -229,7 +232,7 @@ impl HomePage {
 
         hortu.set_moreview(true);
 
-        hortu.set_unify_size(true);
+        hortu.set_unify_size(UnifySize::Majority);
 
         hortu.set_prefer_poster(PreferPoster::ParentPost);
 

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -36,6 +36,31 @@ pub enum UnifySize {
     ForcePost,
 }
 
+pub fn resolve_prefer_size(unify_size: UnifySize, items: &[SimpleListItem]) -> PreferSize {
+    match unify_size {
+        UnifySize::Disable => PreferSize::Auto,
+        UnifySize::ForceVideo => PreferSize::Video,
+        UnifySize::ForcePost => PreferSize::Post,
+        UnifySize::Majority => {
+            let primary_ratio: Vec<_> = items
+                .iter()
+                .filter(|i| i.item_type != "Episode")
+                .filter_map(|i| i.primary_image_aspect_ratio)
+                .collect();
+            if primary_ratio.is_empty() {
+                return PreferSize::Auto;
+            }
+            let video_percentage = primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
+                / primary_ratio.len() as f64;
+            match video_percentage {
+                p if p > 0.8 => PreferSize::Video,
+                p if p < 0.2 => PreferSize::Post,
+                _ => PreferSize::Auto,
+            }
+        }
+    }
+}
+
 mod imp {
     use std::cell::{
         OnceCell,
@@ -184,7 +209,7 @@ impl HortuScrolled {
 
         self.set_visible(true);
 
-        let prefer_size = self.evaluate_prefer_size(items);
+        let prefer_size = resolve_prefer_size(self.unify_size(), items);
 
         let items = items
             .iter()
@@ -215,31 +240,6 @@ impl HortuScrolled {
 
         self.imp().left_button.opacity() >= 0.68
             || self.show_controls_animation().state() == adw::AnimationState::Playing
-    }
-
-    fn evaluate_prefer_size(&self, items: &[SimpleListItem]) -> PreferSize {
-        match self.unify_size() {
-            UnifySize::Disable => PreferSize::Auto,
-            UnifySize::ForceVideo => PreferSize::Video,
-            UnifySize::ForcePost => PreferSize::Post,
-            UnifySize::Majority => {
-                let primary_ratio: Vec<_> = items
-                    .iter()
-                    .filter(|i| i.item_type != "Episode") // Episode uses parent poster, can be misleading, just ignore it
-                    .filter_map(|i| i.primary_image_aspect_ratio)
-                    .collect();
-                if primary_ratio.is_empty() {
-                    return PreferSize::Auto;
-                }
-                let video_percentage = primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
-                    / primary_ratio.len() as f64;
-                match video_percentage {
-                    p if p > 0.8 => PreferSize::Video,
-                    p if p < 0.2 => PreferSize::Post,
-                    _ => PreferSize::Auto,
-                }
-            }
-        }
     }
 
     fn show_controls_animation(&self) -> &adw::TimedAnimation {

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -25,6 +25,17 @@ use crate::{
 
 pub const SHOW_BUTTON_ANIMATION_DURATION: u32 = 500;
 
+#[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
+#[repr(u32)]
+#[enum_type(name = "UnifySize")]
+pub enum UnifySize {
+    #[default]
+    Disable,
+    Majority,
+    ForceVideo,
+    ForcePost,
+}
+
 mod imp {
     use std::cell::{
         OnceCell,
@@ -69,8 +80,8 @@ mod imp {
         #[property(get, set)]
         pub title: RefCell<String>,
 
-        #[property(get, set, default_value = false)]
-        pub unify_size: RefCell<bool>,
+        #[property(get, set, builder(UnifySize::default()))]
+        pub unify_size: RefCell<UnifySize>,
 
         #[property(get, set, builder(PreferPoster::default()))]
         pub prefer_poster: RefCell<PreferPoster>,
@@ -207,23 +218,27 @@ impl HortuScrolled {
     }
 
     fn evaluate_prefer_size(&self, items: &[SimpleListItem]) -> PreferSize {
-        if !self.unify_size() {
-            return PreferSize::Auto;
-        }
-        let primary_ratio: Vec<_> = items
-            .iter()
-            .filter(|i| i.item_type != "Episode") // Episode uses parent poster, can be misleading, just ignore it
-            .filter_map(|i| i.primary_image_aspect_ratio)
-            .collect();
-        if primary_ratio.is_empty() {
-            return PreferSize::Auto;
-        }
-        let video_percentage =
-            primary_ratio.iter().filter(|i| **i > 1.0).count() as f64 / primary_ratio.len() as f64;
-        match video_percentage {
-            p if p > 0.8 => PreferSize::Video,
-            p if p < 0.2 => PreferSize::Post,
-            _ => PreferSize::Auto,
+        match self.unify_size() {
+            UnifySize::Disable => PreferSize::Auto,
+            UnifySize::ForceVideo => PreferSize::Video,
+            UnifySize::ForcePost => PreferSize::Post,
+            UnifySize::Majority => {
+                let primary_ratio: Vec<_> = items
+                    .iter()
+                    .filter(|i| i.item_type != "Episode") // Episode uses parent poster, can be misleading, just ignore it
+                    .filter_map(|i| i.primary_image_aspect_ratio)
+                    .collect();
+                if primary_ratio.is_empty() {
+                    return PreferSize::Auto;
+                }
+                let video_percentage = primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
+                    / primary_ratio.len() as f64;
+                match video_percentage {
+                    p if p > 0.8 => PreferSize::Video,
+                    p if p < 0.2 => PreferSize::Post,
+                    _ => PreferSize::Auto,
+                }
+            }
         }
     }
 

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -13,7 +13,10 @@ use crate::{
     client::structs::SimpleListItem,
     ui::{
         provider::{
-            tu_item::PreferSize,
+            tu_item::{
+                PreferPoster,
+                PreferSize,
+            },
             tu_object::TuObject,
         },
         widgets::fix::ScrolledWindowFixExt,
@@ -68,6 +71,9 @@ mod imp {
 
         #[property(get, set, default_value = false)]
         pub unify_size: RefCell<bool>,
+
+        #[property(get, set, builder(PreferPoster::default()))]
+        pub prefer_poster: RefCell<PreferPoster>,
 
         pub show_button_animation: OnceCell<adw::TimedAnimation>,
         pub hide_button_animation: OnceCell<adw::TimedAnimation>,
@@ -175,6 +181,7 @@ impl HortuScrolled {
                 let object = TuObject::from_simple(item, None);
                 object.item().set_is_resume(self.isresume());
                 object.item().set_prefer_size(prefer_size);
+                object.item().set_prefer_poster(self.prefer_poster());
                 object
             })
             .collect::<Vec<_>>();
@@ -205,6 +212,7 @@ impl HortuScrolled {
         }
         let primary_ratio: Vec<_> = items
             .iter()
+            .filter(|i| i.item_type != "Episode") // Episode uses parent poster, can be misleading, just ignore it
             .filter_map(|i| i.primary_image_aspect_ratio)
             .collect();
         if primary_ratio.is_empty() {

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -1,7 +1,10 @@
 use super::{
     episode_switcher::EpisodeButton,
     fix::ScrolledWindowFixExt,
-    hortu_scrolled::SHOW_BUTTON_ANIMATION_DURATION,
+    hortu_scrolled::{
+        SHOW_BUTTON_ANIMATION_DURATION,
+        UnifySize,
+    },
     item_utils::*,
     song_widget::format_duration,
     utils::{
@@ -1181,6 +1184,8 @@ impl ItemPage {
                 List::default()
             }
         };
+
+        hortu.set_unify_size(UnifySize::Majority);
 
         hortu.set_items(&results.items);
     }

--- a/src/ui/widgets/liked.rs
+++ b/src/ui/widgets/liked.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     fraction,
     fraction_reset,
+    ui::provider::tu_item::PreferPoster,
     utils::{
         spawn,
         spawn_tokio,
@@ -187,21 +188,25 @@ impl LikedPage {
                 let page = crate::ui::widgets::single_grid::SingleGrid::new();
                 let type_clone1 = type_.to_owned();
                 let type_clone2 = type_.to_owned();
-                page.connect_sort_changed_tokio(false, move |sort_by, sort_order, filters_list| {
-                    let type_clone1 = type_clone1.to_owned();
-                    async move {
-                        JELLYFIN_CLIENT
-                            .get_favourite(
-                                &type_clone1,
-                                0,
-                                50,
-                                &sort_by,
-                                &sort_order,
-                                &filters_list,
-                            )
-                            .await
-                    }
-                });
+                page.connect_sort_changed_tokio(
+                    false,
+                    PreferPoster::Auto,
+                    move |sort_by, sort_order, filters_list| {
+                        let type_clone1 = type_clone1.to_owned();
+                        async move {
+                            JELLYFIN_CLIENT
+                                .get_favourite(
+                                    &type_clone1,
+                                    0,
+                                    50,
+                                    &sort_by,
+                                    &sort_order,
+                                    &filters_list,
+                                )
+                                .await
+                        }
+                    },
+                );
                 page.connect_end_edge_overshot_tokio(
                     move |sort_by, sort_order, n_items, filters_list| {
                         let type_clone2 = type_clone2.to_owned();

--- a/src/ui/widgets/liked.rs
+++ b/src/ui/widgets/liked.rs
@@ -189,12 +189,12 @@ impl LikedPage {
             move |_| {
                 let tag = format!("{} {}", "Favourite", type_);
                 let page = crate::ui::widgets::single_grid::SingleGrid::new();
+                page.set_unify_size(UnifySize::Majority);
                 let type_clone1 = type_.to_owned();
                 let type_clone2 = type_.to_owned();
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
-                    UnifySize::Majority,
                     move |sort_by, sort_order, filters_list| {
                         let type_clone1 = type_clone1.to_owned();
                         async move {

--- a/src/ui/widgets/liked.rs
+++ b/src/ui/widgets/liked.rs
@@ -7,7 +7,10 @@ use gtk::{
     subclass::prelude::*,
 };
 
-use super::utils::GlobalToast;
+use super::{
+    hortu_scrolled::UnifySize,
+    utils::GlobalToast,
+};
 use crate::{
     client::{
         error::UserFacingError,
@@ -191,6 +194,7 @@ impl LikedPage {
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
+                    UnifySize::Majority,
                     move |sort_by, sort_order, filters_list| {
                         let type_clone1 = type_clone1.to_owned();
                         async move {

--- a/src/ui/widgets/list.rs
+++ b/src/ui/widgets/list.rs
@@ -10,7 +10,10 @@ use super::single_grid::{
     SingleGrid,
     imp::ListType,
 };
-use crate::client::jellyfin_client::JELLYFIN_CLIENT;
+use crate::{
+    client::jellyfin_client::JELLYFIN_CLIENT,
+    ui::provider::tu_item::PreferPoster,
+};
 mod imp {
 
     use std::cell::OnceCell;
@@ -100,7 +103,7 @@ impl ListPage {
 
         if &collection_type == "livetv" {
             let page = SingleGrid::new();
-            page.connect_sort_changed_tokio(false, move |_, _, _| async move {
+            page.connect_sort_changed_tokio(false, PreferPoster::Auto, move |_, _, _| async move {
                 JELLYFIN_CLIENT.get_channels_list(0).await
             });
             page.connect_end_edge_overshot_tokio(move |_, _, n_items, _| async move {
@@ -129,6 +132,11 @@ impl ListPage {
             let include_item_types_clone1 = include_item_types.to_owned();
             page.connect_sort_changed_tokio(
                 list_type == ListType::Resume,
+                if list_type == ListType::Resume {
+                    PreferPoster::ParentVideo
+                } else {
+                    PreferPoster::Auto
+                },
                 move |sort_by, sort_order, filters_list| {
                     let id_clone1 = id_clone1.to_owned();
                     let include_item_types_clone1 = include_item_types_clone1.to_owned();

--- a/src/ui/widgets/list.rs
+++ b/src/ui/widgets/list.rs
@@ -106,12 +106,10 @@ impl ListPage {
 
         if &collection_type == "livetv" {
             let page = SingleGrid::new();
-            page.connect_sort_changed_tokio(
-                false,
-                PreferPoster::Auto,
-                UnifySize::Majority,
-                move |_, _, _| async move { JELLYFIN_CLIENT.get_channels_list(0).await },
-            );
+            page.set_unify_size(UnifySize::Majority);
+            page.connect_sort_changed_tokio(false, PreferPoster::Auto, move |_, _, _| async move {
+                JELLYFIN_CLIENT.get_channels_list(0).await
+            });
             page.connect_end_edge_overshot_tokio(move |_, _, n_items, _| async move {
                 JELLYFIN_CLIENT.get_channels_list(n_items).await
             });
@@ -134,6 +132,7 @@ impl ListPage {
         for (name, title, list_type) in pages {
             let page = SingleGrid::new();
             page.set_list_type(list_type);
+            page.set_unify_size(UnifySize::Majority);
             let id_clone1 = id.to_owned();
             let include_item_types_clone1 = include_item_types.to_owned();
             page.connect_sort_changed_tokio(
@@ -143,7 +142,6 @@ impl ListPage {
                 } else {
                     PreferPoster::Auto
                 },
-                UnifySize::Majority,
                 move |sort_by, sort_order, filters_list| {
                     let id_clone1 = id_clone1.to_owned();
                     let include_item_types_clone1 = include_item_types_clone1.to_owned();

--- a/src/ui/widgets/list.rs
+++ b/src/ui/widgets/list.rs
@@ -6,9 +6,12 @@ use gtk::{
     subclass::prelude::*,
 };
 
-use super::single_grid::{
-    SingleGrid,
-    imp::ListType,
+use super::{
+    hortu_scrolled::UnifySize,
+    single_grid::{
+        SingleGrid,
+        imp::ListType,
+    },
 };
 use crate::{
     client::jellyfin_client::JELLYFIN_CLIENT,
@@ -103,9 +106,12 @@ impl ListPage {
 
         if &collection_type == "livetv" {
             let page = SingleGrid::new();
-            page.connect_sort_changed_tokio(false, PreferPoster::Auto, move |_, _, _| async move {
-                JELLYFIN_CLIENT.get_channels_list(0).await
-            });
+            page.connect_sort_changed_tokio(
+                false,
+                PreferPoster::Auto,
+                UnifySize::Majority,
+                move |_, _, _| async move { JELLYFIN_CLIENT.get_channels_list(0).await },
+            );
             page.connect_end_edge_overshot_tokio(move |_, _, n_items, _| async move {
                 JELLYFIN_CLIENT.get_channels_list(n_items).await
             });
@@ -137,6 +143,7 @@ impl ListPage {
                 } else {
                     PreferPoster::Auto
                 },
+                UnifySize::Majority,
                 move |sort_by, sort_order, filters_list| {
                     let id_clone1 = id_clone1.to_owned();
                     let include_item_types_clone1 = include_item_types_clone1.to_owned();

--- a/src/ui/widgets/music_album.rs
+++ b/src/ui/widgets/music_album.rs
@@ -191,7 +191,7 @@ impl AlbumPage {
             imp.artist_label.set_text("...");
 
             let duration = item.run_time_ticks();
-            let release = format!("{}", run_time_ticks_to_label(duration as u64));
+            let release = run_time_ticks_to_label(duration).to_string();
             imp.released_label.set_text(&release);
         }
 

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -339,7 +339,6 @@ impl OtherPage {
         for item in list.items {
             let tu_item = TuItem::from_simple(&item, None);
             tu_item.set_is_resume(true);
-            tu_item.set_prefer_poster(PreferPoster::ParentVideo);
             let tu_item = TuObject::new(&tu_item);
             store.append(&tu_item);
         }

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -13,7 +13,10 @@ use crate::{
     fraction,
     fraction_reset,
     ui::provider::{
-        tu_item::TuItem,
+        tu_item::{
+            PreferPoster,
+            TuItem,
+        },
         tu_object::TuObject,
     },
     utils::{
@@ -336,6 +339,7 @@ impl OtherPage {
         for item in list.items {
             let tu_item = TuItem::from_simple(&item, None);
             tu_item.set_is_resume(true);
+            tu_item.set_prefer_poster(PreferPoster::ParentVideo);
             let tu_item = TuObject::new(&tu_item);
             store.append(&tu_item);
         }
@@ -426,22 +430,26 @@ impl OtherPage {
                 let type_clone2 = type1_.to_owned();
                 let id_clone1 = id.to_owned();
                 let id_clone2 = id.to_owned();
-                page.connect_sort_changed_tokio(false, move |sort_by, sort_order, filters_list| {
-                    let id_clone1 = id_clone1.to_owned();
-                    let type_clone1 = type_clone1.to_owned();
-                    async move {
-                        JELLYFIN_CLIENT
-                            .get_person_large_list(
-                                &id_clone1,
-                                &type_clone1,
-                                &sort_by,
-                                &sort_order,
-                                0,
-                                &filters_list,
-                            )
-                            .await
-                    }
-                });
+                page.connect_sort_changed_tokio(
+                    false,
+                    PreferPoster::Auto,
+                    move |sort_by, sort_order, filters_list| {
+                        let id_clone1 = id_clone1.to_owned();
+                        let type_clone1 = type_clone1.to_owned();
+                        async move {
+                            JELLYFIN_CLIENT
+                                .get_person_large_list(
+                                    &id_clone1,
+                                    &type_clone1,
+                                    &sort_by,
+                                    &sort_order,
+                                    0,
+                                    &filters_list,
+                                )
+                                .await
+                        }
+                    },
+                );
                 page.connect_end_edge_overshot_tokio(
                     move |sort_by, sort_order, n_items, filters_list| {
                         let id_clone2 = id_clone2.to_owned();

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -12,15 +12,12 @@ use crate::{
     },
     fraction,
     fraction_reset,
-    ui::{
-        provider::{
-            tu_item::{
-                PreferPoster,
-                TuItem,
-            },
-            tu_object::TuObject,
+    ui::provider::{
+        tu_item::{
+            PreferPoster,
+            TuItem,
         },
-        widgets::hortu_scrolled::UnifySize,
+        tu_object::TuObject,
     },
     utils::{
         CachePolicy,
@@ -435,7 +432,6 @@ impl OtherPage {
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
-                    UnifySize::Disable,
                     move |sort_by, sort_order, filters_list| {
                         let id_clone1 = id_clone1.to_owned();
                         let type_clone1 = type_clone1.to_owned();

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -12,12 +12,15 @@ use crate::{
     },
     fraction,
     fraction_reset,
-    ui::provider::{
-        tu_item::{
-            PreferPoster,
-            TuItem,
+    ui::{
+        provider::{
+            tu_item::{
+                PreferPoster,
+                TuItem,
+            },
+            tu_object::TuObject,
         },
-        tu_object::TuObject,
+        widgets::hortu_scrolled::UnifySize,
     },
     utils::{
         CachePolicy,
@@ -432,6 +435,7 @@ impl OtherPage {
                 page.connect_sort_changed_tokio(
                     false,
                     PreferPoster::Auto,
+                    UnifySize::Disable,
                     move |sort_by, sort_order, filters_list| {
                         let id_clone1 = id_clone1.to_owned();
                         let type_clone1 = type_clone1.to_owned();

--- a/src/ui/widgets/search.rs
+++ b/src/ui/widgets/search.rs
@@ -51,6 +51,7 @@ mod imp {
             provider::tu_item::PreferPoster,
             widgets::{
                 filter_panel::FilterPanelDialog,
+                hortu_scrolled::UnifySize,
                 tuview_scrolled::TuViewScrolled,
             },
         },
@@ -114,6 +115,9 @@ mod imp {
         fn constructed(&self) {
             let obj = self.obj();
             self.parent_constructed();
+            self.searchscrolled
+                .get()
+                .set_unify_size(UnifySize::Majority);
             self.searchscrolled.connect_end_edge_reached(glib::clone!(
                 #[weak]
                 obj,

--- a/src/ui/widgets/search.rs
+++ b/src/ui/widgets/search.rs
@@ -15,7 +15,10 @@ use crate::{
         jellyfin_client::JELLYFIN_CLIENT,
         structs::*,
     },
-    ui::provider::tu_item::TuItem,
+    ui::provider::tu_item::{
+        PreferPoster,
+        TuItem,
+    },
     utils::{
         spawn,
         spawn_tokio,
@@ -44,9 +47,12 @@ mod imp {
     use gtk::prelude::*;
 
     use crate::{
-        ui::widgets::{
-            filter_panel::FilterPanelDialog,
-            tuview_scrolled::TuViewScrolled,
+        ui::{
+            provider::tu_item::PreferPoster,
+            widgets::{
+                filter_panel::FilterPanelDialog,
+                tuview_scrolled::TuViewScrolled,
+            },
         },
         utils::spawn,
     };
@@ -122,7 +128,11 @@ mod imp {
 
                             let search_results = obj.get_search_results::<true>().await;
 
-                            scrolled.set_store::<false>(search_results.items, false);
+                            scrolled.set_store::<false>(
+                                search_results.items,
+                                false,
+                                PreferPoster::Auto,
+                            );
 
                             scrolled.reveal_spinner(false);
 
@@ -238,7 +248,7 @@ impl SearchPage {
         };
 
         imp.searchscrolled
-            .set_store::<true>(search_results.items, false);
+            .set_store::<true>(search_results.items, false, PreferPoster::Auto);
 
         imp.stack.set_visible_child_name("result");
     }

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -34,6 +34,7 @@ use crate::{
             SimpleListItem,
         },
     },
+    ui::provider::tu_item::PreferPoster,
     utils::{
         spawn,
         spawn_tokio,
@@ -478,10 +479,12 @@ impl SingleGrid {
         };
     }
 
-    pub fn add_items<const C: bool>(&self, items: Vec<SimpleListItem>, is_resume: bool) {
+    pub fn add_items<const C: bool>(
+        &self, items: Vec<SimpleListItem>, is_resume: bool, prefer_poster: PreferPoster,
+    ) {
         let imp = self.imp();
         let scrolled = imp.scrolled.get();
-        scrolled.set_store::<C>(items, is_resume);
+        scrolled.set_store::<C>(items, is_resume, prefer_poster);
         if scrolled.n_items() == 0 {
             imp.stack.set_visible_child_name("fallback");
         } else {
@@ -508,8 +511,9 @@ impl SingleGrid {
         );
     }
 
-    pub fn connect_sort_changed_tokio<F, Fut>(&self, is_resume: bool, f: F)
-    where
+    pub fn connect_sort_changed_tokio<F, Fut>(
+        &self, is_resume: bool, prefer_poster: PreferPoster, f: F,
+    ) where
         F: Fn(String, String, FiltersList) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<List>> + Send + 'static,
     {
@@ -535,7 +539,7 @@ impl SingleGrid {
                     obj.imp().stack.set_visible_child_name("loading");
                     match spawn_tokio(future).await {
                         Ok(item) => {
-                            obj.add_items::<true>(item.items, is_resume);
+                            obj.add_items::<true>(item.items, is_resume, prefer_poster);
                             obj.imp()
                                 .count
                                 .set_text(&format!("{} Items", item.total_record_count));
@@ -582,7 +586,9 @@ impl SingleGrid {
                         scrolled.reveal_spinner(true);
 
                         match spawn_tokio(future).await {
-                            Ok(item) => obj.add_items::<false>(item.items, false),
+                            Ok(item) => {
+                                obj.add_items::<false>(item.items, false, PreferPoster::Auto)
+                            }
                             Err(e) => {
                                 obj.toast(e.to_user_facing());
                             }

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -499,6 +499,10 @@ impl SingleGrid {
             .set_text(&format!("{} {}", n, gettextrs::gettext("Items")));
     }
 
+    pub fn set_unify_size(&self, unify_size: UnifySize) {
+        self.imp().scrolled.get().set_unify_size(unify_size);
+    }
+
     pub fn connect_sort_changed<F>(&self, f: F)
     where
         F: Fn(&Self) + 'static,
@@ -513,12 +517,11 @@ impl SingleGrid {
     }
 
     pub fn connect_sort_changed_tokio<F, Fut>(
-        &self, is_resume: bool, prefer_poster: PreferPoster, unify_size: UnifySize, f: F,
+        &self, is_resume: bool, prefer_poster: PreferPoster, f: F,
     ) where
         F: Fn(String, String, FiltersList) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<List>> + Send + 'static,
     {
-        self.imp().scrolled.get().set_unify_size(unify_size);
         self.connect_sort_changed(move |obj| {
             let sort_by = obj.sort_by().to_string();
             let sort_order = obj.sort_order().to_string();

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -19,6 +19,7 @@ use super::{
         FilterPanelDialog,
         FiltersList,
     },
+    hortu_scrolled::UnifySize,
     tu_list_item::imp::PosterType,
     tu_overview_item::imp::ViewGroup,
     utils::{
@@ -512,11 +513,12 @@ impl SingleGrid {
     }
 
     pub fn connect_sort_changed_tokio<F, Fut>(
-        &self, is_resume: bool, prefer_poster: PreferPoster, f: F,
+        &self, is_resume: bool, prefer_poster: PreferPoster, unify_size: UnifySize, f: F,
     ) where
         F: Fn(String, String, FiltersList) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<List>> + Send + 'static,
     {
+        self.imp().scrolled.get().set_unify_size(unify_size);
         self.connect_sort_changed(move |obj| {
             let sort_by = obj.sort_by().to_string();
             let sort_order = obj.sort_order().to_string();

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -1,7 +1,10 @@
 use gtk::prelude::*;
 
 use crate::ui::{
-    provider::tu_item::TuItem,
+    provider::tu_item::{
+        PreferPoster,
+        TuItem,
+    },
     widgets::{
         picture_loader::PictureLoader,
         tu_list_item::imp::PosterType,
@@ -51,19 +54,40 @@ pub trait TuItemOverlayPrelude {
             }
         }
 
-        if item.is_resume() {
-            Self::set_overlay_size(&self.overlay(), TU_ITEM_VIDEO_SIZE.0, TU_ITEM_VIDEO_SIZE.1);
-            if let Some(parent_thumb_item_id) = item.parent_thumb_item_id() {
-                ("Thumb", None, parent_thumb_item_id)
-            } else if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id() {
-                ("Backdrop", Some(0.to_string()), parent_backdrop_item_id)
-            } else {
-                ("Backdrop", Some(0.to_string()), item.id())
+        match item.prefer_poster() {
+            PreferPoster::ParentVideo => {
+                if let Some(parent_thumb_item_id) = item.parent_thumb_item_id() {
+                    ("Thumb", None, parent_thumb_item_id)
+                } else if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id() {
+                    ("Backdrop", Some(0.to_string()), parent_backdrop_item_id)
+                } else {
+                    ("Backdrop", Some(0.to_string()), item.id())
+                }
             }
-        } else if let Some(img_tags) = item.primary_image_item_id() {
-            ("Primary", None, img_tags)
-        } else {
-            ("Primary", None, item.id())
+            PreferPoster::ParentPost
+                if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id()
+                    && item.series_primary_image_tag().is_some() =>
+            {
+                println!(
+                    "Using series primary image for item {} with id {}: primary image tag: {:?}, parent backdrop item id: {:?}",
+                    item.name(),
+                    item.id(),
+                    item.series_primary_image_tag(),
+                    item.parent_backdrop_item_id()
+                );
+                (
+                    "Primary",
+                    item.series_primary_image_tag(),
+                    parent_backdrop_item_id,
+                )
+            }
+            _ => {
+                if let Some(img_tags) = item.primary_image_item_id() {
+                    ("Primary", None, img_tags)
+                } else {
+                    ("Primary", None, item.id())
+                }
+            }
         }
     }
 

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -53,8 +53,8 @@ pub trait TuItemOverlayPrelude {
                 }
             }
         }
-
         match item.prefer_poster() {
+            // Continue Watching, use parent video poster if possible
             PreferPoster::ParentVideo => {
                 if let Some(parent_thumb_item_id) = item.parent_thumb_item_id() {
                     ("Thumb", None, parent_thumb_item_id)
@@ -64,27 +64,24 @@ pub trait TuItemOverlayPrelude {
                     ("Backdrop", Some(0.to_string()), item.id())
                 }
             }
+            // Latest, use parent primary image if possible, this is for latest episodes
             PreferPoster::ParentPost
-                if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id()
-                    && item.series_primary_image_tag().is_some() =>
+                if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id() =>
             {
-                println!(
-                    "Using series primary image for item {} with id {}: primary image tag: {:?}, parent backdrop item id: {:?}",
-                    item.name(),
-                    item.id(),
-                    item.series_primary_image_tag(),
-                    item.parent_backdrop_item_id()
-                );
-                (
-                    "Primary",
-                    item.series_primary_image_tag(),
-                    parent_backdrop_item_id,
-                )
+                ("Primary", None, parent_backdrop_item_id)
             }
             _ => {
                 if let Some(img_tags) = item.primary_image_item_id() {
+                    // use primary image if possible
                     ("Primary", None, img_tags)
+                } else if item.image_tags().is_none_or(|t| t.all_none())
+                    && let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id()
+                {
+                    // fallback to parent backdrop if no image tags and parent backdrop exists, this
+                    // is for some season items that don't have image tags
+                    ("Primary", None, parent_backdrop_item_id)
                 } else {
+                    // finally fallback to primary image with item id
                     ("Primary", None, item.id())
                 }
             }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -28,7 +28,10 @@ use super::{
         TU_ITEM_VIDEO_SIZE,
     },
 };
-use crate::ui::provider::tu_item::TuItem;
+use crate::ui::provider::tu_item::{
+    PreferSize,
+    TuItem,
+};
 
 pub mod imp {
     use std::cell::{
@@ -236,7 +239,6 @@ impl TuListItem {
                 self.set_played();
                 if item.is_resume() {
                     self.set_progress(item.played_percentage());
-                    return;
                 }
             }
             "Video" | "MusicVideo" | "AdultVideo" => {
@@ -440,17 +442,16 @@ impl TuListItem {
         }
         // if the item has a prefer size, use it to override the default size
         match item.prefer_size() {
-            crate::ui::provider::tu_item::PreferSize::Video => {
+            PreferSize::Video => {
                 imp.overlay
                     .set_size_request(TU_ITEM_VIDEO_SIZE.0, TU_ITEM_VIDEO_SIZE.1);
             }
-            crate::ui::provider::tu_item::PreferSize::Post => {
+            PreferSize::Post => {
                 imp.overlay
                     .set_size_request(TU_ITEM_POST_SIZE.0, TU_ITEM_POST_SIZE.1);
             }
             _ => {}
         }
-
         self.set_tooltip_text(Some(&item.name()));
     }
 }

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -30,7 +30,10 @@ use super::{
 use crate::{
     client::structs::SimpleListItem,
     ui::provider::{
-        tu_item::TuItem,
+        tu_item::{
+            PreferPoster,
+            TuItem,
+        },
         tu_object::TuObject,
     },
 };
@@ -109,7 +112,9 @@ impl TuViewScrolled {
         glib::Object::new()
     }
 
-    pub fn set_store<const C: bool>(&self, items: Vec<SimpleListItem>, is_resume: bool) {
+    pub fn set_store<const C: bool>(
+        &self, items: Vec<SimpleListItem>, is_resume: bool, prefer_poster: PreferPoster,
+    ) {
         let imp = self.imp();
         let Some(store) = imp.selection.model().and_downcast::<gio::ListStore>() else {
             return;
@@ -122,6 +127,7 @@ impl TuViewScrolled {
         for item in items {
             let tu_item = TuItem::from_simple(&item, None);
             tu_item.set_is_resume(is_resume);
+            tu_item.set_prefer_poster(prefer_poster);
             let tu_item = TuObject::new(&tu_item);
             store.append(&tu_item);
         }

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -22,6 +22,10 @@ use gtk::{
 };
 
 use super::{
+    hortu_scrolled::{
+        UnifySize,
+        resolve_prefer_size,
+    },
     single_grid::imp::ViewType,
     tu_list_item::imp::PosterType,
     tu_overview_item::imp::ViewGroup,
@@ -32,6 +36,7 @@ use crate::{
     ui::provider::{
         tu_item::{
             PreferPoster,
+            PreferSize,
             TuItem,
         },
         tu_object::TuObject,
@@ -45,13 +50,17 @@ pub(crate) mod imp {
         atomic::AtomicBool,
     };
 
+    use std::cell::RefCell;
+
     use glib::subclass::InitializingObject;
+    use gtk::glib::Properties;
 
     use super::*;
     use crate::ui::provider::tu_object::TuObject;
 
-    #[derive(CompositeTemplate, Default)]
+    #[derive(CompositeTemplate, Default, Properties)]
     #[template(resource = "/moe/tsuna/tsukimi/ui/tuview_scrolled.ui")]
+    #[properties(wrapper_type = super::TuViewScrolled)]
     pub struct TuViewScrolled {
         #[template_child]
         pub scrolled_window: TemplateChild<gtk::ScrolledWindow>,
@@ -64,6 +73,10 @@ pub(crate) mod imp {
 
         pub selection: gtk::SingleSelection,
         pub lock: Arc<AtomicBool>,
+
+        #[property(get, set, builder(UnifySize::default()))]
+        pub unify_size: RefCell<UnifySize>,
+        pub prefer_size_cache: RefCell<PreferSize>,
     }
 
     #[glib::object_subclass]
@@ -122,12 +135,17 @@ impl TuViewScrolled {
 
         if C {
             store.remove_all();
+            let size = resolve_prefer_size(self.unify_size(), &items);
+            self.imp().prefer_size_cache.replace(size);
         }
+
+        let prefer_size = *self.imp().prefer_size_cache.borrow();
 
         for item in items {
             let tu_item = TuItem::from_simple(&item, None);
             tu_item.set_is_resume(is_resume);
             tu_item.set_prefer_poster(prefer_poster);
+            tu_item.set_prefer_size(prefer_size);
             let tu_item = TuObject::new(&tu_item);
             store.append(&tu_item);
         }

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -95,6 +95,7 @@ pub(crate) mod imp {
         }
     }
 
+    #[glib::derived_properties]
     impl ObjectImpl for TuViewScrolled {
         fn constructed(&self) {
             self.parent_constructed();


### PR DESCRIPTION
该 PR 改进了封面选择逻辑，并将上个 PR 中的统一 size 逻辑扩大到了更多组件。

为了实现这一点，我将 item 的 is_resume 与封面选择、size 设置逻辑解耦，新代码中：
1. `is_resume` 表示是否“继续观看”，影响进度条
2. `prefer_poster` 表示 item 偏好的封面
3. `prefer_size` 表示 item 偏好的封面尺寸

它们均受父组件控制，如：
1. `is_resume` 在 Continue Watching 中由父组件对所有 item 设置。
2. `prefer_poster` 根据所处父组件有不同逻辑，如 Continue Watching 内的 item 应该优先使用父横屏封面，Latest 组件内的 episode 应该优先使用父竖屏封面，某季下的若干 episode 应该优先使用自己的封面。**注意该 PR 包含一个小调整，在计算分布时会筛掉单集，因为单集最终会使用剧集封面而非自己的封面，因此 PrimaryImageAspectRatio 可以认为是无效数据**。
3. `prefer_size` 由父组件 unify_size 策略决定，如 Continue Watching 需要强制横屏，Latest、推荐、搜索页、媒体库详情根据多数决定整体偏好等。

特殊地，由于媒体库详情是无限滚动的设计，`prefer_size` 由第一页的多数情况决定，page_size 看起来不算小，应该足够获取比较可信的结果。

----

修复效果：

1. Latest 中的单集可以正确显示剧集封面而非使用单集封面

|Before|After|
|-------|-------|
|<img width="947" height="652" alt="图片" src="https://github.com/user-attachments/assets/be71faf8-a566-4c28-b91b-d0a561ccce48" />|<img width="913" height="1427" alt="图片" src="https://github.com/user-attachments/assets/43f646af-ee70-4ca3-a5cd-0411c246fe30" />|

2. 媒体库详情、搜索、推荐等页面均会根据封面比例分布决定使用横屏还是竖屏

|Before|After|
|-------|-------|
|<img width="1923" height="1797" alt="图片" src="https://github.com/user-attachments/assets/de70c01b-b27a-4b47-84a4-67beb93e5111" />|<img width="1933" height="2078" alt="图片" src="https://github.com/user-attachments/assets/09ab2587-44d0-4a1e-9439-ef75ba7428e3" />|


3. 对于不存在封面的季，现在会正确 fallback 至剧集封面

|Before|After|
|-------|-------|
|<img width="1158" height="1218" alt="图片" src="https://github.com/user-attachments/assets/a6bae33f-dee0-4414-bc71-f4724d13940d" />|<img width="1933" height="2078" alt="图片" src="https://github.com/user-attachments/assets/fbfc5be0-698b-462f-9791-732d558e5e47" />|

    

4. 季的单集信息现在会正确使用单集封面而非剧集封面

|Before|After|
|-------|-------|
|<img width="1920" height="2093" alt="图片" src="https://github.com/user-attachments/assets/b41c90ea-5abb-4a7b-b3f4-ed454668e03a" />|<img width="3840" height="2160" alt="图片" src="https://github.com/user-attachments/assets/6a479be5-c89f-4888-86c2-1cd1beceb34a" />|

----

我本地只有视频库测试，不清楚变更是否会对音乐库产生副作用，可能需要测试确认。