### PR TITLE
feat: improve homepage refresh logic and cache mechanism

### DIFF
--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -151,7 +151,7 @@ mod imp {
             //
             // https://github.com/mpv-player/mpv/blob/86e12929aa0bbc61946d3804982acf887786a7cb/include/mpv/render_gl.h#L91
             #[cfg(target_os = "linux")]
-            if let Some(display_wrapper) = display.clone().downcast::<X11Display>().ok() {
+            if let Ok(display_wrapper) = display.clone().downcast::<X11Display>() {
                 render_params.push(RenderParam::X11Display(
                     unsafe { display_wrapper.xdisplay() } as *const c_void,
                 ));

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -1180,6 +1180,7 @@ impl MPVPage {
             .unwrap();
         window.imp().stack.set_visible_child_name("main");
         window.allow_suspend();
+        window.refresh_homepage_if_needed();
 
         spawn_g_timeout(glib::clone!(
             #[weak(rename_to = obj)]

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -420,6 +420,7 @@ impl TuItem {
             &format!("audio_{}", &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_songs(&id).await },
+            None,
         )
         .await
         {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -420,7 +420,7 @@ impl TuItem {
             &format!("audio_{}", &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_songs(&id).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -31,6 +31,7 @@ use crate::{
         CachePolicy,
         fetch_with_cache,
         spawn,
+        spawn_g_timeout,
     },
 };
 mod imp {
@@ -126,7 +127,7 @@ impl HomePage {
     }
 
     pub fn update(&self, enable_cache: bool) {
-        spawn(glib::clone!(
+        spawn_g_timeout(glib::clone!(
             #[weak(rename_to = obj)]
             self,
             async move {

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -144,18 +144,17 @@ impl HomePage {
     pub async fn setup_history(&self, enable_cache: bool) {
         let hortu = self.imp().hishortu.get();
 
-        let (cache_policy, on_refresh): (CachePolicy, Option<Box<dyn FnOnce(List)>>) =
-            if enable_cache {
-                let hortu_ref = hortu.clone();
-                (
-                    CachePolicy::ReadCacheAndRefresh,
-                    Some(Box::new(move |data: List| {
-                        hortu_ref.set_items(&data.items);
-                    })),
-                )
-            } else {
-                (CachePolicy::RefreshCache, None)
-            };
+        let (cache_policy, on_refresh): (CachePolicy, Option<_>) = if enable_cache {
+            let hortu_ref = hortu.clone();
+            (
+                CachePolicy::ReadCacheAndRefresh,
+                Some(move |data: List| {
+                    hortu_ref.set_items(&data.items);
+                }),
+            )
+        } else {
+            (CachePolicy::RefreshCache, None)
+        };
 
         let results = match fetch_with_cache(
             "history",
@@ -178,18 +177,17 @@ impl HomePage {
     pub async fn setup_library(&self, enable_cache: bool) {
         let hortu = self.imp().libhortu.get();
 
-        let (cache_policy, on_refresh): (CachePolicy, Option<Box<dyn FnOnce(List)>>) =
-            if enable_cache {
-                let hortu_ref = hortu.clone();
-                (
-                    CachePolicy::ReadCacheAndRefresh,
-                    Some(Box::new(move |data: List| {
-                        hortu_ref.set_items(&data.items);
-                    })),
-                )
-            } else {
-                (CachePolicy::RefreshCache, None)
-            };
+        let (cache_policy, on_refresh): (CachePolicy, Option<_>) = if enable_cache {
+            let hortu_ref = hortu.clone();
+            (
+                CachePolicy::ReadCacheAndRefresh,
+                Some(move |data: List| {
+                    hortu_ref.set_items(&data.items);
+                }),
+            )
+        } else {
+            (CachePolicy::RefreshCache, None)
+        };
 
         let results = match fetch_with_cache(
             "library",
@@ -261,16 +259,13 @@ impl HomePage {
         let view_id = view.id.clone();
         let collection_type = view.collection_type.clone();
 
-        let (cache_policy, on_refresh): (
-            CachePolicy,
-            Option<Box<dyn FnOnce(Vec<SimpleListItem>)>>,
-        ) = if enable_cache {
+        let (cache_policy, on_refresh): (CachePolicy, Option<_>) = if enable_cache {
             let hortu_ref = hortu.clone();
             (
                 CachePolicy::ReadCacheAndRefresh,
-                Some(Box::new(move |data: Vec<SimpleListItem>| {
+                Some(move |data: Vec<SimpleListItem>| {
                     hortu_ref.set_items(&data);
-                })),
+                }),
             )
         } else {
             (CachePolicy::RefreshCache, None)

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -120,8 +120,6 @@ impl HomePage {
             self,
             async move {
                 obj.setup(true).await;
-                gtk::glib::timeout_future_seconds(1).await;
-                obj.setup_history(false).await;
             }
         ));
     }
@@ -139,22 +137,32 @@ impl HomePage {
     pub async fn setup(&self, enable_cache: bool) {
         fraction_reset!(self);
         self.setup_history(enable_cache).await;
-        self.setup_library().await;
+        self.setup_library(enable_cache).await;
         fraction!(self);
     }
 
     pub async fn setup_history(&self, enable_cache: bool) {
         let hortu = self.imp().hishortu.get();
 
-        let cache_policy = if enable_cache {
-            CachePolicy::UseCacheIfAvailable
-        } else {
-            CachePolicy::RefreshCache
-        };
+        let (cache_policy, on_refresh): (CachePolicy, Option<Box<dyn FnOnce(List)>>) =
+            if enable_cache {
+                let hortu_ref = hortu.clone();
+                (
+                    CachePolicy::ReadCacheAndRefresh,
+                    Some(Box::new(move |data: List| {
+                        hortu_ref.set_items(&data.items);
+                    })),
+                )
+            } else {
+                (CachePolicy::RefreshCache, None)
+            };
 
-        let results = match fetch_with_cache("history", cache_policy, async {
-            JELLYFIN_CLIENT.get_resume().await
-        })
+        let results = match fetch_with_cache(
+            "history",
+            cache_policy,
+            async { JELLYFIN_CLIENT.get_resume().await },
+            on_refresh,
+        )
         .await
         {
             Ok(history) => history,
@@ -167,12 +175,28 @@ impl HomePage {
         hortu.set_items(&results.items);
     }
 
-    pub async fn setup_library(&self) {
+    pub async fn setup_library(&self, enable_cache: bool) {
         let hortu = self.imp().libhortu.get();
 
-        let results = match fetch_with_cache("library", CachePolicy::ReadCacheAndRefresh, async {
-            JELLYFIN_CLIENT.get_library().await
-        })
+        let (cache_policy, on_refresh): (CachePolicy, Option<Box<dyn FnOnce(List)>>) =
+            if enable_cache {
+                let hortu_ref = hortu.clone();
+                (
+                    CachePolicy::ReadCacheAndRefresh,
+                    Some(Box::new(move |data: List| {
+                        hortu_ref.set_items(&data.items);
+                    })),
+                )
+            } else {
+                (CachePolicy::RefreshCache, None)
+            };
+
+        let results = match fetch_with_cache(
+            "library",
+            cache_policy,
+            async { JELLYFIN_CLIENT.get_library().await },
+            on_refresh,
+        )
         .await
         {
             Ok(history) => history,
@@ -186,10 +210,10 @@ impl HomePage {
 
         hortu.set_items(&results);
 
-        self.setup_libsview(results).await;
+        self.setup_libsview(results, enable_cache).await;
     }
 
-    pub async fn setup_libsview(&self, items: Vec<SimpleListItem>) {
+    pub async fn setup_libsview(&self, items: Vec<SimpleListItem>, enable_cache: bool) {
         let libsbox = &self.imp().libsbox;
         for _ in 0..libsbox.observe_children().n_items() {
             libsbox.remove(&libsbox.last_child().unwrap());
@@ -200,34 +224,14 @@ impl HomePage {
                 #[weak(rename_to = obj)]
                 self,
                 async move {
-                    obj.setup_libview(view).await;
+                    obj.setup_libview(view, enable_cache).await;
                 }
             ));
         }
     }
 
-    async fn setup_libview(&self, view: SimpleListItem) {
+    async fn setup_libview(&self, view: SimpleListItem, enable_cache: bool) {
         let ac_view = view.to_owned();
-
-        let results = match fetch_with_cache(
-            &format!("library_{}", view.id),
-            CachePolicy::ReadCacheAndRefresh,
-            async move {
-                if view.collection_type.as_deref() == Some("livetv") {
-                    JELLYFIN_CLIENT.get_channels().await.map(|x| x.items)
-                } else {
-                    JELLYFIN_CLIENT.get_latest(&view.id).await
-                }
-            },
-        )
-        .await
-        {
-            Ok(history) => history,
-            Err(e) => {
-                self.toast(e.to_user_facing());
-                return;
-            }
-        };
 
         let hortu = HortuScrolled::new();
 
@@ -238,8 +242,6 @@ impl HomePage {
         hortu.set_prefer_poster(PreferPoster::ParentPost);
 
         hortu.set_title(format!("{} {}", gettext("Latest"), view.name));
-
-        hortu.set_items(&results);
 
         hortu.connect_morebutton(glib::clone!(
             #[weak(rename_to = obj)]
@@ -255,5 +257,46 @@ impl HomePage {
         ));
 
         self.imp().libsbox.append(&hortu);
+
+        let view_id = view.id.clone();
+        let collection_type = view.collection_type.clone();
+
+        let (cache_policy, on_refresh): (
+            CachePolicy,
+            Option<Box<dyn FnOnce(Vec<SimpleListItem>)>>,
+        ) = if enable_cache {
+            let hortu_ref = hortu.clone();
+            (
+                CachePolicy::ReadCacheAndRefresh,
+                Some(Box::new(move |data: Vec<SimpleListItem>| {
+                    hortu_ref.set_items(&data);
+                })),
+            )
+        } else {
+            (CachePolicy::RefreshCache, None)
+        };
+
+        let results = match fetch_with_cache(
+            &format!("library_{}", view_id),
+            cache_policy,
+            async move {
+                if collection_type.as_deref() == Some("livetv") {
+                    JELLYFIN_CLIENT.get_channels().await.map(|x| x.items)
+                } else {
+                    JELLYFIN_CLIENT.get_latest(&view_id).await
+                }
+            },
+            on_refresh,
+        )
+        .await
+        {
+            Ok(history) => history,
+            Err(e) => {
+                self.toast(e.to_user_facing());
+                return;
+            }
+        };
+
+        hortu.set_items(&results);
     }
 }

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -857,7 +857,7 @@ impl ItemPage {
             &format!("season_{}", &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_season_list(&id).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {
@@ -901,7 +901,7 @@ impl ItemPage {
             &format!("item_{}", &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_item_info(&id).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {
@@ -1177,7 +1177,7 @@ impl ItemPage {
                     _ => Ok(List::default()),
                 }
             },
-            None,
+            None::<fn(_)>,
         )
         .await
         {

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -857,6 +857,7 @@ impl ItemPage {
             &format!("season_{}", &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_season_list(&id).await },
+            None,
         )
         .await
         {
@@ -900,6 +901,7 @@ impl ItemPage {
             &format!("item_{}", &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_item_info(&id).await },
+            None,
         )
         .await
         {
@@ -1175,6 +1177,7 @@ impl ItemPage {
                     _ => Ok(List::default()),
                 }
             },
+            None,
         )
         .await
         {

--- a/src/ui/widgets/music_album.rs
+++ b/src/ui/widgets/music_album.rs
@@ -231,6 +231,7 @@ impl AlbumPage {
             &format!("audio_{}", item.id()),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_songs(&id).await },
+            None,
         )
         .await
         {
@@ -354,6 +355,7 @@ impl AlbumPage {
                     _ => Ok(List::default()),
                 }
             },
+            None,
         )
         .await
         {

--- a/src/ui/widgets/music_album.rs
+++ b/src/ui/widgets/music_album.rs
@@ -231,7 +231,7 @@ impl AlbumPage {
             &format!("audio_{}", item.id()),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_songs(&id).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {
@@ -355,7 +355,7 @@ impl AlbumPage {
                     _ => Ok(List::default()),
                 }
             },
-            None,
+            None::<fn(_)>,
         )
         .await
         {

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -202,7 +202,7 @@ impl OtherPage {
             &format!("list_{id}"),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_item_info(&id).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {
@@ -319,7 +319,7 @@ impl OtherPage {
             &format!("season_{id}"),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_episodes_all(&series_id, &id).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {
@@ -376,7 +376,7 @@ impl OtherPage {
             &format!("boxset_{id}"),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_includedby(&id).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {
@@ -482,7 +482,7 @@ impl OtherPage {
             &format!("other_{}_{}", type_, &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_actor_item_list(&id, &type_).await },
-            None,
+            None::<fn(_)>,
         )
         .await
         {

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -202,6 +202,7 @@ impl OtherPage {
             &format!("list_{id}"),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_item_info(&id).await },
+            None,
         )
         .await
         {
@@ -318,6 +319,7 @@ impl OtherPage {
             &format!("season_{id}"),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_episodes_all(&series_id, &id).await },
+            None,
         )
         .await
         {
@@ -374,6 +376,7 @@ impl OtherPage {
             &format!("boxset_{id}"),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_includedby(&id).await },
+            None,
         )
         .await
         {
@@ -479,6 +482,7 @@ impl OtherPage {
             &format!("other_{}_{}", type_, &id),
             CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_actor_item_list(&id, &type_).await },
+            None,
         )
         .await
         {

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -342,14 +342,7 @@ impl Window {
 
         imp.popbutton.set_visible(false);
         imp.navipage.set_title("");
-        if imp.insidestack.visible_child_name() == Some("homepage".into()) && SETTINGS.is_refresh()
-        {
-            let binding = imp.homepage.child();
-            let Some(homepage) = binding.and_downcast_ref::<HomePage>() else {
-                return;
-            };
-            homepage.update(false);
-        }
+        self.refresh_homepage_if_needed();
     }
 
     pub async fn set_servers(&self) {
@@ -567,6 +560,16 @@ impl Window {
 
     pub fn mainpage(&self) {
         self.imp().stack.set_visible_child_name("main");
+    }
+
+    pub fn refresh_homepage_if_needed(&self) {
+        let imp = self.imp();
+        if imp.insidestack.visible_child_name() == Some("homepage".into()) && SETTINGS.is_refresh()
+        {
+            if let Some(homepage) = imp.homepage.child().and_downcast_ref::<HomePage>() {
+                homepage.update(false);
+            }
+        }
     }
 
     fn placeholder(&self) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,6 +76,7 @@ where
 }
 
 pub enum CachePolicy {
+    #[allow(dead_code)]
     UseCacheIfAvailable,
     RefreshCache,
     #[allow(dead_code)]
@@ -85,6 +86,7 @@ pub enum CachePolicy {
 
 pub async fn fetch_with_cache<T, F>(
     cache_key: &str, cache_policy: CachePolicy, future: F,
+    on_refresh: Option<Box<dyn FnOnce(T) + 'static>>,
 ) -> Result<T>
 where
     T: for<'de> Deserialize<'de> + Serialize + Send + 'static,
@@ -108,13 +110,27 @@ where
     if read_cache {
         if let Some(data) = read_from_cache(&path) {
             if update_in_background {
-                let future = future;
                 let path = path.to_owned();
-                runtime().spawn(async move {
-                    if let Ok(data) = future.await {
-                        let _ = write_to_cache(&path, &data);
-                    }
-                });
+                if let Some(callback) = on_refresh {
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    runtime().spawn(async move {
+                        if let Ok(data) = future.await {
+                            let _ = write_to_cache(&path, &data);
+                            let _ = tx.send(data);
+                        }
+                    });
+                    spawn(async move {
+                        if let Ok(data) = rx.await {
+                            callback(data);
+                        }
+                    });
+                } else {
+                    runtime().spawn(async move {
+                        if let Ok(data) = future.await {
+                            let _ = write_to_cache(&path, &data);
+                        }
+                    });
+                }
             }
             return Ok(data);
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ pub enum CachePolicy {
 
 pub async fn fetch_with_cache<T, F>(
     cache_key: &str, cache_policy: CachePolicy, future: F,
-    on_refresh: Option<Box<dyn FnOnce(T) + 'static>>,
+    on_refresh: Option<impl FnOnce(T) + 'static>,
 ) -> Result<T>
 where
     T: for<'de> Deserialize<'de> + Serialize + Send + 'static,


### PR DESCRIPTION
当前主页刷新逻辑存在一些问题：
1. 初次加载，稍后再看会先展示缓存，在 1s 后请求最新数据刷新一次，即使在局域网下运行也能看到明显的变白重载过程；
2. 开启“返回主页刷新”后，返回主页的动画会被刷新阻塞导致卡顿；
3. 稍后再看会先请求到最新数据再渲染，最新的 xx 会使用缓存内容渲染再后台刷新（刷新后不重载页面），导致稍后再看使用当次请求的数据，最新的 xx 使用上次请求的数据，出现不一致；
4. 如果在主页直接点进视频播放，退出后不会正确触发“返回主页刷新”，导致稍后再看数据过时。

该 PR：
+ 对于 1、3，引入 refresh 回调，现在稍后再看和最新的 xx 均会优先展示缓存并在后台请求数据，新数据返回后重绘；
+ 对于 2，将 spawn 替换为 spawn_g_timeout 避免阻塞动画，与其它部分保持一致；
+ 对于 4，在 mpv 退出时新增“返回主页刷新”的检查。

### Before

https://github.com/user-attachments/assets/aa8e80fd-0e18-43d3-8f20-ba3618e19c26

### After

https://github.com/user-attachments/assets/ebdb281c-22ee-4b67-9269-8f717cdb5c8d

