### PR TITLE
fix: fix resume position precision and sidebar re-expand on resize

### DIFF
--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -80,9 +80,8 @@
       </object>
     </child>
     <child>
-      <object class="AdwBreakpoint">
+      <object class="AdwBreakpoint" id="sidebar_breakpoint">
         <condition>max-width: 500sp</condition>
-        <setter object="split_view" property="collapsed">True</setter>
         <setter object="mpv_view" property="show-sidebar">False</setter>
       </object>
     </child>

--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -207,7 +207,7 @@ impl MPVGLArea {
         Object::builder().build()
     }
 
-    pub fn play(&self, url: &str, percentage: f64) {
+    pub fn play(&self, url: &str, start_seconds: f64) {
         let url = url.to_owned();
 
         spawn(glib::clone!(
@@ -225,7 +225,7 @@ impl MPVGLArea {
                 info!("Now Playing: {}", url);
                 mpv.load_video(&url);
 
-                mpv.set_start(percentage);
+                mpv.set_start(start_seconds);
 
                 mpv.pause(false);
             }

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -505,7 +505,7 @@ impl MPVPage {
 
     pub fn play(
         &self, selected: Option<SelectedVideoSubInfo>, item: TuItem, episode_list: Vec<TuItem>,
-        video_matcher: Option<String>, per: f64,
+        video_matcher: Option<String>, start_seconds: f64,
     ) {
         let (title1, title2) = if let Some(series_name) = item.series_name() {
             let episode_info = format!(
@@ -660,7 +660,7 @@ impl MPVPage {
                     }
                 };
 
-                imp.video.play(&video_url, per);
+                imp.video.play(&video_url, start_seconds);
 
                 if SETTINGS.is_danmaku_enabled() {
                     obj.imp().danmaku_area.clear_danmaku();

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -242,8 +242,10 @@ impl TsukimiMPV {
         self.command("loadfile", &[url, "replace"]);
     }
 
-    pub fn set_start(&self, percentage: f64) {
-        self.set_property("start", format!("{}%", percentage as u32));
+    pub fn set_start(&self, start_seconds: f64) {
+        if start_seconds > 0.0 {
+            self.set_property("start", format!("{:.2}", start_seconds));
+        }
     }
 
     pub fn set_volume(&self, volume: i64) {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -459,7 +459,13 @@ impl TuItem {
         &self, obj: &impl IsA<gtk::Widget>, video: TuItem, episode_list: Vec<TuItem>,
     ) {
         if let Some(window) = obj.root().and_downcast_ref::<Window>() {
-            window.play_media(None, video, episode_list, None, self.played_percentage())
+            window.play_media(
+                None,
+                video,
+                episode_list,
+                None,
+                self.playback_position_ticks() as f64 / 10_000_000.0,
+            )
         }
     }
 

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -1259,7 +1259,7 @@ impl ItemPage {
         };
 
         let item = self.current_item().unwrap_or(self.item());
-        let played_percentage = item.played_percentage();
+        let start_seconds = item.playback_position_ticks() as f64 / 10_000_000.0;
 
         let episode_list = self.imp().episode_list_vec.borrow();
         let episode_list: Vec<TuItem> = episode_list
@@ -1270,7 +1270,7 @@ impl ItemPage {
         let matcher = self.imp().video_version_matcher.borrow().to_owned();
 
         self.window()
-            .play_media(Some(info), item, episode_list, matcher, played_percentage);
+            .play_media(Some(info), item, episode_list, matcher, start_seconds);
     }
 
     fn set_control_opacity(&self, opacity: f64) {

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -125,6 +125,9 @@ mod imp {
         pub mpv_playlist_selection: gtk::SingleSelection,
 
         pub suspend_cookie: RefCell<Option<u32>>,
+
+        #[template_child]
+        pub sidebar_breakpoint: TemplateChild<adw::Breakpoint>,
     }
 
     #[glib::object_subclass]
@@ -198,11 +201,22 @@ mod imp {
 
             let obj = self.obj();
 
-            self.split_view.connect_collapsed_notify(move |split_view| {
-                if !split_view.is_collapsed() && SETTINGS.is_overlay() {
-                    split_view.set_collapsed(true);
+            self.sidebar_breakpoint.connect_apply(glib::clone!(
+                #[weak]
+                obj,
+                move |_breakpoint| {
+                    obj.imp().split_view.set_collapsed(true);
                 }
-            });
+            ));
+            self.sidebar_breakpoint.connect_unapply(glib::clone!(
+                #[weak]
+                obj,
+                move |_breakpoint| {
+                    if !SETTINGS.is_overlay() {
+                        obj.imp().split_view.set_collapsed(false);
+                    }
+                }
+            ));
 
             obj.bind_about_action();
 

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -28,6 +28,7 @@ mod imp {
 
     use crate::{
         ui::{
+            SETTINGS,
             mpv::{
                 control_sidebar::MPVControlSidebar,
                 page::MPVPage,
@@ -196,6 +197,12 @@ mod imp {
                 .set_player(Some(&self.mpvnav.imp().video.get()));
 
             let obj = self.obj();
+
+            self.split_view.connect_collapsed_notify(move |split_view| {
+                if !split_view.is_collapsed() && SETTINGS.is_overlay() {
+                    split_view.set_collapsed(true);
+                }
+            });
 
             obj.bind_about_action();
 
@@ -748,13 +755,14 @@ impl Window {
 
     pub fn play_media(
         &self, selected: Option<SelectedVideoSubInfo>, item: TuItem, episode_list: Vec<TuItem>,
-        matcher: Option<String>, per: f64,
+        matcher: Option<String>, start_seconds: f64,
     ) {
         let imp = self.imp();
         imp.stack.set_visible_child_name("mpv");
         self.prevent_suspend();
         self.set_mpv_playlist(&episode_list);
-        imp.mpvnav.play(selected, item, episode_list, matcher, per);
+        imp.mpvnav
+            .play(selected, item, episode_list, matcher, start_seconds);
     }
 
     pub fn push_page<T>(&self, page: &T, tag: &str, name: &str)


### PR DESCRIPTION
这个改动比较小，主要修复了两个问题：
1. 续播使用百分比传递，精度丢失导致位置不准确；
2. 即使开启隐藏侧边栏，当把程序窗口缩小再放大时，布局跳变仍然会将侧边栏展开。

### Before

https://github.com/user-attachments/assets/366af914-647c-4f66-b10e-b12adb026930

### After

https://github.com/user-attachments/assets/e2cc06b0-c854-45fd-a9d8-2277fe17cedf

