### PR TITLE
fix: correct resume position tick calculation and start handling

### DIFF
--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -223,9 +223,9 @@ impl MPVGLArea {
                 let url = JELLYFIN_CLIENT.get_streaming_url(&url).await;
 
                 info!("Now Playing: {}", url);
-                mpv.load_video(&url);
-
                 mpv.set_start(start_seconds);
+
+                mpv.load_video(&url);
 
                 mpv.pause(false);
             }

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -1213,8 +1213,9 @@ impl MPVPage {
         }
 
         if let Some(back) = back.as_ref() {
+            let duration = *position as u64 * 10000000;
             let mut back = back.to_owned();
-            back.tick = *position as u64 * 10000000;
+            back.tick = duration;
             crate::utils::spawn_tokio_without_await(async move {
                 let _ = JELLYFIN_CLIENT.position_back(&back, backtype).await;
             });

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -600,7 +600,7 @@ impl MPVPage {
                     id: id.to_owned(),
                     playsessionid: play_session_id.to_owned(),
                     mediasourceid: media_source.id.to_owned(),
-                    tick: (start_seconds * 10_000_000.0) as u64,
+                    tick: media_source.run_time_ticks.unwrap_or(0),
                     start_tick: glib::DateTime::now_local().unwrap().to_unix() as u64,
                 };
 
@@ -852,8 +852,8 @@ impl MPVPage {
                         ListenEvent::CacheSpeed(value) => {
                             obj.on_cache_speed_update(value);
                         }
-                        ListenEvent::StartFile => {
-                            obj.on_start_file();
+                        ListenEvent::FileLoaded => {
+                            obj.on_file_loaded();
                         }
                         ListenEvent::TrackList(value) => {
                             obj.set_audio_and_video_tracks_dropdown(value);
@@ -936,7 +936,7 @@ impl MPVPage {
         imp.video.set_volume(btn.value() as i64);
     }
 
-    fn on_start_file(&self) {
+    fn on_file_loaded(&self) {
         let imp = self.imp();
         if let Some(suburl) = imp.suburl.borrow().as_ref() {
             imp.video.add_sub(suburl);
@@ -1214,11 +1214,7 @@ impl MPVPage {
 
         if let Some(back) = back.as_ref() {
             let mut back = back.to_owned();
-            if backtype != BackType::Start {
-                // Start happens when a new file starts, at which point position is 0.
-                // Skip the overwrite so the initial tick (from start_seconds) is used.
-                back.tick = *position as u64 * 10000000;
-            }
+            back.tick = *position as u64 * 10000000;
             crate::utils::spawn_tokio_without_await(async move {
                 let _ = JELLYFIN_CLIENT.position_back(&back, backtype).await;
             });

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -600,7 +600,7 @@ impl MPVPage {
                     id: id.to_owned(),
                     playsessionid: play_session_id.to_owned(),
                     mediasourceid: media_source.id.to_owned(),
-                    tick: media_source.run_time_ticks.unwrap_or(0),
+                    tick: (start_seconds * 10_000_000.0) as u64,
                     start_tick: glib::DateTime::now_local().unwrap().to_unix() as u64,
                 };
 
@@ -1213,9 +1213,12 @@ impl MPVPage {
         }
 
         if let Some(back) = back.as_ref() {
-            let duration = *position as u64 * 10000000;
             let mut back = back.to_owned();
-            back.tick = duration;
+            if backtype != BackType::Start {
+                // Start happens when a new file starts, at which point position is 0.
+                // Skip the overwrite so the initial tick (from start_seconds) is used.
+                back.tick = *position as u64 * 10000000;
+            }
             crate::utils::spawn_tokio_without_await(async move {
                 let _ = JELLYFIN_CLIENT.position_back(&back, backtype).await;
             });

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -243,9 +243,7 @@ impl TsukimiMPV {
     }
 
     pub fn set_start(&self, start_seconds: f64) {
-        if start_seconds > 0.0 {
-            self.set_property("start", format!("{:.2}", start_seconds));
-        }
+        self.set_property("start", format!("{:.2}", start_seconds));
     }
 
     pub fn set_volume(&self, volume: i64) {

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -188,7 +188,7 @@ pub enum ListenEvent {
     Seek,
     PlaybackRestart,
     Eof(u32),
-    StartFile,
+    FileLoaded,
     Duration(f64),
     Pause(bool),
     CacheSpeed(i64),
@@ -468,8 +468,8 @@ impl TsukimiMPV {
                             Event::EndFile(r) => {
                                 let _ = MPV_EVENT_CHANNEL.tx.send(ListenEvent::Eof(r));
                             }
-                            Event::StartFile => {
-                                let _ = MPV_EVENT_CHANNEL.tx.send(ListenEvent::StartFile);
+                            Event::FileLoaded => {
+                                let _ = MPV_EVENT_CHANNEL.tx.send(ListenEvent::FileLoaded);
                             }
                             Event::Shutdown => {
                                 let _ = MPV_EVENT_CHANNEL.tx.send(ListenEvent::Shutdown);


### PR DESCRIPTION
1. 修复上个 PR 引入的问题：mpv 的 start property 是一个持久化状态，应该确保每次播放视频都设置。如果写 if start_seconds > 0.0 会跳过未观看视频的 start 设置，导致上个 resume 状态应用于未看过的视频。

2. 修复 mpv play 调用顺序：*deepseek 指出：set_start 应该在 loadfile 之前设置，以前能 work 是因为 load-file 碰巧是异步操作*。我测试了下倒过来效果相同，所以它的解释应该是对的，之前写法存在竞态。

2. 修复start tick 上报为 0 的问题：对于 resume 视频，点击播放在控制台看到的播放是从 0:00 开始，直到第一个 progress 上报才会修正进度。这是因为 startfile 发生时文件还未加载，读取到的进度是 0。修改为 file_loaded 后测试，在 handle_callback 内能正确读取到 set_start 设置的初始进度。