### PR TITLE
refactor: apply some uncontroversial optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,9 +223,12 @@ checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -5618,6 +5621,7 @@ name = "tsukimi"
 version = "25.5.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "atomic-wait",
  "base64 0.22.1",
  "bytefmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ gettext-rs = { version = "~0.7", features = ["gettext-system"] }
 hostname = "0.4.2"
 epoxy = "0.1.0"
 libloading = "0.8.9"
+arc-swap = "1.9.1"
 atomic-wait = "1.1.0"
 flume = "0.12.0"
 derive_builder = "0.20.2"

--- a/src/client/account.rs
+++ b/src/client/account.rs
@@ -5,7 +5,7 @@ use serde::{
 
 use crate::ui::provider::descriptor::VecSerialize;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct Account {
     pub servername: String,
     pub server: String,

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -4,6 +4,7 @@ use anyhow::{
     Result,
     anyhow,
 };
+use arc_swap::ArcSwap;
 use once_cell::sync::Lazy;
 use reqwest::{
     Client,
@@ -21,11 +22,8 @@ use serde_json::{
     Value,
     json,
 };
-use tokio::sync::Mutex;
-use tracing::{
-    debug,
-    warn,
-};
+use std::sync::Arc;
+use tracing::warn;
 use url::Url;
 use uuid::Uuid;
 
@@ -97,16 +95,41 @@ pub enum BackType {
     Back,
 }
 
+#[derive(Clone)]
+pub struct Session {
+    pub account: Account,
+    pub url: Option<Url>,
+    pub headers: reqwest::header::HeaderMap,
+    pub server_name_hash: String,
+}
+
+impl Session {
+    fn empty() -> Self {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("Accept-Encoding", HeaderValue::from_static("gzip"));
+        headers.insert(
+            "X-Emby-authorization",
+            HeaderValue::from_str(&generate_jellyfin_authorization(
+                "",
+                CLIENT_ID,
+                &DEVICE_NAME,
+                &DEVICE_ID,
+                VERSION,
+            ))
+            .unwrap(),
+        );
+        Self {
+            account: Account::default(),
+            url: None,
+            headers,
+            server_name_hash: String::new(),
+        }
+    }
+}
+
 pub struct JellyfinClient {
-    pub url: Mutex<Option<Url>>,
+    pub session: ArcSwap<Session>,
     pub client: Client,
-    pub headers: Mutex<reqwest::header::HeaderMap>,
-    pub user_id: Mutex<String>,
-    pub user_name: Mutex<String>,
-    pub user_password: Mutex<String>,
-    pub user_access_token: Mutex<String>,
-    pub server_name: Mutex<String>,
-    pub server_name_hash: Mutex<String>,
 }
 
 fn generate_jellyfin_authorization(
@@ -125,43 +148,50 @@ fn generate_hash(s: &str) -> String {
 
 impl Default for JellyfinClient {
     fn default() -> Self {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("Accept-Encoding", HeaderValue::from_static("gzip"));
-        headers.insert(
-            "X-Emby-authorization",
-            HeaderValue::from_str(&generate_jellyfin_authorization(
-                "",
-                CLIENT_ID,
-                &DEVICE_NAME,
-                &DEVICE_ID,
-                VERSION,
-            ))
-            .unwrap(),
-        );
         Self {
-            url: Mutex::new(None),
+            session: ArcSwap::from_pointee(Session::empty()),
             client: ReqClient::build(),
-            headers: Mutex::new(headers),
-            user_id: Mutex::new(String::new()),
-            user_name: Mutex::new(String::new()),
-            user_password: Mutex::new(String::new()),
-            user_access_token: Mutex::new(String::new()),
-            server_name: Mutex::new(String::new()),
-            server_name_hash: Mutex::new(String::new()),
         }
     }
 }
 
 impl JellyfinClient {
+    pub fn session(&self) -> arc_swap::Guard<Arc<Session>> {
+        self.session.load()
+    }
+
     pub async fn init(&self, account: &Account) -> Result<(), Box<dyn std::error::Error>> {
-        self.header_change_url(&account.server, &account.port)
-            .await?;
-        self.header_change_token(&account.access_token).await?;
-        self.set_user_id(&account.user_id).await?;
-        self.set_user_name(&account.username).await?;
-        self.set_user_password(&account.password).await?;
-        self.set_user_access_token(&account.access_token).await?;
-        self.set_server_name(&account.servername).await?;
+        let url = {
+            let mut url = Url::parse(&account.server)?;
+            url.set_port(Some(account.port.parse::<u16>().unwrap_or_default()))
+                .map_err(|_| anyhow!("Failed to set port"))?;
+            url.join("emby/")?
+        };
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("Accept-Encoding", HeaderValue::from_static("gzip"));
+        headers.insert(
+            "X-Emby-Token",
+            HeaderValue::from_str(&account.access_token)?,
+        );
+        headers.insert(
+            "X-Emby-authorization",
+            HeaderValue::from_str(&generate_jellyfin_authorization(
+                &account.user_id,
+                CLIENT_ID,
+                &DEVICE_NAME,
+                &DEVICE_ID,
+                VERSION,
+            ))?,
+        );
+
+        self.session.store(Arc::new(Session {
+            account: account.clone(),
+            url: Some(url),
+            headers,
+            server_name_hash: generate_hash(&account.servername),
+        }));
+
         crate::ui::provider::set_admin(false);
         spawn_tokio_without_await(async move {
             match JELLYFIN_CLIENT.authenticate_admin().await {
@@ -176,81 +206,37 @@ impl JellyfinClient {
         Ok(())
     }
 
-    pub async fn header_change_token(&self, token: &str) -> Result<()> {
-        let mut headers = self.headers.lock().await;
-        headers.insert("X-Emby-Token", HeaderValue::from_str(token)?);
-        Ok(())
-    }
-
-    pub async fn header_change_url(&self, url: &str, port: &str) -> Result<()> {
-        let mut url = Url::parse(url)?;
+    pub fn header_change_url(&self, url_str: &str, port: &str) -> Result<()> {
+        let mut url = Url::parse(url_str)?;
         url.set_port(Some(port.parse::<u16>().unwrap_or_default()))
             .map_err(|_| anyhow!("Failed to set port"))?;
-        let mut url_lock = self.url.lock().await;
-        *url_lock = Some(url.join("emby/")?);
+        let url = url.join("emby/")?;
+        self.session.rcu(|current| {
+            let mut session = (**current).clone();
+            session.url = Some(url.clone());
+            Arc::new(session)
+        });
         Ok(())
     }
 
-    pub async fn set_user_id(&self, user_id: &str) -> Result<()> {
-        let mut user_id_lock = self.user_id.lock().await;
-        *user_id_lock = user_id.to_string();
-        self.header_change_user_id(user_id).await?;
+    pub fn header_change_token(&self, token: &str) -> Result<()> {
+        let token = HeaderValue::from_str(token)?;
+        self.session.rcu(|current| {
+            let mut session = (**current).clone();
+            session.headers.insert("X-Emby-Token", token.clone());
+            Arc::new(session)
+        });
         Ok(())
     }
 
-    pub async fn header_change_user_id(&self, user_id: &str) -> Result<()> {
-        let mut headers = self.headers.lock().await;
-        headers.insert(
-            "X-Emby-authorization",
-            HeaderValue::from_str(&generate_jellyfin_authorization(
-                user_id,
-                CLIENT_ID,
-                &DEVICE_NAME,
-                &DEVICE_ID,
-                VERSION,
-            ))?,
-        );
-        Ok(())
-    }
-
-    pub async fn set_user_name(&self, user_name: &str) -> Result<()> {
-        let mut user_name_lock = self.user_name.lock().await;
-        *user_name_lock = user_name.to_string();
-        Ok(())
-    }
-
-    pub async fn set_user_password(&self, user_password: &str) -> Result<()> {
-        let mut user_password_lock = self.user_password.lock().await;
-        *user_password_lock = user_password.to_string();
-        Ok(())
-    }
-
-    pub async fn set_user_access_token(&self, user_access_token: &str) -> Result<()> {
-        let mut user_access_token_lock = self.user_access_token.lock().await;
-        *user_access_token_lock = user_access_token.to_string();
-        Ok(())
-    }
-
-    pub async fn set_server_name(&self, server_name: &str) -> Result<()> {
-        let mut server_name_lock = self.server_name.lock().await;
-        *server_name_lock = server_name.to_string();
-
-        let mut server_name_hash_lock = self.server_name_hash.lock().await;
-
-        *server_name_hash_lock = generate_hash(server_name);
-        Ok(())
-    }
-
-    pub async fn get_url_and_headers(&self) -> Result<(Url, reqwest::header::HeaderMap)> {
-        let url = self
+    pub fn get_url_and_headers(&self) -> Result<(Url, reqwest::header::HeaderMap)> {
+        let s = self.session();
+        let url = s
             .url
-            .lock()
-            .await
             .as_ref()
             .ok_or_else(|| anyhow!("URL is not set"))?
-            .to_owned();
-        let headers = self.headers.lock().await.to_owned();
-        Ok((url, headers))
+            .clone();
+        Ok((url, s.headers.clone()))
     }
 
     pub async fn request<T>(&self, path: &str, params: &[(&str, &str)]) -> Result<T>
@@ -332,23 +318,29 @@ impl JellyfinClient {
     async fn prepare_request(
         &self, method: Method, path: &str, params: &[(&str, &str)],
     ) -> Result<RequestBuilder> {
-        let (mut url, headers) = self.get_url_and_headers().await?;
+        let (mut url, headers) = self.get_url_and_headers()?;
         url = url.join(path)?;
-        self.add_params_to_url(&mut url, params);
-        Ok(self.client.request(method, url).headers(headers))
+        Ok(self
+            .client
+            .request(method, url)
+            .query(params)
+            .headers(headers))
     }
 
     async fn prepare_request_headers(
         &self, method: Method, path: &str, params: &[(&str, &str)], content_type: &str,
     ) -> Result<RequestBuilder> {
-        let (mut url, mut headers) = self.get_url_and_headers().await?;
+        let (mut url, mut headers) = self.get_url_and_headers()?;
         url = url.join(path)?;
         headers.insert(
             reqwest::header::CONTENT_TYPE,
             HeaderValue::from_str(content_type)?,
         );
-        self.add_params_to_url(&mut url, params);
-        Ok(self.client.request(method, url).headers(headers))
+        Ok(self
+            .client
+            .request(method, url)
+            .query(params)
+            .headers(headers))
     }
 
     async fn send_request(&self, request: RequestBuilder) -> Result<Response> {
@@ -360,7 +352,9 @@ impl JellyfinClient {
     }
 
     pub async fn authenticate_admin(&self) -> Result<AuthenticateResponse> {
-        let path = format!("Users/{}", self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}", s.account.user_id);
         let res = self.request(&path, &[]).await?;
         Ok(res)
     }
@@ -373,18 +367,13 @@ impl JellyfinClient {
         self.post_json("Users/authenticatebyname", &[], body).await
     }
 
-    pub fn add_params_to_url(&self, url: &mut Url, params: &[(&str, &str)]) {
-        for (key, value) in params {
-            url.query_pairs_mut().append_pair(key, value);
-        }
-        debug!("Request URL: {}", url);
-    }
-
     // jellyfin
     pub async fn get_direct_stream_url(
         &self, continer: &str, media_source_id: &str, etag: &str,
     ) -> String {
-        let mut url = self.url.lock().await.as_ref().unwrap().to_owned();
+        let s = self.session();
+
+        let mut url = s.url.clone().expect("URL not set");
         url.path_segments_mut().unwrap().pop();
         let path = format!("Videos/{media_source_id}/stream.{continer}");
         let mut url = url.join(&path).unwrap();
@@ -392,7 +381,7 @@ impl JellyfinClient {
             .append_pair("Static", "true")
             .append_pair("mediaSourceId", media_source_id)
             .append_pair("deviceId", &DEVICE_ID)
-            .append_pair("api_key", self.user_access_token.lock().await.as_str())
+            .append_pair("api_key", &s.account.access_token)
             .append_pair("Tag", etag);
         url.to_string()
     }
@@ -400,7 +389,9 @@ impl JellyfinClient {
     pub async fn get_item_stream_url(
         &self, container: &str, item_id: &str, media_source_id: &str,
     ) -> Result<String> {
-        let (mut url, _) = self.get_url_and_headers().await?;
+        let s = self.session();
+
+        let mut url = s.url.clone().expect("URL not set");
         url.path_segments_mut()
             .map_err(|_| anyhow!("Failed to build item stream URL path"))?
             .pop();
@@ -413,7 +404,7 @@ impl JellyfinClient {
             pairs
                 .append_pair("Static", "true")
                 .append_pair("deviceId", &DEVICE_ID)
-                .append_pair("api_key", self.user_access_token.lock().await.as_str())
+                .append_pair("api_key", &s.account.access_token)
                 .append_pair("MediaSourceId", media_source_id);
         }
         Ok(url.to_string())
@@ -422,8 +413,10 @@ impl JellyfinClient {
     pub async fn search(
         &self, query: &str, filter: &[&str], start_index: &str, filters_list: &FiltersList,
     ) -> Result<List> {
+        let s = self.session();
+
         let filter_str = filter.join(",");
-        let path = format!("Users/{}/Items", self.user_id().await);
+        let path = format!("Users/{}/Items", s.account.user_id);
         let mut params = vec![
             (
                 "Fields",
@@ -451,6 +444,8 @@ impl JellyfinClient {
     }
 
     pub async fn get_episodes(&self, id: &str, season_id: &str, start_index: u32) -> Result<List> {
+        let s = self.session();
+
         let path = format!("Shows/{id}/Episodes");
         let params = [
             (
@@ -461,12 +456,14 @@ impl JellyfinClient {
             ("StartIndex", &start_index.to_string()),
             ("ImageTypeLimit", "1"),
             ("SeasonId", season_id),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
         ];
         self.request(&path, &params).await
     }
 
     pub async fn get_episodes_all(&self, id: &str, season_id: &str) -> Result<List> {
+        let s = self.session();
+
         let path = format!("Shows/{id}/Episodes");
         let params = [
             (
@@ -475,19 +472,23 @@ impl JellyfinClient {
             ),
             ("ImageTypeLimit", "1"),
             ("SeasonId", season_id),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
         ];
         self.request(&path, &params).await
     }
 
     pub async fn get_item_info(&self, id: &str) -> Result<SimpleListItem> {
-        let path = format!("Users/{}/Items/{}", self.user_id().await, id);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items/{}", s.account.user_id, id);
         let params = [("Fields", "ShareLevel")];
         self.request(&path, &params).await
     }
 
     pub async fn get_edit_info(&self, id: &str) -> Result<Value> {
-        let path = format!("Users/{}/Items/{}", self.user_id().await, id);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items/{}", s.account.user_id, id);
         let params = [("Fields", "ChannelMappingInfo")];
         self.request(&path, &params).await
     }
@@ -498,7 +499,9 @@ impl JellyfinClient {
     }
 
     pub async fn get_resume(&self) -> Result<List> {
-        let path = format!("Users/{}/Items/Resume", self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items/Resume", s.account.user_id);
         let params = [
             ("Recursive", "true"),
             (
@@ -646,7 +649,9 @@ impl JellyfinClient {
     }
 
     pub async fn get_artist_albums(&self, id: &str, artist_id: &str) -> Result<List> {
-        let path = format!("Users/{}/Items", self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", s.account.user_id);
         let params = [
             ("IncludeItemTypes", "MusicAlbum"),
             ("Recursive", "true"),
@@ -666,13 +671,15 @@ impl JellyfinClient {
     }
 
     pub async fn get_shows_next_up(&self, series_id: &str) -> Result<List> {
+        let s = self.session();
+
         let path = "Shows/NextUp".to_string();
         let params = [
             ("Fields", "BasicSyncInfo,CanDelete,PrimaryImageAspectRatio"),
             ("Limit", "1"),
             ("ImageTypeLimit", "1"),
             ("SeriesId", series_id),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
         ];
         self.request(&path, &params).await
     }
@@ -681,11 +688,13 @@ impl JellyfinClient {
         &self, id: &str, sub_stream_index: Option<u64>, media_source_id: Option<String>,
         is_playback: bool,
     ) -> Result<Media> {
+        let s = self.session();
+
         let path = format!("Items/{id}/PlaybackInfo");
         let subtitle_stream_index = sub_stream_index.map(|s| s.to_string()).unwrap_or_default();
         let params = [
             ("StartTimeTicks", "0"),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
             ("AutoOpenLiveStream", "true"),
             ("IsPlayback", &is_playback.to_string()),
             ("MediaSourceId", &media_source_id.unwrap_or_default()),
@@ -736,7 +745,9 @@ impl JellyfinClient {
     }
 
     pub async fn get_user_avatar(&self) -> Result<String> {
-        let path = format!("Users/{}/Images/Primary", self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Images/Primary", s.account.user_id);
         let params = [("maxHeight", "50"), ("maxWidth", "50")];
         let response = self.request_picture(&path, &params, None).await?;
         let etag = response
@@ -745,7 +756,7 @@ impl JellyfinClient {
             .map(|v| v.to_str().unwrap_or_default().to_string());
         let bytes = response.bytes().await?;
         let path = self
-            .save_image(&self.user_id().await, "Primary", None, &bytes, etag)
+            .save_image(&s.account.user_id, "Primary", None, &bytes, etag)
             .await;
         Ok(path)
     }
@@ -757,12 +768,16 @@ impl JellyfinClient {
     }
 
     pub async fn get_library(&self) -> Result<List> {
-        let path = format!("Users/{}/Views", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Views", &s.account.user_id);
         self.request(&path, &[]).await
     }
 
     pub async fn get_latest(&self, id: &str) -> Result<Vec<SimpleListItem>> {
-        let path = format!("Users/{}/Items/Latest", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items/Latest", &s.account.user_id);
         let params = [
             ("Limit", "16"),
             (
@@ -777,7 +792,9 @@ impl JellyfinClient {
     }
 
     pub async fn get_streaming_url(&self, path: &str) -> String {
-        let url = self.url.lock().await.as_ref().unwrap().to_owned();
+        let s = self.session();
+
+        let url = s.url.clone().expect("URL not set");
         url.join(path.trim_start_matches('/')).unwrap().to_string()
     }
 
@@ -786,7 +803,9 @@ impl JellyfinClient {
         &self, id: &str, start: u32, include_item_types: &str, list_type: ListType,
         sort_order: &str, sortby: &str, filters_list: &FiltersList,
     ) -> Result<List> {
-        let user_id = &self.user_id().await;
+        let s = self.session();
+
+        let user_id = &s.account.user_id;
         let path = match list_type {
             ListType::All => format!("Users/{user_id}/Items"),
             ListType::Resume => format!("Users/{user_id}/Items/Resume"),
@@ -866,7 +885,9 @@ impl JellyfinClient {
         &self, id: Option<String>, start: u32, listtype: &str, parentid: &str, sort_order: &str,
         sortby: &str, filters_list: &FiltersList,
     ) -> Result<List> {
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let start_string = start.to_string();
         let mut params = vec![
             ("Limit", "50"),
@@ -903,29 +924,33 @@ impl JellyfinClient {
     }
 
     pub async fn like(&self, id: &str) -> Result<()> {
-        let path = format!("Users/{}/FavoriteItems/{}", &self.user_id().await, id);
+        let s = self.session();
+
+        let path = format!("Users/{}/FavoriteItems/{}", &s.account.user_id, id);
         self.post(&path, &[], json!({})).await?;
         Ok(())
     }
 
     pub async fn unlike(&self, id: &str) -> Result<()> {
-        let path = format!(
-            "Users/{}/FavoriteItems/{}/Delete",
-            &self.user_id().await,
-            id
-        );
+        let s = self.session();
+
+        let path = format!("Users/{}/FavoriteItems/{}/Delete", &s.account.user_id, id);
         self.post(&path, &[], json!({})).await?;
         Ok(())
     }
 
     pub async fn set_as_played(&self, id: &str) -> Result<()> {
-        let path = format!("Users/{}/PlayedItems/{}", &self.user_id().await, id);
+        let s = self.session();
+
+        let path = format!("Users/{}/PlayedItems/{}", &s.account.user_id, id);
         self.post(&path, &[], json!({})).await?;
         Ok(())
     }
 
     pub async fn set_as_unplayed(&self, id: &str) -> Result<()> {
-        let path = format!("Users/{}/PlayedItems/{}/Delete", &self.user_id().await, id);
+        let s = self.session();
+
+        let path = format!("Users/{}/PlayedItems/{}/Delete", &s.account.user_id, id);
         self.post(&path, &[], json!({})).await?;
         Ok(())
     }
@@ -943,13 +968,15 @@ impl JellyfinClient {
     }
 
     pub async fn get_similar(&self, id: &str) -> Result<List> {
+        let s = self.session();
+
         let path = format!("Items/{id}/Similar");
         let params = [
             (
                 "Fields",
                 "BasicSyncInfo,CanDelete,PrimaryImageAspectRatio,ProductionYear,Status,EndDate,CommunityRating",
             ),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
             ("ImageTypeLimit", "1"),
             ("Limit", "12"),
         ];
@@ -957,7 +984,9 @@ impl JellyfinClient {
     }
 
     pub async fn get_actor_item_list(&self, id: &str, types: &str) -> Result<List> {
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let params = [
             (
                 "Fields",
@@ -979,8 +1008,10 @@ impl JellyfinClient {
         &self, id: &str, types: &str, sort_by: &str, sort_order: &str, start_index: u32,
         filters_list: &FiltersList,
     ) -> Result<List> {
+        let s = self.session();
+
         let start_string = start_index.to_string();
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let mut params = vec![
             (
                 "Fields",
@@ -1006,6 +1037,8 @@ impl JellyfinClient {
     }
 
     pub async fn get_continue_play_list(&self, parent_id: &str) -> Result<List> {
+        let s = self.session();
+
         let path = "Shows/NextUp".to_string();
         let params = [
             (
@@ -1015,26 +1048,30 @@ impl JellyfinClient {
             ("Limit", "40"),
             ("ImageTypeLimit", "1"),
             ("SeriesId", parent_id),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
         ];
         self.request(&path, &params).await
     }
 
     pub async fn get_season_list(&self, parent_id: &str) -> Result<List> {
+        let s = self.session();
+
         let path = format!("Shows/{parent_id}/Seasons");
         let params = [
             (
                 "Fields",
                 "BasicSyncInfo,CanDelete,PremiereDate,PrimaryImageAspectRatio,Overview",
             ),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
             ("ImageTypeLimit", "1"),
         ];
         self.request(&path, &params).await
     }
 
     pub async fn get_search_recommend(&self) -> Result<List> {
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let params = [
             ("Limit", "20"),
             ("Fields", "Overview"),
@@ -1052,7 +1089,9 @@ impl JellyfinClient {
         &self, types: &str, start: u32, limit: u32, sort_by: &str, sort_order: &str,
         filters_list: &FiltersList,
     ) -> Result<List> {
-        let user_id = self.user_id.lock().await;
+        let s = self.session();
+
+        let user_id = &s.account.user_id;
         let path = if types == "People" {
             "Persons".to_string()
         } else {
@@ -1074,7 +1113,7 @@ impl JellyfinClient {
             ("Limit", &limit_string),
             ("StartIndex", &start_string),
             if types == "People" {
-                ("UserId", &user_id)
+                ("UserId", user_id)
             } else {
                 ("", "")
             },
@@ -1089,7 +1128,9 @@ impl JellyfinClient {
     }
 
     pub async fn get_included(&self, id: &str) -> Result<List> {
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let params = [
             (
                 "Fields",
@@ -1106,7 +1147,9 @@ impl JellyfinClient {
     }
 
     pub async fn get_includedby(&self, parent_id: &str) -> Result<List> {
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let params = [
             (
                 "Fields",
@@ -1125,7 +1168,9 @@ impl JellyfinClient {
         &self, parent_id: &str, sort_by: &str, sort_order: &str, start_index: u32,
         filters_list: &FiltersList,
     ) -> Result<List> {
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let start_index_string = start_index.to_string();
         let sort_by = format!("IsFolder,{sort_by}");
         let mut params = vec![
@@ -1150,9 +1195,11 @@ impl JellyfinClient {
     }
 
     pub async fn change_password(&self, new_password: &str) -> Result<()> {
-        let path = format!("Users/{}/Password", &self.user_id().await);
+        let s = self.session();
 
-        let old_password = self.user_password.lock().await.to_owned();
+        let path = format!("Users/{}/Password", s.account.user_id);
+
+        let old_password = s.account.password.as_str();
 
         let body = json!({
             "CurrentPw": old_password,
@@ -1164,18 +1211,18 @@ impl JellyfinClient {
     }
 
     pub async fn hide_from_resume(&self, id: &str) -> Result<()> {
-        let path = format!(
-            "Users/{}/Items/{}/HideFromResume",
-            &self.user_id().await,
-            id
-        );
+        let s = self.session();
+
+        let path = format!("Users/{}/Items/{}/HideFromResume", &s.account.user_id, id);
         let params = [("Hide", "true")];
         self.post(&path, &params, json!({})).await?;
         Ok(())
     }
 
     pub async fn get_songs(&self, parent_id: &str) -> Result<List> {
-        let path = format!("Users/{}/Items", &self.user_id().await);
+        let s = self.session();
+
+        let path = format!("Users/{}/Items", &s.account.user_id);
         let params = [
             (
                 "Fields",
@@ -1189,26 +1236,26 @@ impl JellyfinClient {
     }
 
     pub async fn get_song_streaming_uri(&self, id: &str) -> String {
-        let url = self.url.lock().await.as_ref().unwrap().to_owned();
+        let s = self.session();
 
-        url.join(&format!("Audio/{}/universal?UserId={}&DeviceId={}&MaxStreamingBitrate=4000000&Container=opus,mp3|mp3,mp2,mp3|mp2,m4a|aac,mp4|aac,flac,webma,webm,wav|PCM_S16LE,wav|PCM_S24LE,ogg&TranscodingContainer=aac&TranscodingProtocol=hls&AudioCodec=aac&api_key={}&PlaySessionId=1715006733496&StartTimeTicks=0&EnableRedirection=true&EnableRemoteMedia=false",
-        id, &self.user_id().await, &DEVICE_ID.to_string(), self.user_access_token.lock().await, )).unwrap().to_string()
-    }
-
-    async fn user_id(&self) -> String {
-        self.user_id.lock().await.to_string()
+        s.url.as_ref().expect("URL not set").join(&format!("Audio/{}/universal?UserId={}&DeviceId={}&MaxStreamingBitrate=4000000&Container=opus,mp3|mp3,mp2,mp3|mp2,m4a|aac,mp4|aac,flac,webma,webm,wav|PCM_S16LE,wav|PCM_S24LE,ogg&TranscodingContainer=aac&TranscodingProtocol=hls&AudioCodec=aac&api_key={}&PlaySessionId=1715006733496&StartTimeTicks=0&EnableRedirection=true&EnableRemoteMedia=false",
+        id, &s.account.user_id, &DEVICE_ID.to_string(), &s.account.access_token, )).unwrap().to_string()
     }
 
     pub async fn get_additional(&self, id: &str) -> Result<List> {
+        let s = self.session();
+
         let path = format!("Videos/{id}/AdditionalParts");
-        let params: [(&str, &str); 1] = [("UserId", &self.user_id().await)];
+        let params: [(&str, &str); 1] = [("UserId", &s.account.user_id)];
         self.request(&path, &params).await
     }
 
     pub async fn get_channels(&self) -> Result<List> {
+        let s = self.session();
+
         let params = [
             ("IsAiring", "true"),
-            ("userId", &self.user_id().await),
+            ("userId", &s.account.user_id),
             ("ImageTypeLimit", "1"),
             ("Limit", "12"),
             ("Fields", "ProgramPrimaryImageAspectRatio"),
@@ -1219,9 +1266,11 @@ impl JellyfinClient {
     }
 
     pub async fn get_channels_list(&self, start_index: u32) -> Result<List> {
+        let s = self.session();
+
         let params = [
             ("IsAiring", "true"),
-            ("userId", &self.user_id().await),
+            ("userId", &s.account.user_id),
             ("ImageTypeLimit", "1"),
             ("Limit", "50"),
             ("Fields", "ProgramPrimaryImageAspectRatio"),
@@ -1270,16 +1319,10 @@ impl JellyfinClient {
     pub async fn get_image_path(
         &self, id: &str, image_type: &str, image_index: Option<u32>,
     ) -> String {
+        let s = self.session();
+
         let path = format!("Items/{id}/Images/{image_type}/");
-        let url = self
-            .url
-            .lock()
-            .await
-            .as_ref()
-            .unwrap()
-            .to_owned()
-            .join(&path)
-            .unwrap();
+        let url = s.url.as_ref().expect("URL not set").join(&path).unwrap();
         match image_index {
             Some(index) => url.join(&index.to_string()).unwrap().to_string(),
             None => url.to_string(),
@@ -1329,9 +1372,11 @@ impl JellyfinClient {
     pub async fn get_show_missing(
         &self, id: &str, include_specials: bool, upcoming: bool,
     ) -> Result<MissingEpisodesList> {
+        let s = self.session();
+
         let params = [
             ("Fields", "Overview"),
-            ("UserId", &self.user_id().await),
+            ("UserId", &s.account.user_id),
             ("ParentId", id),
             ("IncludeSpecials", &include_specials.to_string()),
             ("IncludeUnaired", &upcoming.to_string()),
@@ -1345,6 +1390,8 @@ impl JellyfinClient {
     }
 
     pub async fn filters(&self, type_: &str) -> Result<FilterList> {
+        let s = self.session();
+
         let params = [
             ("SortBy", "SortName"),
             ("SortOrder", "Ascending"),
@@ -1355,7 +1402,7 @@ impl JellyfinClient {
                 "IncludeItemTypes",
                 "Movie,Series,Episode,BoxSet,Person,MusicAlbum,Audio,Video",
             ),
-            ("userId", &self.user_id().await),
+            ("userId", &s.account.user_id),
         ];
         self.request(type_, &params).await
     }
@@ -1368,17 +1415,22 @@ mod tests {
 
     #[tokio::test]
     async fn search() {
-        let _ = JELLYFIN_CLIENT
-            .header_change_url("https://example.com", "443")
-            .await;
+        let _ = JELLYFIN_CLIENT.header_change_url("https://example.com", "443");
         let result = JELLYFIN_CLIENT.login("test", "test").await;
         match result {
             Ok(response) => {
                 println!("{}", response.access_token);
-                let _ = JELLYFIN_CLIENT
-                    .header_change_token(&response.access_token)
-                    .await;
-                let _ = JELLYFIN_CLIENT.set_user_id(&response.user.id).await;
+                let account = Account {
+                    servername: "test".to_string(),
+                    server: "https://example.com".to_string(),
+                    username: "inaha".to_string(),
+                    password: String::new(),
+                    port: "443".to_string(),
+                    user_id: response.user.id,
+                    access_token: response.access_token,
+                    server_type: Some("Jellyfin".to_string()),
+                };
+                let _ = JELLYFIN_CLIENT.init(&account).await;
             }
             Err(e) => {
                 eprintln!("{}", e.to_user_facing());
@@ -1412,9 +1464,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_upload_image() {
-        let _ = JELLYFIN_CLIENT
-            .header_change_url("http://127.0.0.1", "8096")
-            .await;
+        let _ = JELLYFIN_CLIENT.header_change_url("http://127.0.0.1", "8096");
         let result = JELLYFIN_CLIENT.login("inaha", "").await;
         match result {
             Ok(response) => {

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -1,7 +1,4 @@
-use std::{
-    hash::Hasher,
-    sync::Arc,
-};
+use std::hash::Hasher;
 
 use anyhow::{
     Result,

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -103,7 +103,6 @@ pub enum BackType {
 pub struct JellyfinClient {
     pub url: Mutex<Option<Url>>,
     pub client: Client,
-    pub semaphore: Arc<tokio::sync::Semaphore>,
     pub headers: Mutex<reqwest::header::HeaderMap>,
     pub user_id: Mutex<String>,
     pub user_name: Mutex<String>,
@@ -145,7 +144,6 @@ impl Default for JellyfinClient {
         Self {
             url: Mutex::new(None),
             client: ReqClient::build(),
-            semaphore: Arc::new(tokio::sync::Semaphore::new(SETTINGS.threads() as usize)),
             headers: Mutex::new(headers),
             user_id: Mutex::new(String::new()),
             user_name: Mutex::new(String::new()),
@@ -357,12 +355,10 @@ impl JellyfinClient {
     }
 
     async fn send_request(&self, request: RequestBuilder) -> Result<Response> {
-        let permit = self.semaphore.acquire().await?;
         let res = match request.send().await {
             Ok(r) => r,
             Err(e) => return Err(anyhow!(e.to_user_facing())),
         };
-        drop(permit);
         Ok(res)
     }
 

--- a/src/ui/models/mod.rs
+++ b/src/ui/models/mod.rs
@@ -1,21 +1,22 @@
 use once_cell::sync::Lazy;
 pub mod settings;
 pub use self::settings::Settings;
-use crate::client::jellyfin_client::JELLYFIN_CLIENT;
+use crate::{
+    client::jellyfin_client::JELLYFIN_CLIENT,
+    utils::spawn_tokio_blocking,
+};
 pub static SETTINGS: Lazy<Settings> = Lazy::new(Settings::default);
 
-pub static CACHE_PATH: Lazy<std::path::PathBuf> = Lazy::new(|| {
-    let path = gtk::glib::user_cache_dir().join("tsukimi");
-    if !path.exists() {
-        std::fs::create_dir_all(&path).expect("Failed to create directory");
-    }
-    path
-});
+pub static CACHE_PATH: Lazy<std::path::PathBuf> =
+    Lazy::new(|| gtk::glib::user_cache_dir().join("tsukimi"));
 
 pub async fn jellyfin_cache_path() -> std::path::PathBuf {
     let path = CACHE_PATH.join(JELLYFIN_CLIENT.server_name_hash.lock().await.as_str());
-    if !path.exists() {
-        std::fs::create_dir_all(&path).expect("Failed to create directory");
-    }
-    path
+    spawn_tokio_blocking(|| {
+        if !path.exists() {
+            std::fs::create_dir_all(&path).expect("Failed to create directory");
+        }
+        path
+    })
+    .await
 }

--- a/src/ui/models/mod.rs
+++ b/src/ui/models/mod.rs
@@ -1,22 +1,21 @@
 use once_cell::sync::Lazy;
 pub mod settings;
 pub use self::settings::Settings;
-use crate::{
-    client::jellyfin_client::JELLYFIN_CLIENT,
-    utils::spawn_tokio_blocking,
-};
+use crate::client::jellyfin_client::JELLYFIN_CLIENT;
 pub static SETTINGS: Lazy<Settings> = Lazy::new(Settings::default);
 
-pub static CACHE_PATH: Lazy<std::path::PathBuf> =
-    Lazy::new(|| gtk::glib::user_cache_dir().join("tsukimi"));
+pub static CACHE_PATH: Lazy<std::path::PathBuf> = Lazy::new(|| {
+    let path = gtk::glib::user_cache_dir().join("tsukimi");
+    if !path.exists() {
+        std::fs::create_dir_all(&path).expect("Failed to create directory");
+    }
+    path
+});
 
 pub async fn jellyfin_cache_path() -> std::path::PathBuf {
     let path = CACHE_PATH.join(&JELLYFIN_CLIENT.session().server_name_hash);
-    spawn_tokio_blocking(|| {
-        if !path.exists() {
-            std::fs::create_dir_all(&path).expect("Failed to create directory");
-        }
-        path
-    })
-    .await
+    if !path.exists() {
+        std::fs::create_dir_all(&path).expect("Failed to create directory");
+    }
+    path
 }

--- a/src/ui/models/mod.rs
+++ b/src/ui/models/mod.rs
@@ -11,7 +11,7 @@ pub static CACHE_PATH: Lazy<std::path::PathBuf> =
     Lazy::new(|| gtk::glib::user_cache_dir().join("tsukimi"));
 
 pub async fn jellyfin_cache_path() -> std::path::PathBuf {
-    let path = CACHE_PATH.join(JELLYFIN_CLIENT.server_name_hash.lock().await.as_str());
+    let path = CACHE_PATH.join(&JELLYFIN_CLIENT.session().server_name_hash);
     spawn_tokio_blocking(|| {
         if !path.exists() {
             std::fs::create_dir_all(&path).expect("Failed to create directory");

--- a/src/ui/widgets/account_add.rs
+++ b/src/ui/widgets/account_add.rs
@@ -149,8 +149,8 @@ impl AccountWindow {
 
         let server = format!("{protocol}{server}");
 
-        let _ = JELLYFIN_CLIENT.header_change_url(&server, &port).await;
-        let _ = JELLYFIN_CLIENT.header_change_token(&servername).await;
+        let _ = JELLYFIN_CLIENT.header_change_url(&server, &port);
+        let _ = JELLYFIN_CLIENT.header_change_token(&servername);
         let un = username.to_string();
         let pw = password.to_string();
         let res =
@@ -188,8 +188,8 @@ impl AccountWindow {
         };
 
         let account = Account {
-            servername: servername.to_string(),
-            server: server.to_string(),
+            servername: servername,
+            server: server,
             username: un,
             password: pw,
             port: port.to_string(),

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -374,7 +374,7 @@ impl Window {
         for account in &accounts {
             if SETTINGS.auto_select_server()
                 && account.servername == SETTINGS.preferred_server()
-                && JELLYFIN_CLIENT.user_id.lock().await.is_empty()
+                && JELLYFIN_CLIENT.session().account.user_id.is_empty()
             {
                 let _ = JELLYFIN_CLIENT.init(account).await;
                 self.reset();
@@ -522,10 +522,9 @@ impl Window {
 
     pub async fn account_setup(&self) {
         let imp = self.imp();
-        imp.namerow
-            .set_title(&JELLYFIN_CLIENT.user_name.lock().await);
-        imp.namerow
-            .set_subtitle(&JELLYFIN_CLIENT.server_name.lock().await);
+        let s = JELLYFIN_CLIENT.session();
+        imp.namerow.set_title(&s.account.username);
+        imp.namerow.set_subtitle(&s.account.servername);
     }
 
     pub fn account_settings(&self) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,6 +25,14 @@ where
     runtime().spawn(fut).await.unwrap()
 }
 
+pub async fn spawn_tokio_blocking<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    runtime().spawn_blocking(f).await.unwrap()
+}
+
 pub fn spawn_tokio_without_await<F>(fut: F)
 where
     F: std::future::Future + Send + 'static,
@@ -88,14 +96,14 @@ where
     let update_in_background = matches!(cache_policy, CachePolicy::ReadCacheAndRefresh);
 
     if read_cache {
-        if let Some(data) = read_from_cache(&path) {
+        if let Some(data) = read_from_cache(path.to_owned()).await {
             if update_in_background {
                 let path = path.to_owned();
                 if let Some(callback) = on_refresh {
                     let (tx, rx) = tokio::sync::oneshot::channel();
                     runtime().spawn(async move {
                         if let Ok(data) = future.await {
-                            let _ = write_to_cache(&path, &data);
+                            let _ = write_to_cache(path, &data);
                             let _ = tx.send(data);
                         }
                     });
@@ -107,7 +115,7 @@ where
                 } else {
                     runtime().spawn(async move {
                         if let Ok(data) = future.await {
-                            let _ = write_to_cache(&path, &data);
+                            let _ = write_to_cache(path, &data);
                         }
                     });
                 }
@@ -119,27 +127,28 @@ where
     let data = spawn_tokio(future).await?;
 
     if write_cache {
-        write_to_cache(&path, &data)?;
+        write_to_cache(path, &data).await?;
     }
 
     Ok(data)
 }
 
-fn read_from_cache<T>(path: &PathBuf) -> Option<T>
+async fn read_from_cache<T>(path: PathBuf) -> Option<T>
 where
     T: for<'de> Deserialize<'de>,
 {
-    std::fs::read_to_string(path)
+    spawn_tokio_blocking(move || std::fs::read_to_string(path))
+        .await
         .ok()
         .and_then(|contents| serde_json::from_str(&contents).ok())
 }
 
-fn write_to_cache<T>(path: &PathBuf, data: &T) -> Result<()>
+async fn write_to_cache<T>(path: PathBuf, data: &T) -> Result<()>
 where
     T: Serialize,
 {
     let serialized = serde_json::to_string(data)?;
-    std::fs::write(path, serialized)?;
+    spawn_tokio_blocking(move || std::fs::write(path, serialized)).await?;
     Ok(())
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,14 +25,6 @@ where
     runtime().spawn(fut).await.unwrap()
 }
 
-pub async fn spawn_tokio_blocking<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R + Send + 'static,
-    R: Send + 'static,
-{
-    runtime().spawn_blocking(f).await.unwrap()
-}
-
 pub fn spawn_tokio_without_await<F>(fut: F)
 where
     F: std::future::Future + Send + 'static,
@@ -96,14 +88,14 @@ where
     let update_in_background = matches!(cache_policy, CachePolicy::ReadCacheAndRefresh);
 
     if read_cache {
-        if let Some(data) = read_from_cache(path.to_owned()).await {
+        if let Some(data) = read_from_cache(&path) {
             if update_in_background {
                 let path = path.to_owned();
                 if let Some(callback) = on_refresh {
                     let (tx, rx) = tokio::sync::oneshot::channel();
                     runtime().spawn(async move {
                         if let Ok(data) = future.await {
-                            let _ = write_to_cache(path, &data);
+                            let _ = write_to_cache(&path, &data);
                             let _ = tx.send(data);
                         }
                     });
@@ -115,7 +107,7 @@ where
                 } else {
                     runtime().spawn(async move {
                         if let Ok(data) = future.await {
-                            let _ = write_to_cache(path, &data);
+                            let _ = write_to_cache(&path, &data);
                         }
                     });
                 }
@@ -127,28 +119,27 @@ where
     let data = spawn_tokio(future).await?;
 
     if write_cache {
-        write_to_cache(path, &data).await?;
+        write_to_cache(&path, &data)?;
     }
 
     Ok(data)
 }
 
-async fn read_from_cache<T>(path: PathBuf) -> Option<T>
+fn read_from_cache<T>(path: &PathBuf) -> Option<T>
 where
     T: for<'de> Deserialize<'de>,
 {
-    spawn_tokio_blocking(move || std::fs::read_to_string(path))
-        .await
+    std::fs::read_to_string(path)
         .ok()
         .and_then(|contents| serde_json::from_str(&contents).ok())
 }
 
-async fn write_to_cache<T>(path: PathBuf, data: &T) -> Result<()>
+fn write_to_cache<T>(path: &PathBuf, data: &T) -> Result<()>
 where
     T: Serialize,
 {
     let serialized = serde_json::to_string(data)?;
-    spawn_tokio_blocking(move || std::fs::write(path, serialized)).await?;
+    std::fs::write(path, serialized)?;
     Ok(())
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,32 +17,12 @@ use crate::{
     ui::jellyfin_cache_path,
 };
 
-pub fn _spawn_tokio_blocking<F>(fut: F) -> F::Output
-where
-    F: std::future::Future + Send + 'static,
-    F::Output: Send + 'static,
-{
-    let (sender, receiver) = tokio::sync::oneshot::channel();
-
-    runtime().spawn(async {
-        let response = fut.await;
-        sender.send(response)
-    });
-    receiver.blocking_recv().unwrap()
-}
-
 pub async fn spawn_tokio<F>(fut: F) -> F::Output
 where
     F: std::future::Future + Send + 'static,
     F::Output: Send + 'static,
 {
-    let (sender, receiver) = tokio::sync::oneshot::channel();
-
-    runtime().spawn(async {
-        let response = fut.await;
-        sender.send(response)
-    });
-    receiver.await.unwrap()
+    runtime().spawn(fut).await.unwrap()
 }
 
 pub fn spawn_tokio_without_await<F>(fut: F)


### PR DESCRIPTION
这个 PR 做了一些（几乎）无争议的重构/优化，包括：
1. 对于 Jellyfin Client 内的多读少写场景，使用 ArcSwap 替换大量的 Mutex；
2. `add_params_to_url` 可以用 `request().query()` 替代；
3. 移除 spawn_tokio 内的 oneshot，spawn_tokio 本身是异步函数，无需桥接直接 await JoinHandle 就能拿到结果；
4. 移除 send_request 内的信号量，send_request 按理没必要被 thread 限制（如果这里实际意图是做限流可以先加回来，但感觉最好把并发数和线程数区分下）。