### PR TITLE
fix: get jellyfin stream url

### DIFF
--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -86,7 +86,7 @@ pub struct MediaSource {
     #[serde(rename = "MediaStreams")]
     pub media_streams: Vec<MediaStream>,
     #[serde(rename = "ItemId")]
-    pub item_id: String,
+    pub item_id: Option<String>,
 
     // jellyfin
     #[serde(rename = "ETag")]

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -60,15 +60,6 @@ impl Settings {
     const KEY_WINDOW_HEIGHT: &'static str = "window-height"; // i32
     const KEY_IS_MAXIMIZED: &'static str = "is-maximized"; // bool
     const KEY_IS_FULLSCREEN: &'static str = "is-fullscreen"; // bool
-    const KEY_IS_DANMAKU_ENABLED: &'static str = "is-danmaku-enabled"; // bool
-
-    pub fn is_danmaku_enabled(&self) -> bool {
-        self.boolean(Self::KEY_IS_DANMAKU_ENABLED)
-    }
-
-    pub fn set_danmaku_enabled(&self, is_danmaku_enabled: bool) -> Result<(), glib::BoolError> {
-        self.set_boolean(Self::KEY_IS_DANMAKU_ENABLED, is_danmaku_enabled)
-    }
 
     #[cfg(target_os = "windows")]
     const KEY_IS_FIRST_RUN: &'static str = "is-first-run"; // bool

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -104,8 +104,6 @@ mod imp {
         },
     };
 
-
-
     #[derive(CompositeTemplate, Default, glib::Properties)]
     #[template(resource = "/moe/tsuna/tsukimi/ui/mpvpage.ui")]
     #[properties(wrapper_type = super::MPVPage)]
@@ -1188,7 +1186,6 @@ impl MPVPage {
         self.imp().video.imp().mpv()
     }
 
-
     pub fn notify_has_chapters(&self, has_chapters: bool) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_has_chapters(has_chapters);
@@ -1217,9 +1214,12 @@ impl MPVPage {
 
 pub async fn direct_stream_url(source: &MediaSource) -> Option<String> {
     let container = source.container.as_deref()?;
-    println!("{}", source.id.as_str());
     JELLYFIN_CLIENT
-        .get_item_stream_url(container, &source.item_id, &source.id.to_owned())
+        .get_item_stream_url(
+            container,
+            source.item_id.as_ref().unwrap_or(&source.id),
+            &source.id.to_owned(),
+        )
         .await
         .ok()
 }


### PR DESCRIPTION
还剩一个 **warning: use of deprecated associated function `libadwaita::gdk4::Texture::for_pixbuf`: Since 4.20**，查了查[文档](https://docs.gtk.org/gdk4/ctor.Texture.new_for_pixbuf.html)：
> Use e.g. libglycin, which can load many image formats into a GdkTexture.

但是[ glycin 的文档](https://crates.io/crates/glycin) 又说：

> Glycin is based on technologies like memfds, unix sockets, and linux namespaces. **It currently only works on Linux.**

感觉不太能换，先搁置。