### PR TITLE
feat: add bottom margin for homepage

### DIFF
--- a/resources/ui/home.ui
+++ b/resources/ui/home.ui
@@ -30,6 +30,7 @@
                     <property name="orientation">vertical</property>
                     <property name="spacing">6</property>
                     <property name="height-request">1000</property>
+                    <property name="margin-bottom">18</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
libsbox 内部有 6 的边距，HortuScrolled 上下有 12 的边距，因此正常两个 Latest 之间的距离是 12 * 2 + 6 = 30，但最后一个 Latest 到末尾只有 12 显得很窄。

该 PR 手动补上 18 的底间距来对齐，看起来会更协调一些。

Before:

<img width="2779" height="1670" alt="图片" src="https://github.com/user-attachments/assets/30e93eba-dbc1-4ef5-92f2-572b1742721d" />


After:

<img width="2779" height="1670" alt="图片" src="https://github.com/user-attachments/assets/b45a986f-7e2b-4a39-8628-a7a44c0018ef" />
