### PR TITLE
build: export config::version in meson build

### DIFF
--- a/src/config.rs.in
+++ b/src/config.rs.in
@@ -3,3 +3,6 @@ pub const GETTEXT_PACKAGE: &str = @GETTEXT_PACKAGE@;
 pub const LOCALEDIR: &str = @LOCALEDIR@;
 pub const PKGDATADIR: &str = @PKGDATADIR@;
 
+pub fn version() -> &'static str {
+    VERSION
+}


### PR DESCRIPTION
`config::version()` previously only existed in `config.rs` but not `config.rs.in` and will be wiped off by meson, causing meson builds to fail. This PR adds a minimal compatibility workaournd without touching build workflows.

I would personally suggest removing `config.rs` and enforce building with meson, or at least build with meson on CI.