### PR TITLE
fix: use poster type to resolve item card size

### DIFF
--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -464,14 +464,15 @@ impl TuItem {
         )
         .await;
 
-        let songs = loop {
-            match events.recv().await {
-                Some(CacheEvent::Data { data, .. }) => break data,
-                Some(CacheEvent::Error(e)) => {
-                    obj.toast(e.to_user_facing());
-                    return;
-                }
-                None => return,
+        let Some(event) = events.recv().await else {
+            return;
+        };
+
+        let songs = match event {
+            CacheEvent::Data { data, .. } => data,
+            CacheEvent::Error(e) => {
+                obj.toast(e.to_user_facing());
+                return;
             }
         };
 

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -10,27 +10,17 @@ use crate::ui::{
         hover_scale::HoverScale,
         picture_loader::PictureLoader,
         tu_list_item::imp::PosterType,
-        utils::*,
     },
 };
 
 use super::TuItemBasic;
 
 pub trait TuItemOverlayPrelude {
-    fn set_overlay_size(overlay: &gtk::Overlay, width: i32, height: i32) {
-        overlay.set_size_request(width, height);
-    }
-
     fn get_image_type_and_tag(&self, item: &TuItem) -> (&str, Option<String>, String) {
         if self.poster_type_ext() != PosterType::Poster {
             if let Some(imag_tags) = item.image_tags() {
                 match self.poster_type_ext() {
                     PosterType::Banner => {
-                        Self::set_overlay_size(
-                            &self.overlay(),
-                            TU_ITEM_BANNER_SIZE.0,
-                            TU_ITEM_BANNER_SIZE.1,
-                        );
                         if imag_tags.banner().is_some() {
                             return ("Banner", None, item.id());
                         } else if imag_tags.thumb().is_some() {
@@ -40,11 +30,6 @@ pub trait TuItemOverlayPrelude {
                         }
                     }
                     PosterType::Backdrop => {
-                        Self::set_overlay_size(
-                            &self.overlay(),
-                            TU_ITEM_VIDEO_SIZE.0,
-                            TU_ITEM_VIDEO_SIZE.1,
-                        );
                         if imag_tags.backdrop().is_some() {
                             return ("Backdrop", Some(0.to_string()), item.id());
                         } else if imag_tags.thumb().is_some() {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -22,6 +22,10 @@ use crate::{
     ui::{
         GlobalToast,
         provider::tu_item::TuItem,
+        widgets::utils::{
+            TU_ITEM_BANNER_SIZE,
+            TU_ITEM_VIDEO_SIZE,
+        },
     },
     utils::spawn,
 };
@@ -433,7 +437,7 @@ impl TuListItem {
             self.set_picture();
         }
 
-        let (w, h) = item.size_hint();
+        let (w, h) = self.size_hint();
 
         imp.overlay.set_size_request(w, h);
 
@@ -458,6 +462,14 @@ impl TuListItem {
         if let Some(title) = item.list_item_title() {
             imp.title.set_text(&title);
             imp.title.set_visible(true);
+        }
+    }
+
+    fn size_hint(&self) -> (i32, i32) {
+        match self.poster_type() {
+            PosterType::Banner => TU_ITEM_BANNER_SIZE,
+            PosterType::Backdrop => TU_ITEM_VIDEO_SIZE,
+            _ => self.item().size_hint(),
         }
     }
 


### PR DESCRIPTION
让 tu_list_item 的图片 size 优先依赖 poster_type，修复切换视图时图片 size 不变化的 bug。

此外移除了 get_image_type_and_tag 内的隐式 size 设置，这里的 size 设置最终会被 size_hint 覆盖，是一个无效操作，且从语义上该方法不应产生此类副作用。