### PR TITLE
feat: run setup methods concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,7 @@ dependencies = [
  "epoxy",
  "flume",
  "fnv",
+ "futures-util",
  "gdk4-wayland",
  "gdk4-x11",
  "gettext-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ base64 = "0.22.1"
 libmpv2 = "4.1.0"
 glow = "0.17"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
+futures-util = "0.3.31"
 
 [build-dependencies]
 embed-resource = "3.0"

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -150,8 +150,10 @@ impl HomePage {
 
     pub async fn setup(&self, enable_cache: bool) {
         fraction_reset!(self);
-        self.setup_history(enable_cache).await;
-        self.setup_library(enable_cache).await;
+        futures_util::join!(
+            self.setup_history(enable_cache),
+            self.setup_library(enable_cache)
+        );
         fraction!(self);
     }
 


### PR DESCRIPTION
这里使用 tokio::join! 其实也能 work，因为 tokio::join! 并不依赖 tokio runtime。但该方法是少数例外，tokio 内的大量功能仍然依赖 runtime，为了避免出错还是尽量不在 glib 的异步上下文里用 tokio，futures 是更好的选择。

之前项目中已经包含对 futures-util 的依赖，这里显式声明一下就好。