### PR TITLE
perf: reduce unnecessary clones in UI paths

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -3,4 +3,4 @@ comment_width = 100
 format_code_in_doc_comments = true
 imports_granularity = "Crate"
 imports_layout = "Vertical"
-wrap_comments = true
+wrap_comments = false

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -755,19 +755,20 @@ impl MPVPage {
             return;
         };
 
-        let video_list = self.imp().current_episode_list.borrow().to_owned();
-
-        let next_item = video_list.iter().enumerate().find_map(|(i, item)| {
-            // Don't use id() here, because the same video maybe have different id
-            if item.index_number() == current_video.index_number()
-                && item.parent_index_number() == current_video.parent_index_number()
-            {
-                let new_index = (i as isize + offset) as usize;
-                video_list.get(new_index).cloned()
-            } else {
-                None
-            }
-        });
+        let next_item = {
+            let video_list = self.imp().current_episode_list.borrow();
+            video_list.iter().enumerate().find_map(|(i, item)| {
+                // Don't use id() here, because the same video maybe have different id
+                if item.index_number() == current_video.index_number()
+                    && item.parent_index_number() == current_video.parent_index_number()
+                {
+                    let new_index = (i as isize + offset) as usize;
+                    video_list.get(new_index).cloned()
+                } else {
+                    None
+                }
+            })
+        };
 
         let Some(next_item) = next_item else {
             self.toast(gettext("No more video found"));
@@ -1365,7 +1366,7 @@ pub async fn direct_stream_url(source: &MediaSource) -> Option<String> {
         .get_item_stream_url(
             container,
             source.item_id.as_ref().unwrap_or(&source.id),
-            &source.id.to_owned(),
+            &source.id,
         )
         .await
         .ok()

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -235,9 +235,12 @@ impl Default for TuItem {
 }
 
 impl TuItem {
-    pub fn from_simple(latest: &SimpleListItem, poster: Option<&str>) -> Self {
+    pub fn from_simple(item: &SimpleListItem, poster: Option<&str>) -> Self {
+        Self::from_simple_owned(item.to_owned(), poster)
+    }
+
+    pub fn from_simple_owned(item: SimpleListItem, poster: Option<&str>) -> Self {
         let tu_item: TuItem = glib::object::Object::new();
-        let item = latest.to_owned();
         tu_item.set_id(item.id);
         tu_item.set_name(item.name);
         tu_item.set_item_type(item.item_type);
@@ -478,9 +481,9 @@ impl TuItem {
 
         let song_widgets = songs
             .items
-            .iter()
+            .into_iter()
             .map(|song| {
-                let item = TuItem::from_simple(song, None);
+                let item = TuItem::from_simple_owned(song, None);
                 let song_widget = SongWidget::new(item, SongWidgetView::MusicAlbumItem);
                 song_widget.coresong()
             })
@@ -536,8 +539,8 @@ impl TuItem {
             TuItem::from_simple(nextup_item, None),
             nextup_list
                 .items
-                .iter()
-                .map(|item| TuItem::from_simple(item, None))
+                .into_iter()
+                .map(|item| TuItem::from_simple_owned(item, None))
                 .collect(),
         )
         .await;

--- a/src/ui/provider/tu_object.rs
+++ b/src/ui/provider/tu_object.rs
@@ -45,6 +45,11 @@ impl TuObject {
         glib::Object::builder().property("item", item).build()
     }
 
+    pub fn from_simple_owned(latest: SimpleListItem, poster: Option<&str>) -> Self {
+        let tu_item = TuItem::from_simple_owned(latest, poster);
+        TuObject::new(&tu_item)
+    }
+
     pub fn from_simple(latest: &SimpleListItem, poster: Option<&str>) -> Self {
         let tu_item = TuItem::from_simple(latest, poster);
         TuObject::new(&tu_item)

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -174,7 +174,7 @@ impl HomePage {
         while let Some(event) = events.recv().await {
             match event {
                 CacheEvent::Data { data, .. } => {
-                    hortu.set_items(&data.items);
+                    hortu.set_items(data.items);
                 }
                 CacheEvent::Error(e) => {
                     self.toast(e.to_user_facing());
@@ -202,9 +202,9 @@ impl HomePage {
             match event {
                 CacheEvent::Data { data, source } => {
                     if enable_cache || matches!(source, CacheSource::Network) {
-                        hortu.set_items(&data.items);
+                        hortu.set_items(data.items.clone());
                     }
-                    self.setup_libsview(data.items, enable_cache).await;
+                    self.setup_libsview(data.items, enable_cache);
                 }
                 CacheEvent::Error(e) => {
                     self.toast(e.to_user_facing());
@@ -214,7 +214,7 @@ impl HomePage {
         }
     }
 
-    pub async fn setup_libsview(&self, items: Vec<SimpleListItem>, enable_cache: bool) {
+    pub fn setup_libsview(&self, items: Vec<SimpleListItem>, enable_cache: bool) {
         let current_ids = items
             .iter()
             .map(|view| view.id.as_str())
@@ -316,7 +316,7 @@ impl HomePage {
         while let Some(event) = events.recv().await {
             match event {
                 CacheEvent::Data { data, .. } => {
-                    hortu.set_items(&data);
+                    hortu.set_items(data);
                 }
                 CacheEvent::Error(e) => {
                     self.toast(e.to_user_facing());

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -247,9 +247,7 @@ impl HomePage {
         }
     }
 
-    fn setup_hortu(&self, view: &SimpleListItem) -> HortuScrolled {
-        let ac_view = view.to_owned();
-
+    fn setup_hortu(&self, ac_view: SimpleListItem) -> HortuScrolled {
         let hortu = HortuScrolled::new();
 
         hortu.set_moreview(true);
@@ -258,7 +256,9 @@ impl HomePage {
 
         hortu.set_prefer_poster(PreferPoster::ParentPost);
 
-        hortu.set_title(format!("{} {}", gettext("Latest"), view.name));
+        hortu.set_title(format!("{} {}", gettext("Latest"), ac_view.name));
+
+        let ac_view_id = ac_view.id.to_owned();
 
         hortu.connect_morebutton(glib::clone!(
             #[weak(rename_to = obj)]
@@ -278,7 +278,7 @@ impl HomePage {
         self.imp()
             .libs_hortu
             .borrow_mut()
-            .insert(view.id.to_owned(), hortu.downgrade());
+            .insert(ac_view_id, hortu.downgrade());
 
         hortu
     }
@@ -291,10 +291,10 @@ impl HomePage {
             .get(&view.id)
             .and_then(|w| w.upgrade());
 
-        let hortu = hortu.unwrap_or_else(|| self.setup_hortu(&view));
-
         let view_id = view.id.clone();
         let collection_type = view.collection_type.clone();
+
+        let hortu = hortu.unwrap_or_else(|| self.setup_hortu(view));
 
         let mut events = fetch_with_cache(
             &format!("library_{}", view_id),

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -215,20 +215,24 @@ impl HortuScrolled {
         let prefer_size = resolve_prefer_size(self.unify_size(), &items);
         let visible_ids = items
             .iter()
-            .map(|item| item.id.clone())
+            .map(|item| item.id.as_str())
             .collect::<std::collections::HashSet<_>>();
         imp.item_cache
             .borrow_mut()
-            .retain(|id, _| visible_ids.contains(id));
+            .retain(|id, _| visible_ids.contains(id.as_str()));
 
         let items = items
             .into_iter()
             .map(|item| {
                 let mut cache = imp.item_cache.borrow_mut();
-                let object = cache
-                    .entry(item.id.clone())
-                    .or_insert_with(|| TuObject::from_simple_owned(item, None))
-                    .clone();
+                let object = if let Some(object) = cache.get(&item.id) {
+                    object.clone()
+                } else {
+                    let id = item.id.clone();
+                    let object = TuObject::from_simple_owned(item, None);
+                    cache.insert(id, object.clone());
+                    object
+                };
                 let tu_item = object.item();
                 tu_item.set_is_resume(self.isresume());
                 tu_item.set_prefer_size(prefer_size);

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -201,7 +201,7 @@ impl HortuScrolled {
         imp.morebutton.set_visible(true);
     }
 
-    pub fn set_items(&self, items: &[SimpleListItem]) {
+    pub fn set_items(&self, items: Vec<SimpleListItem>) {
         let imp = self.imp();
 
         if items.is_empty() {
@@ -212,7 +212,7 @@ impl HortuScrolled {
 
         self.set_visible(true);
 
-        let prefer_size = resolve_prefer_size(self.unify_size(), items);
+        let prefer_size = resolve_prefer_size(self.unify_size(), &items);
         let visible_ids = items
             .iter()
             .map(|item| item.id.clone())
@@ -222,12 +222,12 @@ impl HortuScrolled {
             .retain(|id, _| visible_ids.contains(id));
 
         let items = items
-            .iter()
+            .into_iter()
             .map(|item| {
                 let mut cache = imp.item_cache.borrow_mut();
                 let object = cache
                     .entry(item.id.clone())
-                    .or_insert_with(|| TuObject::from_simple(item, None))
+                    .or_insert_with(|| TuObject::from_simple_owned(item, None))
                     .clone();
                 let tu_item = object.item();
                 tu_item.set_is_resume(self.isresume());

--- a/src/ui/widgets/image_dialog/image_infocard.rs
+++ b/src/ui/widgets/image_dialog/image_infocard.rs
@@ -248,6 +248,12 @@ impl ImageInfoCard {
                             None::<&gio::Cancellable>,
                             move |r| match r {
                                 Ok(pixbuf) => {
+                                    #[allow(deprecated)]
+                                    // FIXME: `Texture::for_pixbuf` is deprecated since GTK 4.20.
+                                    // GTK recommends libglycin for loading images into `GdkTexture`, but
+                                    // glycin currently only works on Linux, so keep this fallback for now.
+                                    // https://docs.gtk.org/gdk4/ctor.Texture.new_for_pixbuf.html
+                                    // https://docs.rs/crate/glycin/latest
                                     picture.set_paintable(Some(&gtk::gdk::Texture::for_pixbuf(
                                         &pixbuf,
                                     )));

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -707,7 +707,6 @@ impl ItemPage {
     }
 
     pub async fn set_dropdown(&self, playbackinfo: &Media) {
-        let playbackinfo = playbackinfo.to_owned();
         let imp = self.imp();
         let namedropdown = imp.namedropdown.get();
         let subdropdown = imp.subdropdown.get();
@@ -744,7 +743,7 @@ impl ItemPage {
                     sstore.remove(0);
                 }
                 for media in &media_sources {
-                    if &Some(media.id.to_owned()) == selected {
+                    if selected.as_deref().is_some_and(|s| s == media.id) {
                         let mut lang_list = Vec::new();
                         for stream in &media.media_streams {
                             if stream.stream_type == "Subtitle" {

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -881,7 +881,7 @@ impl ItemPage {
                         .map(|season| season.name.as_str())
                         .collect::<Vec<_>>();
                     season_list_store.splice(0, season_list_store.n_items(), &names);
-                    imp.seasonshortu.set_items(&season_list);
+                    imp.seasonshortu.set_items(season_list.to_owned());
                     imp.season_list_vec.replace(season_list);
                     self.on_season_selected(None, imp.seasonlist.get()).await;
                 }
@@ -1162,7 +1162,7 @@ impl ItemPage {
 
     pub async fn setactorscrolled(&self, actors: Vec<SimpleListItem>) {
         let hortu = self.imp().actorhortu.get();
-        hortu.set_items(&actors);
+        hortu.set_items(actors);
     }
 
     pub async fn set_lists(&self, id: &str) {
@@ -1200,7 +1200,7 @@ impl ItemPage {
         while let Some(event) = events.recv().await {
             match event {
                 CacheEvent::Data { data, .. } => {
-                    hortu.set_items(&data.items);
+                    hortu.set_items(data.items);
                 }
                 CacheEvent::Error(e) => {
                     self.toast(e.to_user_facing());

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -410,7 +410,7 @@ impl ItemPage {
                     match spawn_tokio(async move { JELLYFIN_CLIENT.get_item_info(&id).await }).await
                     {
                         Ok(item) => {
-                            obj.set_intro::<true>(&TuItem::from_simple(&item, None))
+                            obj.set_intro::<true>(&TuItem::from_simple_owned(item, None))
                                 .await;
                         }
                         Err(e) => {
@@ -564,14 +564,15 @@ impl ItemPage {
             }
         };
 
-        self.set_episode_list(&list.items);
+        let index = list
+            .items
+            .iter()
+            .position(|item| item.index_number == Some(self.item().index_number()))
+            .unwrap_or(0);
+
+        self.set_episode_list(list.items);
 
         if position == 0 {
-            let index = list
-                .items
-                .iter()
-                .position(|item| item.index_number == Some(self.item().index_number()))
-                .unwrap_or(0);
             // itemlist need wait for property binding to scroll
             spawn_g_timeout(glib::clone!(
                 #[weak]
@@ -603,7 +604,7 @@ impl ItemPage {
         }
     }
 
-    fn set_episode_list(&self, list: &[SimpleListItem]) {
+    fn set_episode_list(&self, list: Vec<SimpleListItem>) {
         let imp = self.imp();
         let store_model = imp.selection.model();
         let Some(store) = store_model.and_downcast_ref::<gio::ListStore>() else {
@@ -624,7 +625,7 @@ impl ItemPage {
 
         store.extend_from_slice(&items);
 
-        imp.episode_list_vec.replace(list.to_owned());
+        imp.episode_list_vec.replace(list);
         imp.episode_stack.set_visible_child_name("view");
     }
 
@@ -659,7 +660,7 @@ impl ItemPage {
             }
         };
 
-        self.set_episode_list(&list.items);
+        self.set_episode_list(list.items);
     }
 
     async fn set_shows_next_up(&self, id: &str) -> Option<TuItem> {
@@ -673,11 +674,13 @@ impl ItemPage {
                 }
             };
 
-        let next_up_item = next_up.items.first()?;
+        let next_up_item = next_up.items.into_iter().next()?;
 
-        self.set_now_item::<false>(&TuItem::from_simple(next_up_item, None));
+        let tu_item = TuItem::from_simple_owned(next_up_item, None);
 
-        Some(TuItem::from_simple(next_up_item, None))
+        self.set_now_item::<false>(&tu_item);
+
+        Some(tu_item)
     }
 
     fn set_now_item<const IS_VIDEO: bool>(&self, item: &TuItem) {

--- a/src/ui/widgets/lazy_diff_view/mod.rs
+++ b/src/ui/widgets/lazy_diff_view/mod.rs
@@ -534,11 +534,15 @@ impl LazyDiffView {
     fn visible_inserted_keys(&self, old_items: &[RowData]) -> HashSet<String> {
         let old_keys = old_items
             .iter()
-            .map(|row| row.key.clone())
+            .map(|row| row.key.as_str())
             .collect::<HashSet<_>>();
-        self.visible_range()
-            .map(|index| self.imp().items.borrow()[index].key.clone())
-            .filter(|key| !old_keys.contains(key))
+        let visiable_range = self.visible_range();
+        let items = self.imp().items.borrow();
+        visiable_range
+            .filter_map(|index| {
+                let key = items.get(index)?.key.as_str();
+                (!old_keys.contains(key)).then(|| key.to_string())
+            })
             .collect()
     }
 
@@ -834,20 +838,8 @@ impl LazyDiffView {
     }
 
     fn reposition_active_rows(&self) {
-        let indices = self
-            .imp()
-            .items
-            .borrow()
-            .iter()
-            .enumerate()
-            .map(|(index, row)| (row.key.clone(), index))
-            .collect::<HashMap<_, _>>();
-
-        for row_data in self.imp().items.borrow().iter() {
+        for (index, row_data) in self.imp().items.borrow().iter().enumerate() {
             let Some(row) = self.imp().rows.borrow().get(&row_data.key).cloned() else {
-                continue;
-            };
-            let Some(index) = indices.get(&row_data.key).copied() else {
                 continue;
             };
             self.position_row(&row, index);

--- a/src/ui/widgets/lazy_diff_view/mod.rs
+++ b/src/ui/widgets/lazy_diff_view/mod.rs
@@ -482,14 +482,13 @@ impl LazyDiffView {
 
     fn apply_items(&self, new_items: Vec<RowData>) {
         let imp = self.imp();
-        let old_items = imp.items.borrow().clone();
         let active_keys = imp.rows.borrow().keys().cloned().collect::<HashSet<_>>();
-        let old_indices = active_indices(&old_items, &active_keys);
+        let old_indices = active_indices(&imp.items.borrow(), &active_keys);
         let new_indices = active_indices(&new_items, &active_keys);
 
         self.animate_removed_rows(&active_keys, &old_indices, &new_indices);
         let reorder_offsets = self.reorder_offsets(&old_indices, &new_indices);
-        *imp.items.borrow_mut() = new_items;
+        let old_items = imp.items.replace(new_items);
         self.reset_item_extent();
         self.resize_viewport();
 

--- a/src/ui/widgets/liked.rs
+++ b/src/ui/widgets/liked.rs
@@ -181,7 +181,7 @@ impl LikedPage {
             return;
         }
 
-        hortu.set_items(&results.items);
+        hortu.set_items(results.items);
 
         hortu.connect_morebutton(glib::clone!(
             #[weak(rename_to = obj)]

--- a/src/ui/widgets/metadata_dialog.rs
+++ b/src/ui/widgets/metadata_dialog.rs
@@ -246,9 +246,8 @@ impl MetadataDialog {
         match spawn_tokio(async move { JELLYFIN_CLIENT.get_edit_info(&id).await }).await {
             Ok(metadata) => {
                 self.imp().stack.set_visible_child_name("page");
-                let value = metadata.to_owned();
-                let _ = self.imp().value.set(value);
-                let Ok(item) = serde_json::from_value::<SimpleListItem>(metadata.to_owned()) else {
+                let _ = self.imp().value.set(metadata.to_owned());
+                let Ok(item) = serde_json::from_value::<SimpleListItem>(metadata) else {
                     return;
                 };
                 self.imp().load_data(item);

--- a/src/ui/widgets/music_album.rs
+++ b/src/ui/widgets/music_album.rs
@@ -259,7 +259,7 @@ impl AlbumPage {
                         songs.items.sort_by_key(|song| song.index_number);
                     }
                     for song in songs.items {
-                        let item = TuItem::from_simple(&song, None);
+                        let item = TuItem::from_simple_owned(song, None);
                         let parent_index_number = if view_type == SongWidgetView::MusicAlbumItem {
                             item.parent_index_number()
                         } else {

--- a/src/ui/widgets/music_album.rs
+++ b/src/ui/widgets/music_album.rs
@@ -379,7 +379,7 @@ impl AlbumPage {
                     }
 
                     hortu.set_visible(true);
-                    hortu.set_items(&data.items);
+                    hortu.set_items(data.items);
                 }
                 CacheEvent::Error(e) => {
                     self.toast(e.to_user_facing());

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -231,7 +231,7 @@ impl OtherPage {
             self.add_external_link_horbu(&links);
         }
         if let Some(actors) = item.people {
-            self.add_actor_item_hortu(&actors);
+            self.add_actor_item_hortu(actors);
         }
         if let Some(studios) = item.studios {
             self.add_sgt_item_horbu(&self.imp().studioshorbu, &studios, "Studios");
@@ -371,7 +371,7 @@ impl OtherPage {
         tu_obj.activate(view);
     }
 
-    pub fn add_actor_item_hortu(&self, items: &[SimpleListItem]) {
+    pub fn add_actor_item_hortu(&self, items: Vec<SimpleListItem>) {
         let hortu = self.imp().actorhortu.get();
         hortu.set_items(items);
     }
@@ -412,9 +412,9 @@ impl OtherPage {
                 _ => {}
             });
 
-        imp.moviehortu.set_items(&movies);
-        imp.serieshortu.set_items(&series);
-        imp.episodehortu.set_items(&episodes);
+        imp.moviehortu.set_items(movies);
+        imp.serieshortu.set_items(series);
+        imp.episodehortu.set_items(episodes);
     }
 
     async fn hortu_set_actor_list(&self, type_: &str) {
@@ -496,7 +496,7 @@ impl OtherPage {
         while let Some(event) = events.recv().await {
             match event {
                 CacheEvent::Data { data, .. } => {
-                    hortu.set_items(&data.items);
+                    hortu.set_items(data.items);
                 }
                 CacheEvent::Error(e) => {
                     self.toast(e.to_user_facing());

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -338,7 +338,7 @@ impl OtherPage {
                     store.remove_all();
 
                     for item in data.items {
-                        let tu_item = TuItem::from_simple(&item, None);
+                        let tu_item = TuItem::from_simple_owned(item, None);
                         tu_item.set_is_resume(true);
                         let tu_item = TuObject::new(&tu_item);
                         store.append(&tu_item);

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -163,6 +163,12 @@ impl PictureLoader {
                             move |r| match r {
                                 Ok(pixbuf) => {
                                     obj.imp().picture.set_paintable(Some(
+                                        #[allow(deprecated)]
+                                        // FIXME: `Texture::for_pixbuf` is deprecated since GTK 4.20.
+                                        // GTK recommends libglycin for loading images into `GdkTexture`, but
+                                        // glycin currently only works on Linux, so keep this fallback for now.
+                                        // https://docs.gtk.org/gdk4/ctor.Texture.new_for_pixbuf.html
+                                        // https://docs.rs/crate/glycin/latest
                                         &gtk::gdk::Texture::for_pixbuf(&pixbuf),
                                     ));
                                     obj.imp().spinner.set_visible(false);

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -158,7 +158,7 @@ impl TuViewScrolled {
         let prefer_size = *self.imp().prefer_size_cache.borrow();
 
         for item in items {
-            let tu_item = TuItem::from_simple(&item, None);
+            let tu_item = TuItem::from_simple_owned(item, None);
             tu_item.set_is_resume(is_resume);
             tu_item.set_prefer_poster(prefer_poster);
             tu_item.set_prefer_size(prefer_size);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -81,11 +81,7 @@ pub enum CacheSource {
 }
 
 pub enum CacheEvent<T> {
-    Data {
-        #[allow(dead_code)]
-        source: CacheSource,
-        data: T,
-    },
+    Data { source: CacheSource, data: T },
     Error(anyhow::Error),
 }
 


### PR DESCRIPTION
~~在 AI 辅助指明大方向下的人类智慧结晶（bushi~~

让 AI 简单查了查比较明显的冗余 clone 然后一个个修的，主要包括：

1. 高强度使用的 TuItem::from_simple 方法内部有隐式 clone，引入新的 TuItem::from_simple_owned 在明确具有所有权的位置避免 clone（事实上绝大部分位置都有所有权）；
2. 很多接受 &[] 但实际在内部 to_owned() 的地方也改成了接受 Vec<>，原因与 1 相同；
3. 对于明显不需要 clone 的情况，做微小修改省去 clone，例如 iter 后 clone 修改为 into_iter；
4. 对于某些具体逻辑，重构为不需要所有权的等价写法，例如调整语句顺序、调整 HashSet<String> 为 HashSet<&str> 等。

由于有些地方涉及到了具体的逻辑重构，因此整体上改动比上个 PR 复杂一些。