### PR TITLE
perf: significantly optimize library scrolling performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2768,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3667,6 +3667,7 @@ dependencies = [
  "mpris-server",
  "once_cell",
  "rand",
+ "rayon",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing = "0.1"
 gst = { version = "0.25", package = "gstreamer" }
 url = "2.5.8"
 image = "0.25"
+rayon = "1.12.0"
 gettext-rs = { version = "~0.7", features = ["gettext-system"] }
 hostname = "0.4.2"
 epoxy = "0.1.0"

--- a/src/ui/models/mod.rs
+++ b/src/ui/models/mod.rs
@@ -1,21 +1,23 @@
 use once_cell::sync::Lazy;
 pub mod settings;
 pub use self::settings::Settings;
-use crate::client::jellyfin_client::JELLYFIN_CLIENT;
+use crate::{
+    client::jellyfin_client::JELLYFIN_CLIENT,
+    utils::spawn_tokio_blocking,
+};
 pub static SETTINGS: Lazy<Settings> = Lazy::new(Settings::default);
 
 pub static CACHE_PATH: Lazy<std::path::PathBuf> = Lazy::new(|| {
     let path = gtk::glib::user_cache_dir().join("tsukimi");
-    if !path.exists() {
-        std::fs::create_dir_all(&path).expect("Failed to create directory");
-    }
+    std::fs::create_dir_all(&path).expect("Failed to create directory");
     path
 });
 
 pub async fn jellyfin_cache_path() -> std::path::PathBuf {
     let path = CACHE_PATH.join(&JELLYFIN_CLIENT.session().server_name_hash);
-    if !path.exists() {
+    spawn_tokio_blocking(move || {
         std::fs::create_dir_all(&path).expect("Failed to create directory");
-    }
-    path
+        path
+    })
+    .await
 }

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -69,7 +69,6 @@ use crate::{
             list::ListPage,
             music_album::AlbumPage,
             other::OtherPage,
-            picture_loader::PictureLoader,
             single_grid::{
                 SingleGrid,
                 imp::ListType,
@@ -117,7 +116,6 @@ pub enum PreferPoster {
 pub mod imp {
     use glib::DateTime;
     use gtk::glib::Properties;
-    use once_cell::sync::OnceCell;
 
     use super::*;
 
@@ -201,8 +199,6 @@ pub mod imp {
         path: RefCell<Option<String>>,
         #[property(get, set)]
         playback_position_ticks: RefCell<u64>,
-
-        pub loaded_picture_loader: OnceCell<PictureLoader>,
     }
 
     #[glib::derived_properties]
@@ -763,14 +759,6 @@ impl TuItem {
 
     pub fn can_direct_play(&self) -> bool {
         matches!(self.item_type().as_str(), MOVIE | EPISODE) && self.is_resume()
-    }
-
-    pub fn set_loaded_picture_loader(&self, picture_loader: PictureLoader) {
-        let _ = self.imp().loaded_picture_loader.set(picture_loader);
-    }
-
-    pub fn loaded_picture_loader(&self) -> Option<PictureLoader> {
-        self.imp().loaded_picture_loader.get().cloned()
     }
 }
 

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -4,10 +4,11 @@ use adw::prelude::*;
 use gettextrs::gettext;
 use glib::DateTime;
 use gtk::{
-    GestureClick, gio, glib::{
+    gio,
+    glib::{
         self,
         subclass::prelude::*,
-    }
+    },
 };
 
 #[allow(dead_code)] //FIXME: refactor with this
@@ -115,10 +116,8 @@ pub enum PreferPoster {
 
 pub mod imp {
     use glib::DateTime;
-    use gtk::{GestureClick, glib::Properties};
-use once_cell::sync::OnceCell;
-
-    use crate::ui::widgets::picture_loader::PictureLoader;
+    use gtk::glib::Properties;
+    use once_cell::sync::OnceCell;
 
     use super::*;
 

--- a/src/ui/widgets/image_paintable.rs
+++ b/src/ui/widgets/image_paintable.rs
@@ -34,52 +34,12 @@ use tracing::error;
 
 /// A single frame of an animation.
 pub struct Frame {
-    pub texture: gdk::Texture,
-    pub duration: Duration,
-}
-
-pub struct DecodedFrame {
-    pub bytes: Vec<u8>,
-    pub layout: SampleLayout,
-    pub format: DecodedFormat,
-    pub duration: Duration,
+    texture: gdk::Texture,
+    duration: Duration,
 }
 
 pub struct DecodedPaintable {
-    pub frames: Vec<DecodedFrame>,
-}
-
-pub enum DecodedFormat {
-    Rgb8,
-    Rgba8,
-    Rgb16,
-    Rgba16,
-    Rgb32F,
-    Rgba32F,
-}
-
-impl From<image::Frame> for Frame {
-    fn from(f: image::Frame) -> Self {
-        let mut duration = Duration::from(f.delay());
-
-        // The convention is to use 100 milliseconds duration if it is defined as 0.
-        if duration.is_zero() {
-            duration = Duration::from_millis(100);
-        }
-
-        let sample = f.into_buffer().into_flat_samples();
-        let texture = texture_from_data(
-            &sample.samples,
-            sample.layout,
-            gdk::MemoryFormat::R8g8b8a8,
-            image::ColorType::Rgba8.bytes_per_pixel(),
-        );
-
-        Frame {
-            texture: texture.upcast(),
-            duration,
-        }
-    }
+    frames: Vec<Frame>,
 }
 
 mod imp {
@@ -212,21 +172,7 @@ impl ImagePaintable {
 
     pub fn from_decoded(decoded: DecodedPaintable) -> Self {
         let obj = glib::Object::new::<Self>();
-        let frames = decoded
-            .frames
-            .into_iter()
-            .map(Frame::from)
-            .collect::<Vec<_>>();
-
-        if frames.len() == 1 {
-            if let Some(frame) = frames.into_iter().next() {
-                obj.imp().frame.replace(Some(frame.texture));
-            }
-        } else {
-            obj.imp().frames.replace(Some(frames));
-            obj.update_frame();
-        }
-
+        obj.load_decoded(decoded);
         obj
     }
 
@@ -245,7 +191,7 @@ impl ImagePaintable {
                     .into_frames()
                     .collect_frames()?
                     .into_iter()
-                    .map(DecodedFrame::from)
+                    .map(Frame::from)
                     .collect()
             }
             image::ImageFormat::Png => {
@@ -256,10 +202,10 @@ impl ImagePaintable {
                         .into_frames()
                         .collect_frames()?
                         .into_iter()
-                        .map(DecodedFrame::from)
+                        .map(Frame::from)
                         .collect()
                 } else {
-                    vec![DecodedFrame::from(DynamicImage::from_decoder(decoder)?)]
+                    vec![Frame::from(DynamicImage::from_decoder(decoder)?)]
                 }
             }
             image::ImageFormat::WebP => {
@@ -269,13 +215,13 @@ impl ImagePaintable {
                         .into_frames()
                         .collect_frames()?
                         .into_iter()
-                        .map(DecodedFrame::from)
+                        .map(Frame::from)
                         .collect()
                 } else {
-                    vec![DecodedFrame::from(DynamicImage::from_decoder(decoder)?)]
+                    vec![Frame::from(DynamicImage::from_decoder(decoder)?)]
                 }
             }
-            _ => vec![DecodedFrame::from(image::load(read, format)?)],
+            _ => vec![Frame::from(image::load(read, format)?)],
         };
 
         Ok(DecodedPaintable { frames })
@@ -297,169 +243,25 @@ impl ImagePaintable {
 
         let reader = reader.with_guessed_format()?;
 
-        obj.load_inner(reader)?;
+        let decoded =
+            Self::decode_reader(reader).map_err(|error| -> Box<dyn std::error::Error> { error })?;
+        obj.load_decoded(decoded);
 
         Ok(obj)
     }
 
-    /// Load an image or animation from the given reader.
-    fn load_inner<R: BufRead + Seek>(
-        &self, reader: image::ImageReader<R>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn load_decoded(&self, decoded: DecodedPaintable) {
         let imp = self.imp();
-        let format = reader.format().ok_or("Could not detect image format")?;
+        let frames = decoded.frames;
 
-        let read = reader.into_inner();
-
-        // Handle animations.
-        match format {
-            image::ImageFormat::Gif => {
-                let decoder = GifDecoder::new(read)?;
-
-                let frames = decoder
-                    .into_frames()
-                    .collect_frames()?
-                    .into_iter()
-                    .map(Frame::from)
-                    .collect::<Vec<_>>();
-
-                if frames.len() == 1 {
-                    if let Some(frame) = frames.into_iter().next() {
-                        imp.frame.replace(Some(frame.texture));
-                    }
-                } else {
-                    imp.frames.replace(Some(frames));
-                    self.update_frame();
-                }
+        if frames.len() == 1 {
+            if let Some(frame) = frames.into_iter().next() {
+                imp.frame.replace(Some(frame.texture));
             }
-            image::ImageFormat::Png => {
-                let decoder = PngDecoder::new(read)?;
-
-                if decoder.is_apng().unwrap_or_default() {
-                    let decoder = decoder.apng()?;
-                    let frames = decoder
-                        .into_frames()
-                        .collect_frames()?
-                        .into_iter()
-                        .map(Frame::from)
-                        .collect::<Vec<_>>();
-                    imp.frames.replace(Some(frames));
-                    self.update_frame();
-                } else {
-                    let image = DynamicImage::from_decoder(decoder)?;
-                    self.set_image(image);
-                }
-            }
-            image::ImageFormat::WebP => {
-                let decoder = WebPDecoder::new(read)?;
-
-                if decoder.has_animation() {
-                    let frames = decoder
-                        .into_frames()
-                        .collect_frames()?
-                        .into_iter()
-                        .map(Frame::from)
-                        .collect::<Vec<_>>();
-                    imp.frames.replace(Some(frames));
-                    self.update_frame();
-                } else {
-                    let image = DynamicImage::from_decoder(decoder)?;
-                    self.set_image(image);
-                }
-            }
-            _ => {
-                let image = image::load(read, format)?;
-                self.set_image(image);
-            }
+        } else {
+            imp.frames.replace(Some(frames));
+            self.update_frame();
         }
-
-        Ok(())
-    }
-
-    /// Set the image that is displayed by this paintable.
-    fn set_image(&self, image: DynamicImage) {
-        let texture = match image.color() {
-            image::ColorType::L8 | image::ColorType::Rgb8 => {
-                let sample = image.into_rgb8().into_flat_samples();
-                texture_from_data(
-                    &sample.samples,
-                    sample.layout,
-                    gdk::MemoryFormat::R8g8b8,
-                    image::ColorType::Rgb8.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::La8 | image::ColorType::Rgba8 => {
-                let sample = image.into_rgba8().into_flat_samples();
-                texture_from_data(
-                    &sample.samples,
-                    sample.layout,
-                    gdk::MemoryFormat::R8g8b8a8,
-                    image::ColorType::Rgba8.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::L16 | image::ColorType::Rgb16 => {
-                let sample = image.into_rgb16().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R16g16b16,
-                    image::ColorType::Rgb16.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::La16 | image::ColorType::Rgba16 => {
-                let sample = image.into_rgba16().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R16g16b16a16,
-                    image::ColorType::Rgba16.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::Rgb32F => {
-                let sample = image.into_rgb32f().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R32g32b32Float,
-                    image::ColorType::Rgb32F.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::Rgba32F => {
-                let sample = image.into_rgb32f().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R32g32b32Float,
-                    image::ColorType::Rgb32F.bytes_per_pixel(),
-                )
-            }
-            c => {
-                error!("Received image of unsupported color format: {c:?}");
-                return;
-            }
-        };
-
-        self.imp().frame.replace(Some(texture.upcast()));
     }
 
     /// Creates a new paintable by loading an image from the given file.
@@ -527,7 +329,7 @@ impl ImagePaintable {
     }
 }
 
-impl From<image::Frame> for DecodedFrame {
+impl From<image::Frame> for Frame {
     fn from(frame: image::Frame) -> Self {
         let mut duration = Duration::from(frame.delay());
 
@@ -537,34 +339,38 @@ impl From<image::Frame> for DecodedFrame {
 
         let sample = frame.into_buffer().into_flat_samples();
         Self {
-            bytes: sample.samples,
-            layout: sample.layout,
-            format: DecodedFormat::Rgba8,
+            texture: texture_from_data(
+                &sample.samples,
+                sample.layout,
+                gdk::MemoryFormat::R8g8b8a8,
+                image::ColorType::Rgba8.bytes_per_pixel(),
+            )
+            .upcast(),
             duration,
         }
     }
 }
 
-impl From<DynamicImage> for DecodedFrame {
+impl From<DynamicImage> for Frame {
     fn from(image: DynamicImage) -> Self {
-        match image.color() {
+        let texture = match image.color() {
             image::ColorType::L8 | image::ColorType::Rgb8 => {
                 let sample = image.into_rgb8().into_flat_samples();
-                Self {
-                    bytes: sample.samples,
-                    layout: sample.layout,
-                    format: DecodedFormat::Rgb8,
-                    duration: Duration::ZERO,
-                }
+                texture_from_data(
+                    &sample.samples,
+                    sample.layout,
+                    gdk::MemoryFormat::R8g8b8,
+                    image::ColorType::Rgb8.bytes_per_pixel(),
+                )
             }
             image::ColorType::La8 | image::ColorType::Rgba8 => {
                 let sample = image.into_rgba8().into_flat_samples();
-                Self {
-                    bytes: sample.samples,
-                    layout: sample.layout,
-                    format: DecodedFormat::Rgba8,
-                    duration: Duration::ZERO,
-                }
+                texture_from_data(
+                    &sample.samples,
+                    sample.layout,
+                    gdk::MemoryFormat::R8g8b8a8,
+                    image::ColorType::Rgba8.bytes_per_pixel(),
+                )
             }
             image::ColorType::L16 | image::ColorType::Rgb16 => {
                 let sample = image.into_rgb16().into_flat_samples();
@@ -573,12 +379,12 @@ impl From<DynamicImage> for DecodedFrame {
                     .into_iter()
                     .flat_map(|b| b.to_ne_bytes())
                     .collect::<Vec<_>>();
-                Self {
-                    bytes,
-                    layout: sample.layout,
-                    format: DecodedFormat::Rgb16,
-                    duration: Duration::ZERO,
-                }
+                texture_from_data(
+                    &bytes,
+                    sample.layout,
+                    gdk::MemoryFormat::R16g16b16,
+                    image::ColorType::Rgb16.bytes_per_pixel(),
+                )
             }
             image::ColorType::La16 | image::ColorType::Rgba16 => {
                 let sample = image.into_rgba16().into_flat_samples();
@@ -587,12 +393,12 @@ impl From<DynamicImage> for DecodedFrame {
                     .into_iter()
                     .flat_map(|b| b.to_ne_bytes())
                     .collect::<Vec<_>>();
-                Self {
-                    bytes,
-                    layout: sample.layout,
-                    format: DecodedFormat::Rgba16,
-                    duration: Duration::ZERO,
-                }
+                texture_from_data(
+                    &bytes,
+                    sample.layout,
+                    gdk::MemoryFormat::R16g16b16a16,
+                    image::ColorType::Rgba16.bytes_per_pixel(),
+                )
             }
             image::ColorType::Rgb32F => {
                 let sample = image.into_rgb32f().into_flat_samples();
@@ -601,12 +407,12 @@ impl From<DynamicImage> for DecodedFrame {
                     .into_iter()
                     .flat_map(|b| b.to_ne_bytes())
                     .collect::<Vec<_>>();
-                Self {
-                    bytes,
-                    layout: sample.layout,
-                    format: DecodedFormat::Rgb32F,
-                    duration: Duration::ZERO,
-                }
+                texture_from_data(
+                    &bytes,
+                    sample.layout,
+                    gdk::MemoryFormat::R32g32b32Float,
+                    image::ColorType::Rgb32F.bytes_per_pixel(),
+                )
             }
             image::ColorType::Rgba32F => {
                 let sample = image.into_rgba32f().into_flat_samples();
@@ -615,64 +421,28 @@ impl From<DynamicImage> for DecodedFrame {
                     .into_iter()
                     .flat_map(|b| b.to_ne_bytes())
                     .collect::<Vec<_>>();
-                Self {
-                    bytes,
-                    layout: sample.layout,
-                    format: DecodedFormat::Rgba32F,
-                    duration: Duration::ZERO,
-                }
+                texture_from_data(
+                    &bytes,
+                    sample.layout,
+                    gdk::MemoryFormat::R32g32b32a32Float,
+                    image::ColorType::Rgba32F.bytes_per_pixel(),
+                )
             }
             color => {
                 error!("Received image of unsupported color format: {color:?}");
                 let sample = image.into_rgba8().into_flat_samples();
-                Self {
-                    bytes: sample.samples,
-                    layout: sample.layout,
-                    format: DecodedFormat::Rgba8,
-                    duration: Duration::ZERO,
-                }
+                texture_from_data(
+                    &sample.samples,
+                    sample.layout,
+                    gdk::MemoryFormat::R8g8b8a8,
+                    image::ColorType::Rgba8.bytes_per_pixel(),
+                )
             }
-        }
-    }
-}
+        };
 
-impl From<DecodedFrame> for Frame {
-    fn from(frame: DecodedFrame) -> Self {
-        let (format, bpp) = frame.format.memory_format_and_bpp();
-        Frame {
-            texture: texture_from_data(&frame.bytes, frame.layout, format, bpp).upcast(),
-            duration: frame.duration,
-        }
-    }
-}
-
-impl DecodedFormat {
-    fn memory_format_and_bpp(&self) -> (gdk::MemoryFormat, u8) {
-        match self {
-            Self::Rgb8 => (
-                gdk::MemoryFormat::R8g8b8,
-                image::ColorType::Rgb8.bytes_per_pixel(),
-            ),
-            Self::Rgba8 => (
-                gdk::MemoryFormat::R8g8b8a8,
-                image::ColorType::Rgba8.bytes_per_pixel(),
-            ),
-            Self::Rgb16 => (
-                gdk::MemoryFormat::R16g16b16,
-                image::ColorType::Rgb16.bytes_per_pixel(),
-            ),
-            Self::Rgba16 => (
-                gdk::MemoryFormat::R16g16b16a16,
-                image::ColorType::Rgba16.bytes_per_pixel(),
-            ),
-            Self::Rgb32F => (
-                gdk::MemoryFormat::R32g32b32Float,
-                image::ColorType::Rgb32F.bytes_per_pixel(),
-            ),
-            Self::Rgba32F => (
-                gdk::MemoryFormat::R32g32b32a32Float,
-                image::ColorType::Rgba32F.bytes_per_pixel(),
-            ),
+        Self {
+            texture: texture.upcast(),
+            duration: Duration::ZERO,
         }
     }
 }

--- a/src/ui/widgets/image_paintable.rs
+++ b/src/ui/widgets/image_paintable.rs
@@ -3,6 +3,8 @@ use std::{
         BufRead,
         BufReader,
         Cursor,
+        Error as IoError,
+        ErrorKind,
         Seek,
     },
     time::Duration,
@@ -20,6 +22,7 @@ use image::{
     AnimationDecoder,
     DynamicImage,
     ImageFormat,
+    ImageReader,
     codecs::{
         gif::GifDecoder,
         png::PngDecoder,
@@ -33,6 +36,26 @@ use tracing::error;
 pub struct Frame {
     pub texture: gdk::Texture,
     pub duration: Duration,
+}
+
+pub struct DecodedFrame {
+    pub bytes: Vec<u8>,
+    pub layout: SampleLayout,
+    pub format: DecodedFormat,
+    pub duration: Duration,
+}
+
+pub struct DecodedPaintable {
+    pub frames: Vec<DecodedFrame>,
+}
+
+pub enum DecodedFormat {
+    Rgb8,
+    Rgba8,
+    Rgb16,
+    Rgba16,
+    Rgb32F,
+    Rgba32F,
 }
 
 impl From<image::Frame> for Frame {
@@ -173,6 +196,85 @@ glib::wrapper! {
 }
 
 impl ImagePaintable {
+    pub fn decode_bytes(
+        bytes: glib::Bytes,
+    ) -> Result<DecodedPaintable, Box<dyn std::error::Error + Send + Sync>> {
+        let reader = Cursor::new(bytes);
+        let reader = ImageReader::new(reader).with_guessed_format()?;
+        Self::decode_reader(reader)
+    }
+
+    pub fn from_decoded(decoded: DecodedPaintable) -> Self {
+        let obj = glib::Object::new::<Self>();
+        let frames = decoded
+            .frames
+            .into_iter()
+            .map(Frame::from)
+            .collect::<Vec<_>>();
+
+        if frames.len() == 1 {
+            if let Some(frame) = frames.into_iter().next() {
+                obj.imp().frame.replace(Some(frame.texture));
+            }
+        } else {
+            obj.imp().frames.replace(Some(frames));
+            obj.update_frame();
+        }
+
+        obj
+    }
+
+    fn decode_reader<R: BufRead + Seek>(
+        reader: ImageReader<R>,
+    ) -> Result<DecodedPaintable, Box<dyn std::error::Error + Send + Sync>> {
+        let format = reader
+            .format()
+            .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "Could not detect image format"))?;
+
+        let read = reader.into_inner();
+        let frames = match format {
+            image::ImageFormat::Gif => {
+                let decoder = GifDecoder::new(read)?;
+                decoder
+                    .into_frames()
+                    .collect_frames()?
+                    .into_iter()
+                    .map(DecodedFrame::from)
+                    .collect()
+            }
+            image::ImageFormat::Png => {
+                let decoder = PngDecoder::new(read)?;
+                if decoder.is_apng().unwrap_or_default() {
+                    decoder
+                        .apng()?
+                        .into_frames()
+                        .collect_frames()?
+                        .into_iter()
+                        .map(DecodedFrame::from)
+                        .collect()
+                } else {
+                    vec![DecodedFrame::from(DynamicImage::from_decoder(decoder)?)]
+                }
+            }
+            image::ImageFormat::WebP => {
+                let decoder = WebPDecoder::new(read)?;
+                if decoder.has_animation() {
+                    decoder
+                        .into_frames()
+                        .collect_frames()?
+                        .into_iter()
+                        .map(DecodedFrame::from)
+                        .collect()
+                } else {
+                    vec![DecodedFrame::from(DynamicImage::from_decoder(decoder)?)]
+                }
+            }
+            _ => vec![DecodedFrame::from(image::load(read, format)?)],
+        };
+
+        Ok(DecodedPaintable { frames })
+    }
+
     /// Load an image from the given reader in the optional format.
     ///
     /// The actual format will try to be guessed from the content.
@@ -416,6 +518,156 @@ impl ImagePaintable {
     /// Get the current frame of this `ImagePaintable`, if any.
     pub fn current_frame(&self) -> Option<gdk::Texture> {
         self.imp().frame.borrow().to_owned()
+    }
+}
+
+impl From<image::Frame> for DecodedFrame {
+    fn from(frame: image::Frame) -> Self {
+        let mut duration = Duration::from(frame.delay());
+
+        if duration.is_zero() {
+            duration = Duration::from_millis(100);
+        }
+
+        let sample = frame.into_buffer().into_flat_samples();
+        Self {
+            bytes: sample.samples,
+            layout: sample.layout,
+            format: DecodedFormat::Rgba8,
+            duration,
+        }
+    }
+}
+
+impl From<DynamicImage> for DecodedFrame {
+    fn from(image: DynamicImage) -> Self {
+        match image.color() {
+            image::ColorType::L8 | image::ColorType::Rgb8 => {
+                let sample = image.into_rgb8().into_flat_samples();
+                Self {
+                    bytes: sample.samples,
+                    layout: sample.layout,
+                    format: DecodedFormat::Rgb8,
+                    duration: Duration::ZERO,
+                }
+            }
+            image::ColorType::La8 | image::ColorType::Rgba8 => {
+                let sample = image.into_rgba8().into_flat_samples();
+                Self {
+                    bytes: sample.samples,
+                    layout: sample.layout,
+                    format: DecodedFormat::Rgba8,
+                    duration: Duration::ZERO,
+                }
+            }
+            image::ColorType::L16 | image::ColorType::Rgb16 => {
+                let sample = image.into_rgb16().into_flat_samples();
+                let bytes = sample
+                    .samples
+                    .into_iter()
+                    .flat_map(|b| b.to_ne_bytes())
+                    .collect::<Vec<_>>();
+                Self {
+                    bytes,
+                    layout: sample.layout,
+                    format: DecodedFormat::Rgb16,
+                    duration: Duration::ZERO,
+                }
+            }
+            image::ColorType::La16 | image::ColorType::Rgba16 => {
+                let sample = image.into_rgba16().into_flat_samples();
+                let bytes = sample
+                    .samples
+                    .into_iter()
+                    .flat_map(|b| b.to_ne_bytes())
+                    .collect::<Vec<_>>();
+                Self {
+                    bytes,
+                    layout: sample.layout,
+                    format: DecodedFormat::Rgba16,
+                    duration: Duration::ZERO,
+                }
+            }
+            image::ColorType::Rgb32F => {
+                let sample = image.into_rgb32f().into_flat_samples();
+                let bytes = sample
+                    .samples
+                    .into_iter()
+                    .flat_map(|b| b.to_ne_bytes())
+                    .collect::<Vec<_>>();
+                Self {
+                    bytes,
+                    layout: sample.layout,
+                    format: DecodedFormat::Rgb32F,
+                    duration: Duration::ZERO,
+                }
+            }
+            image::ColorType::Rgba32F => {
+                let sample = image.into_rgba32f().into_flat_samples();
+                let bytes = sample
+                    .samples
+                    .into_iter()
+                    .flat_map(|b| b.to_ne_bytes())
+                    .collect::<Vec<_>>();
+                Self {
+                    bytes,
+                    layout: sample.layout,
+                    format: DecodedFormat::Rgba32F,
+                    duration: Duration::ZERO,
+                }
+            }
+            color => {
+                error!("Received image of unsupported color format: {color:?}");
+                let sample = image.into_rgba8().into_flat_samples();
+                Self {
+                    bytes: sample.samples,
+                    layout: sample.layout,
+                    format: DecodedFormat::Rgba8,
+                    duration: Duration::ZERO,
+                }
+            }
+        }
+    }
+}
+
+impl From<DecodedFrame> for Frame {
+    fn from(frame: DecodedFrame) -> Self {
+        let (format, bpp) = frame.format.memory_format_and_bpp();
+        Frame {
+            texture: texture_from_data(&frame.bytes, frame.layout, format, bpp).upcast(),
+            duration: frame.duration,
+        }
+    }
+}
+
+impl DecodedFormat {
+    fn memory_format_and_bpp(&self) -> (gdk::MemoryFormat, u8) {
+        match self {
+            Self::Rgb8 => (
+                gdk::MemoryFormat::R8g8b8,
+                image::ColorType::Rgb8.bytes_per_pixel(),
+            ),
+            Self::Rgba8 => (
+                gdk::MemoryFormat::R8g8b8a8,
+                image::ColorType::Rgba8.bytes_per_pixel(),
+            ),
+            Self::Rgb16 => (
+                gdk::MemoryFormat::R16g16b16,
+                image::ColorType::Rgb16.bytes_per_pixel(),
+            ),
+            Self::Rgba16 => (
+                gdk::MemoryFormat::R16g16b16a16,
+                image::ColorType::Rgba16.bytes_per_pixel(),
+            ),
+            Self::Rgb32F => (
+                gdk::MemoryFormat::R32g32b32Float,
+                image::ColorType::Rgb32F.bytes_per_pixel(),
+            ),
+            Self::Rgba32F => (
+                gdk::MemoryFormat::R32g32b32a32Float,
+                image::ColorType::Rgba32F.bytes_per_pixel(),
+            ),
+        }
     }
 }
 

--- a/src/ui/widgets/image_paintable.rs
+++ b/src/ui/widgets/image_paintable.rs
@@ -124,7 +124,13 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for ImagePaintable {}
+    impl ObjectImpl for ImagePaintable {
+        fn dispose(&self) {
+            if let Some(source_id) = self.timeout_source_id.borrow_mut().take() {
+                source_id.remove();
+            }
+        }
+    }
 
     impl PaintableImpl for ImagePaintable {
         fn intrinsic_height(&self) -> i32 {

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -18,7 +18,10 @@ use tracing::{
 };
 
 use super::{
-    image_paintable::ImagePaintable,
+    image_paintable::{
+        DecodedPaintable,
+        ImagePaintable,
+    },
     utils::{
         TU_ITEM_POST_SIZE,
         TU_ITEM_VIDEO_SIZE,
@@ -33,9 +36,14 @@ use crate::{
     },
 };
 
+enum LoadedImage {
+    Texture(gtk::gdk::Texture),
+    Decoded(DecodedPaintable),
+}
+
 pub(crate) mod imp {
     use std::cell::{
-        OnceCell,
+        Cell,
         RefCell,
     };
 
@@ -47,13 +55,13 @@ pub(crate) mod imp {
     #[template(resource = "/moe/tsuna/tsukimi/ui/picture_loader.ui")]
     #[properties(wrapper_type = super::PictureLoader)]
     pub struct PictureLoader {
-        #[property(get, set, construct_only)]
-        pub id: OnceCell<String>,
-        #[property(get, set, construct_only)]
-        pub imagetype: OnceCell<String>,
-        #[property(get, set, nullable, construct_only)]
+        #[property(get, set)]
+        pub id: RefCell<String>,
+        #[property(get, set)]
+        pub imagetype: RefCell<String>,
+        #[property(get, set, nullable)]
         pub tag: RefCell<Option<String>>,
-        #[property(get, set, nullable, construct_only)]
+        #[property(get, set, nullable)]
         pub url: RefCell<Option<String>>,
         #[template_child]
         pub revealer: TemplateChild<gtk::Revealer>,
@@ -63,8 +71,10 @@ pub(crate) mod imp {
         pub spinner: TemplateChild<adw::Spinner>,
         #[template_child]
         pub broken: TemplateChild<gtk::Box>,
-        #[property(get, set, default = false, construct_only)]
-        pub animated: std::cell::Cell<bool>,
+        #[property(get, set, default = false)]
+        pub animated: Cell<bool>,
+        pub cancellable: RefCell<Option<gio::Cancellable>>,
+        pub generation: Cell<u64>,
     }
 
     #[glib::object_subclass]
@@ -90,16 +100,14 @@ pub(crate) mod imp {
             let obj = self.obj();
 
             if let Some(url) = obj.url() {
-                obj.load_pic_for_url(url);
+                obj.start_url_loading(url);
             } else {
-                spawn(clone!(
-                    #[weak]
-                    obj,
-                    async move {
-                        obj.load_pic().await;
-                    }
-                ));
+                obj.start_loading();
             }
+        }
+
+        fn dispose(&self) {
+            self.obj().cancel_loading();
         }
     }
 
@@ -138,8 +146,79 @@ impl PictureLoader {
             .build()
     }
 
+    pub fn reload(&self, id: &str, image_type: &str, tag: Option<String>, animated: bool) {
+        self.reset();
+        self.set_id(id);
+        self.set_imagetype(image_type);
+        self.set_tag(tag);
+        self.set_url(None::<String>);
+        self.set_animated(animated);
+        self.start_loading();
+    }
+
+    pub fn reset(&self) {
+        self.cancel_loading();
+    }
+
+    pub fn reset_in(widget: &gtk::Widget) {
+        if let Some(picture_loader) = widget.downcast_ref::<Self>() {
+            picture_loader.reset();
+            return;
+        }
+
+        if let Some(bin) = widget.downcast_ref::<adw::Bin>()
+            && let Some(child) = bin.child()
+        {
+            Self::reset_in(&child);
+        }
+    }
+
+    fn start_loading(&self) {
+        let (cancellable, generation) = self.new_request();
+        spawn(clone!(
+            #[weak(rename_to = obj)]
+            self,
+            #[strong]
+            cancellable,
+            async move {
+                obj.load_pic(cancellable, generation).await;
+            }
+        ));
+    }
+
+    fn start_url_loading(&self, url: String) {
+        let (cancellable, generation) = self.new_request();
+        self.load_pic_for_url(url, cancellable, generation);
+    }
+
+    fn new_request(&self) -> (gio::Cancellable, u64) {
+        if let Some(cancellable) = self.imp().cancellable.borrow_mut().take() {
+            cancellable.cancel();
+        }
+
+        let generation = self.imp().generation.get().wrapping_add(1);
+        self.imp().generation.set(generation);
+
+        let cancellable = gio::Cancellable::new();
+        self.imp().cancellable.replace(Some(cancellable.clone()));
+        (cancellable, generation)
+    }
+
+    pub fn cancel_loading(&self) {
+        if let Some(cancellable) = self.imp().cancellable.borrow_mut().take() {
+            cancellable.cancel();
+        }
+
+        let generation = self.imp().generation.get().wrapping_add(1);
+        self.imp().generation.set(generation);
+    }
+
+    fn is_current(&self, cancellable: &gio::Cancellable, generation: u64) -> bool {
+        !cancellable.is_cancelled() && self.imp().generation.get() == generation
+    }
+
     // for EuListItem
-    pub fn load_pic_for_url(&self, url: String) {
+    pub fn load_pic_for_url(&self, url: String, cancellable: gio::Cancellable, generation: u64) {
         let size = match self.imagetype().as_str() {
             "Primary" => &TU_ITEM_POST_SIZE,
             _ => &TU_ITEM_VIDEO_SIZE,
@@ -149,75 +228,179 @@ impl PictureLoader {
         self.imp().picture.set_height_request(size.1);
         self.imp().picture.set_content_fit(gtk::ContentFit::Contain);
 
-        gio::File::for_uri(&url).read_async(
-            glib::Priority::LOW,
-            None::<&gio::Cancellable>,
-            glib::clone!(
-                #[weak(rename_to = obj)]
-                self,
-                move |res| {
-                    if let Ok(stream) = res {
-                        gtk::gdk_pixbuf::Pixbuf::from_stream_async(
-                            &stream,
-                            None::<&gio::Cancellable>,
-                            move |r| match r {
-                                Ok(pixbuf) => {
-                                    obj.imp().picture.set_paintable(Some(
-                                        #[allow(deprecated)]
-                                        // FIXME: `Texture::for_pixbuf` is deprecated since GTK 4.20.
-                                        // GTK recommends libglycin for loading images into `GdkTexture`, but
-                                        // glycin currently only works on Linux, so keep this fallback for now.
-                                        // https://docs.gtk.org/gdk4/ctor.Texture.new_for_pixbuf.html
-                                        // https://docs.rs/crate/glycin/latest
-                                        &gtk::gdk::Texture::for_pixbuf(&pixbuf),
-                                    ));
-                                    obj.imp().spinner.set_visible(false);
-                                    obj.imp().revealer.set_reveal_child(true);
-                                }
-                                Err(_) => {
-                                    obj.imp().broken.set_visible(true);
-                                }
-                            },
-                        );
-                    }
-                }
-            ),
+        let file = gio::File::for_uri(&url);
+        self.load_file_bytes(file, None, cancellable, generation, false);
+    }
+
+    pub async fn load_pic(&self, cancellable: gio::Cancellable, generation: u64) {
+        if !self.is_current(&cancellable, generation) {
+            return;
+        }
+
+        let cache_file_path = self.cache_file().await;
+        self.reveal_picture(cache_file_path, cancellable, generation, true);
+    }
+
+    pub fn reveal_picture(
+        &self, cache_file_path: PathBuf, cancellable: gio::Cancellable, generation: u64,
+        fetch_on_error: bool,
+    ) {
+        let file = gio::File::for_path(&cache_file_path);
+        self.load_file_bytes(
+            file,
+            Some(cache_file_path),
+            cancellable,
+            generation,
+            fetch_on_error,
         );
     }
 
-    pub async fn load_pic(&self) {
-        let cache_file_path = self.cache_file().await;
-        self.reveal_picture::<true>(&cache_file_path);
-        self.get_file(cache_file_path);
-    }
-
-    pub fn reveal_picture<const R: bool>(&self, cache_file_path: &PathBuf) {
-        let imp = self.imp();
-
-        if cache_file_path.exists() {
-            let file = gio::File::for_path(cache_file_path);
-            if self.animated() {
-                let paintable = ImagePaintable::from_file(&file);
-                imp.picture.set_paintable(paintable.ok().as_ref());
-            } else {
-                imp.picture.set_file(Some(&file));
-            }
-        } else {
-            if R {
-                return;
-            }
-            imp.broken.set_visible(true);
+    fn set_picture_visible(&self, cancellable: gio::Cancellable, generation: u64) {
+        if !self.is_current(&cancellable, generation) {
+            return;
         }
 
+        let imp = self.imp();
         imp.spinner.set_visible(false);
-
         spawn(clone!(
             #[weak]
             imp,
+            #[strong]
+            cancellable,
             async move {
+                if cancellable.is_cancelled() {
+                    return;
+                }
                 imp.revealer.set_reveal_child(true);
             }
         ));
+    }
+
+    fn set_broken(&self, cancellable: gio::Cancellable, generation: u64) {
+        if !self.is_current(&cancellable, generation) {
+            return;
+        }
+
+        let imp = self.imp();
+        imp.broken.set_visible(true);
+        imp.spinner.set_visible(false);
+        spawn(clone!(
+            #[weak]
+            imp,
+            #[strong]
+            cancellable,
+            async move {
+                if cancellable.is_cancelled() {
+                    return;
+                }
+                imp.revealer.set_reveal_child(true);
+            }
+        ));
+    }
+
+    fn load_file_bytes(
+        &self, file: gio::File, cache_file_path: Option<PathBuf>, cancellable: gio::Cancellable,
+        generation: u64, fetch_on_error: bool,
+    ) {
+        if !self.is_current(&cancellable, generation) {
+            return;
+        }
+
+        let weak_self: glib::SendWeakRef<Self> = self.downgrade().into();
+        let read_cancellable = cancellable.clone();
+
+        file.load_bytes_async(Some(&cancellable), move |res| {
+            let cancellable = read_cancellable;
+
+            if cancellable.is_cancelled() {
+                return;
+            }
+
+            let Ok((bytes, _etag)) = res else {
+                let weak_self = weak_self.into_weak_ref();
+                let Some(obj) = weak_self.upgrade() else {
+                    return;
+                };
+
+                if !obj.is_current(&cancellable, generation) {
+                    return;
+                }
+
+                if fetch_on_error {
+                    if let Some(path) = cache_file_path {
+                        obj.get_file(path, cancellable, generation);
+                    }
+                } else {
+                    obj.set_broken(cancellable, generation);
+                }
+                return;
+            };
+
+            let animated = {
+                let weak_self = weak_self.clone().into_weak_ref();
+                let Some(obj) = weak_self.upgrade() else {
+                    return;
+                };
+
+                if !obj.is_current(&cancellable, generation) {
+                    return;
+                }
+
+                obj.animated()
+            };
+
+            rayon::spawn(move || {
+                let decoded = Self::decode_bytes(bytes, animated);
+
+                glib::idle_add_once(move || {
+                    let weak_self = weak_self.into_weak_ref();
+                    let Some(obj) = weak_self.upgrade() else {
+                        return;
+                    };
+
+                    if !obj.is_current(&cancellable, generation) {
+                        return;
+                    }
+
+                    match decoded {
+                        Ok(LoadedImage::Texture(texture)) => {
+                            obj.imp().picture.set_paintable(Some(&texture));
+                            obj.set_picture_visible(cancellable, generation);
+                        }
+                        Ok(LoadedImage::Decoded(decoded)) => {
+                            let paintable = ImagePaintable::from_decoded(decoded);
+                            obj.imp().picture.set_paintable(Some(&paintable));
+                            obj.set_picture_visible(cancellable, generation);
+                        }
+                        Err(_) if fetch_on_error => {
+                            println!("Failed to decode image bytes, fetching from network...");
+                            if let Some(path) = cache_file_path {
+                                obj.get_file(path, cancellable, generation);
+                            } else {
+                                obj.set_broken(cancellable, generation);
+                            }
+                        }
+                        Err(_) => {
+                            println!("Failed to decode image bytes, not fetching from network.");
+                            obj.set_broken(cancellable, generation)
+                        }
+                    }
+                });
+            });
+        });
+    }
+
+    fn decode_bytes(
+        bytes: glib::Bytes, animated: bool,
+    ) -> Result<LoadedImage, Box<dyn std::error::Error + Send + Sync>> {
+        if animated {
+            return ImagePaintable::decode_bytes(bytes).map(LoadedImage::Decoded);
+        }
+
+        match gtk::gdk::Texture::from_bytes(&bytes) {
+            Ok(texture) => Ok(LoadedImage::Texture(texture)),
+            Err(_) => ImagePaintable::decode_bytes(bytes).map(LoadedImage::Decoded),
+        }
     }
 
     pub async fn cache_file(&self) -> PathBuf {
@@ -226,32 +409,40 @@ impl PictureLoader {
             "{}-{}-{}",
             self.id(),
             self.imagetype(),
-            self.tag().unwrap_or("0".to_string())
+            self.tag().as_deref().unwrap_or("0")
         );
         cache_path.join(path)
     }
 
-    pub fn get_file(&self, pathbuf: PathBuf) {
+    pub fn get_file(&self, pathbuf: PathBuf, cancellable: gio::Cancellable, generation: u64) {
         let id = self.id();
         let image_type = self.imagetype();
         let tag = self.tag();
-        spawn(clone!(
-            #[weak(rename_to = obj)]
-            self,
-            async move {
-                spawn_tokio(async move {
-                    let tag = tag.to_owned();
-                    if let Err(e) = JELLYFIN_CLIENT
-                        .get_image(&id, &image_type, tag.and_then(|s| s.parse::<u8>().ok()))
-                        .await
-                    {
-                        warn!("{}: {}-{}", e, id, image_type);
-                    }
-                })
-                .await;
-                debug!("Setting image: {}", &pathbuf.display());
-                obj.reveal_picture::<false>(&pathbuf);
+        let weak_self = self.downgrade();
+        spawn(async move {
+            if cancellable.is_cancelled() {
+                return;
             }
-        ));
+
+            spawn_tokio(async move {
+                let tag = tag.to_owned();
+                if let Err(e) = JELLYFIN_CLIENT
+                    .get_image(&id, &image_type, tag.and_then(|s| s.parse::<u8>().ok()))
+                    .await
+                {
+                    warn!("{}: {}-{}", e, id, image_type);
+                }
+            })
+            .await;
+
+            let Some(obj) = weak_self.upgrade() else {
+                return;
+            };
+
+            if obj.is_current(&cancellable, generation) {
+                debug!("Setting image: {}", &pathbuf.display());
+                obj.reveal_picture(pathbuf, cancellable, generation, false);
+            }
+        });
     }
 }

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -36,6 +36,8 @@ use crate::{
     },
 };
 
+const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
+
 enum LoadedImage {
     Texture(gtk::gdk::Texture),
     Decoded(DecodedPaintable),
@@ -158,6 +160,9 @@ impl PictureLoader {
 
     pub fn reset(&self) {
         self.cancel_loading();
+        self.imp()
+            .picture
+            .set_paintable(None::<&gtk::gdk::Paintable>);
     }
 
     pub fn reset_in(widget: &gtk::Widget) {
@@ -181,6 +186,10 @@ impl PictureLoader {
             #[strong]
             cancellable,
             async move {
+                glib::timeout_future(IMAGE_LOAD_DELAY).await;
+                if !obj.is_current(&cancellable, generation) {
+                    return;
+                }
                 obj.load_pic(cancellable, generation).await;
             }
         ));
@@ -351,7 +360,6 @@ impl PictureLoader {
 
             rayon::spawn(move || {
                 let decoded = Self::decode_bytes(bytes, animated);
-
                 glib::idle_add_once(move || {
                     let weak_self = weak_self.into_weak_ref();
                     let Some(obj) = weak_self.upgrade() else {

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -373,17 +373,13 @@ impl PictureLoader {
                             obj.set_picture_visible(cancellable, generation);
                         }
                         Err(_) if fetch_on_error => {
-                            println!("Failed to decode image bytes, fetching from network...");
                             if let Some(path) = cache_file_path {
                                 obj.get_file(path, cancellable, generation);
                             } else {
                                 obj.set_broken(cancellable, generation);
                             }
                         }
-                        Err(_) => {
-                            println!("Failed to decode image bytes, not fetching from network.");
-                            obj.set_broken(cancellable, generation)
-                        }
+                        Err(_) => obj.set_broken(cancellable, generation),
                     }
                 });
             });

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -1,4 +1,10 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::atomic::{
+        AtomicUsize,
+        Ordering,
+    },
+};
 
 use adw::{
     prelude::*,
@@ -37,10 +43,41 @@ use crate::{
 };
 
 const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
+const IMAGE_DECODE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(120);
+const MAX_IMAGE_DECODE_TASKS: usize = 10;
+
+static IMAGE_DECODE_TASKS: AtomicUsize = AtomicUsize::new(0);
 
 enum LoadedImage {
     Texture(gtk::gdk::Texture),
     Decoded(DecodedPaintable),
+}
+
+struct DecodePermit;
+
+impl Drop for DecodePermit {
+    fn drop(&mut self) {
+        IMAGE_DECODE_TASKS.fetch_sub(1, Ordering::Release);
+    }
+}
+
+fn try_acquire_decode_permit() -> Option<DecodePermit> {
+    let mut current = IMAGE_DECODE_TASKS.load(Ordering::Relaxed);
+    loop {
+        if current >= MAX_IMAGE_DECODE_TASKS {
+            return None;
+        }
+
+        match IMAGE_DECODE_TASKS.compare_exchange_weak(
+            current,
+            current + 1,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return Some(DecodePermit),
+            Err(next) => current = next,
+        }
+    }
 }
 
 pub(crate) mod imp {
@@ -317,7 +354,6 @@ impl PictureLoader {
 
         let weak_self: glib::SendWeakRef<Self> = self.downgrade().into();
         let read_cancellable = cancellable.clone();
-
         file.load_bytes_async(Some(&cancellable), move |res| {
             let cancellable = read_cancellable;
 
@@ -358,38 +394,76 @@ impl PictureLoader {
                 obj.animated()
             };
 
-            rayon::spawn(move || {
-                let decoded = Self::decode_bytes(bytes, animated);
-                glib::idle_add_once(move || {
-                    let weak_self = weak_self.into_weak_ref();
-                    let Some(obj) = weak_self.upgrade() else {
-                        return;
-                    };
+            Self::try_spawn_decode(
+                weak_self,
+                bytes,
+                animated,
+                cache_file_path,
+                cancellable,
+                generation,
+                fetch_on_error,
+            );
+        });
+    }
 
-                    if !obj.is_current(&cancellable, generation) {
-                        return;
-                    }
+    fn try_spawn_decode(
+        weak_self: glib::SendWeakRef<Self>, bytes: glib::Bytes, animated: bool,
+        cache_file_path: Option<PathBuf>, cancellable: gio::Cancellable, generation: u64,
+        fetch_on_error: bool,
+    ) {
+        let Some(decode_permit) = try_acquire_decode_permit() else {
+            glib::timeout_add_local_once(IMAGE_DECODE_RETRY_DELAY, move || {
+                let weak_ref = weak_self.clone().into_weak_ref();
+                let Some(obj) = weak_ref.upgrade() else {
+                    return;
+                };
+                if obj.is_current(&cancellable, generation) {
+                    Self::try_spawn_decode(
+                        weak_self,
+                        bytes,
+                        animated,
+                        cache_file_path,
+                        cancellable,
+                        generation,
+                        fetch_on_error,
+                    );
+                }
+            });
+            return;
+        };
 
-                    match decoded {
-                        Ok(LoadedImage::Texture(texture)) => {
-                            obj.imp().picture.set_paintable(Some(&texture));
-                            obj.set_picture_visible(cancellable, generation);
-                        }
-                        Ok(LoadedImage::Decoded(decoded)) => {
-                            let paintable = ImagePaintable::from_decoded(decoded);
-                            obj.imp().picture.set_paintable(Some(&paintable));
-                            obj.set_picture_visible(cancellable, generation);
-                        }
-                        Err(_) if fetch_on_error => {
-                            if let Some(path) = cache_file_path {
-                                obj.get_file(path, cancellable, generation);
-                            } else {
-                                obj.set_broken(cancellable, generation);
-                            }
-                        }
-                        Err(_) => obj.set_broken(cancellable, generation),
+        rayon::spawn(move || {
+            let decoded = Self::decode_bytes(bytes, animated);
+            drop(decode_permit);
+            glib::idle_add_once(move || {
+                let weak_self = weak_self.into_weak_ref();
+                let Some(obj) = weak_self.upgrade() else {
+                    return;
+                };
+
+                if !obj.is_current(&cancellable, generation) {
+                    return;
+                }
+
+                match decoded {
+                    Ok(LoadedImage::Texture(texture)) => {
+                        obj.imp().picture.set_paintable(Some(&texture));
+                        obj.set_picture_visible(cancellable, generation);
                     }
-                });
+                    Ok(LoadedImage::Decoded(decoded)) => {
+                        let paintable = ImagePaintable::from_decoded(decoded);
+                        obj.imp().picture.set_paintable(Some(&paintable));
+                        obj.set_picture_visible(cancellable, generation);
+                    }
+                    Err(_) if fetch_on_error => {
+                        if let Some(path) = cache_file_path {
+                            obj.get_file(path, cancellable, generation);
+                        } else {
+                            obj.set_broken(cancellable, generation);
+                        }
+                    }
+                    Err(_) => obj.set_broken(cancellable, generation),
+                }
             });
         });
     }

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -199,9 +199,11 @@ impl PictureLoader {
 
     pub fn reset(&self) {
         self.cancel_loading();
-        self.imp()
-            .picture
-            .set_paintable(None::<&gtk::gdk::Paintable>);
+        let imp = self.imp();
+        imp.revealer.set_reveal_child(false);
+        imp.broken.set_visible(false);
+        imp.spinner.set_visible(true);
+        imp.picture.set_paintable(None::<&gtk::gdk::Paintable>);
     }
 
     pub fn reset_in(widget: &gtk::Widget) {

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -47,7 +47,7 @@ use crate::{
 
 const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
 const IMAGE_DECODE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(120);
-static MAX_IMAGE_DECODE_TASKS: LazyLock<usize> = LazyLock::new(|| rayon::current_num_threads());
+static MAX_IMAGE_DECODE_TASKS: LazyLock<usize> = LazyLock::new(rayon::current_num_threads);
 static IMAGE_DECODE_TASKS: AtomicUsize = AtomicUsize::new(0);
 
 enum LoadedImage {

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -1,8 +1,11 @@
 use std::{
     path::PathBuf,
-    sync::atomic::{
-        AtomicUsize,
-        Ordering,
+    sync::{
+        LazyLock,
+        atomic::{
+            AtomicUsize,
+            Ordering,
+        },
     },
 };
 
@@ -44,8 +47,7 @@ use crate::{
 
 const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
 const IMAGE_DECODE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(120);
-const MAX_IMAGE_DECODE_TASKS: usize = 10;
-
+static MAX_IMAGE_DECODE_TASKS: LazyLock<usize> = LazyLock::new(|| rayon::current_num_threads());
 static IMAGE_DECODE_TASKS: AtomicUsize = AtomicUsize::new(0);
 
 enum LoadedImage {
@@ -64,7 +66,7 @@ impl Drop for DecodePermit {
 fn try_acquire_decode_permit() -> Option<DecodePermit> {
     let mut current = IMAGE_DECODE_TASKS.load(Ordering::Relaxed);
     loop {
-        if current >= MAX_IMAGE_DECODE_TASKS {
+        if current >= *MAX_IMAGE_DECODE_TASKS {
             return None;
         }
 

--- a/src/ui/widgets/tu_item/action.rs
+++ b/src/ui/widgets/tu_item/action.rs
@@ -143,6 +143,9 @@ where
             #[weak(rename_to = obj)]
             self,
             move |gesture, _n, x, y| {
+                gesture.set_state(gtk::EventSequenceState::Claimed);
+                obj.insert_action_group("item", obj.set_action().as_ref());
+
                 let builder = Builder::from_resource("/moe/tsuna/tsukimi/ui/pop-menu.ui");
                 let menu = builder.object::<MenuModel>("rightmenu");
                 match menu {
@@ -173,12 +176,8 @@ where
                     }
                     None => eprintln!("Failed to load popover"),
                 }
-
-                gesture.set_state(gtk::EventSequenceState::Claimed);
-                obj.insert_action_group("item", obj.set_action().as_ref());
             }
         ));
-
         gesture
     }
 

--- a/src/ui/widgets/tu_item/action.rs
+++ b/src/ui/widgets/tu_item/action.rs
@@ -20,7 +20,6 @@ use crate::{
 
 use crate::ui::GlobalToast;
 
-use super::prelude::TuItemMenuPrelude;
 use adw::prelude::AlertDialogExt;
 use gettextrs::gettext;
 use gtk::{
@@ -70,7 +69,7 @@ pub trait TuItemAction {
 
 impl<T> TuItemAction for T
 where
-    T: TuItemBasic + TuItemMenuPrelude + IsA<gtk::Widget> + glib::clone::Downgrade,
+    T: TuItemBasic + IsA<gtk::Widget> + glib::clone::Downgrade,
     <T as glib::clone::Downgrade>::Weak: glib::clone::Upgrade<Strong = T>,
 {
     async fn perform_action_inner(id: &str, action: &Action) -> Result<()> {
@@ -164,21 +163,19 @@ where
 
                         new_popover.add_child(&menu_info, "menu-info");
 
-                        if let Some(popover) = obj.popover().borrow_mut().take() {
-                            popover.unparent();
-                        }
                         new_popover.set_parent(&obj);
-                        obj.popover().replace(Some(new_popover));
+                        new_popover.connect_closed(|popover| {
+                            popover.unparent();
+                        });
+                        new_popover
+                            .set_pointing_to(Some(&Rectangle::new(x as i32, y as i32, 0, 0)));
+                        new_popover.popup();
                     }
                     None => eprintln!("Failed to load popover"),
                 }
 
                 gesture.set_state(gtk::EventSequenceState::Claimed);
                 obj.insert_action_group("item", obj.set_action().as_ref());
-                if let Some(popover) = obj.popover().borrow().as_ref() {
-                    popover.set_pointing_to(Some(&Rectangle::new(x as i32, y as i32, 0, 0)));
-                    popover.popup();
-                };
             }
         ));
 

--- a/src/ui/widgets/tu_item/mod.rs
+++ b/src/ui/widgets/tu_item/mod.rs
@@ -8,10 +8,7 @@ pub use overlay::{
     TuItemOverlay,
     TuItemOverlayPrelude,
 };
-pub use prelude::{
-    TuItemBasic,
-    TuItemMenuPrelude,
-};
+pub use prelude::TuItemBasic;
 pub use progressbar_animation::{
     PROGRESSBAR_ANIMATION_DURATION,
     TuItemProgressbarAnimation,

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -111,7 +111,7 @@ where
         hover_scale
     }
 
-    fn set_animated_picture(&self)  -> PictureLoader {
+    fn set_animated_picture(&self) -> PictureLoader {
         let item = self.item();
         let (image_type, tag, id) = self.get_image_type_and_tag(&item);
         let picture_loader = PictureLoader::new_animated(&id, image_type, tag);

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -81,42 +81,39 @@ pub trait TuItemOverlayPrelude {
 }
 
 pub trait TuItemOverlay: TuItemBasic + TuItemOverlayPrelude {
-    fn set_picture(&self) -> PictureLoader;
+    fn set_picture(&self);
 
-    fn set_picture_with_hover_scale(&self) -> HoverScale;
+    fn set_picture_with_hover_scale(&self);
 
-    fn set_animated_picture(&self) -> PictureLoader;
+    fn set_animated_picture(&self);
 }
 
 impl<T> TuItemOverlay for T
 where
     T: TuItemBasic + TuItemOverlayPrelude,
 {
-    fn set_picture(&self) -> PictureLoader {
+    fn set_picture(&self) {
         let item = self.item();
         let (image_type, tag, id) = self.get_image_type_and_tag(&item);
         let picture_loader = PictureLoader::new(&id, image_type, tag);
         picture_loader.add_css_class("inbox");
         self.overlay().set_child(Some(&picture_loader));
-        picture_loader
     }
 
-    fn set_picture_with_hover_scale(&self) -> HoverScale {
+    fn set_picture_with_hover_scale(&self) {
         let item = self.item();
         let (image_type, tag, id) = self.get_image_type_and_tag(&item);
         let picture_loader = PictureLoader::new(&id, image_type, tag);
         let hover_scale = HoverScale::new();
         hover_scale.set_child(Some(&picture_loader));
         self.overlay().set_child(Some(&hover_scale));
-        hover_scale
     }
 
-    fn set_animated_picture(&self) -> PictureLoader {
+    fn set_animated_picture(&self) {
         let item = self.item();
         let (image_type, tag, id) = self.get_image_type_and_tag(&item);
         let picture_loader = PictureLoader::new_animated(&id, image_type, tag);
         picture_loader.add_css_class("inbox");
         self.overlay().set_child(Some(&picture_loader));
-        picture_loader
     }
 }

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -95,25 +95,48 @@ where
     fn set_picture(&self) {
         let item = self.item();
         let (image_type, tag, id) = self.get_image_type_and_tag(&item);
+        let overlay = self.overlay();
+
+        if let Some(picture_loader) = overlay.child().and_downcast::<PictureLoader>() {
+            picture_loader.reload(&id, image_type, tag, false);
+            return;
+        }
+
         let picture_loader = PictureLoader::new(&id, image_type, tag);
         picture_loader.add_css_class("inbox");
-        self.overlay().set_child(Some(&picture_loader));
+        overlay.set_child(Some(&picture_loader));
     }
 
     fn set_picture_with_hover_scale(&self) {
         let item = self.item();
         let (image_type, tag, id) = self.get_image_type_and_tag(&item);
+        let overlay = self.overlay();
+
+        if let Some(hover_scale) = overlay.child().and_downcast::<HoverScale>()
+            && let Some(picture_loader) = hover_scale.child().and_downcast::<PictureLoader>()
+        {
+            picture_loader.reload(&id, image_type, tag, false);
+            return;
+        }
+
         let picture_loader = PictureLoader::new(&id, image_type, tag);
         let hover_scale = HoverScale::new();
         hover_scale.set_child(Some(&picture_loader));
-        self.overlay().set_child(Some(&hover_scale));
+        overlay.set_child(Some(&hover_scale));
     }
 
     fn set_animated_picture(&self) {
         let item = self.item();
         let (image_type, tag, id) = self.get_image_type_and_tag(&item);
+        let overlay = self.overlay();
+
+        if let Some(picture_loader) = overlay.child().and_downcast::<PictureLoader>() {
+            picture_loader.reload(&id, image_type, tag, true);
+            return;
+        }
+
         let picture_loader = PictureLoader::new_animated(&id, image_type, tag);
         picture_loader.add_css_class("inbox");
-        self.overlay().set_child(Some(&picture_loader));
+        overlay.set_child(Some(&picture_loader));
     }
 }

--- a/src/ui/widgets/tu_item/prelude.rs
+++ b/src/ui/widgets/tu_item/prelude.rs
@@ -1,11 +1,5 @@
-use std::cell::RefCell;
-
 use crate::ui::provider::tu_item::TuItem;
 
 pub trait TuItemBasic {
     fn item(&self) -> TuItem;
-}
-
-pub trait TuItemMenuPrelude: TuItemBasic {
-    fn popover(&self) -> &RefCell<Option<gtk::PopoverMenu>>;
 }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -22,12 +22,9 @@ use crate::{
     ui::{
         GlobalToast,
         provider::tu_item::TuItem,
-        widgets::{
-            tu_item::TuItemAction,
-            utils::{
-                TU_ITEM_BANNER_SIZE,
-                TU_ITEM_VIDEO_SIZE,
-            },
+        widgets::utils::{
+            TU_ITEM_BANNER_SIZE,
+            TU_ITEM_VIDEO_SIZE,
         },
     },
     utils::spawn,
@@ -62,6 +59,7 @@ pub mod imp {
                 MAX_SCALE,
             },
             picture_loader::PictureLoader,
+            tu_item::TuItemAction,
         },
     };
 
@@ -157,6 +155,9 @@ pub mod imp {
                     }
                 });
             }
+
+            let obj = self.obj();
+            obj.add_controller(obj.gesture_click());
         }
 
         fn dispose(&self) {
@@ -439,8 +440,6 @@ impl TuListItem {
         } else {
             self.set_picture()
         };
-
-        self.add_controller(self.gesture_click());
 
         let (w, h) = self.size_hint();
 

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -153,6 +153,15 @@ pub mod imp {
 
             let obj = self.obj();
             obj.add_controller(obj.gesture_click());
+            obj.set_has_tooltip(true);
+            obj.connect_query_tooltip(|obj, _, _, _, tooltip| {
+                let name = obj.item().name();
+                if name.is_empty() {
+                    return false;
+                }
+                tooltip.set_text(Some(&name));
+                true
+            });
         }
     }
 
@@ -442,8 +451,6 @@ impl TuListItem {
 
         imp.direct_play_button
             .set_visible(item.has_direct_play_mark());
-
-        self.set_tooltip_text(Some(&item.name()));
 
         if let Some(title) = item.list_item_title() {
             imp.title.set_text(&title);

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -470,7 +470,11 @@ impl TuListItem {
     }
 
     pub fn unbind_item(&self) {
-        self.imp().overlay.set_child(None::<&gtk::Widget>);
+        let imp = self.imp();
+
+        if let Some(child) = imp.overlay.child() {
+            super::picture_loader::PictureLoader::reset_in(&child);
+        }
     }
 
     fn size_hint(&self) -> (i32, i32) {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -434,17 +434,11 @@ impl TuListItem {
         let imp = self.imp();
         let item = self.item();
 
-        if let Some(picture_loader) = item.loaded_picture_loader() {
-            imp.overlay.set_child(Some(&picture_loader));
+        if item.need_animated_picture() {
+            self.set_animated_picture()
         } else {
-            let picture_loader = if item.need_animated_picture() {
-                self.set_animated_picture()
-            } else {
-                self.set_picture()
-            };
-
-            item.set_loaded_picture_loader(picture_loader);
-        }
+            self.set_picture()
+        };
 
         self.add_controller(self.gesture_click());
 

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use adw::prelude::*;
 use gettextrs::gettext;
 use glib::Object;
@@ -14,7 +12,6 @@ use imp::PosterType;
 use super::tu_item::{
     PROGRESSBAR_ANIMATION_DURATION,
     TuItemBasic,
-    TuItemMenuPrelude,
     TuItemOverlay,
     TuItemOverlayPrelude,
 };
@@ -43,7 +40,6 @@ pub mod imp {
     use glib::subclass::InitializingObject;
     use gtk::{
         CompositeTemplate,
-        PopoverMenu,
         gdk,
         glib,
         graphene,
@@ -92,7 +88,6 @@ pub mod imp {
         pub item: RefCell<TuItem>,
         #[property(get, set, builder(PosterType::default()))]
         pub poster_type: Cell<PosterType>,
-        pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
         pub title: TemplateChild<gtk::Label>,
         #[template_child]
@@ -158,12 +153,6 @@ pub mod imp {
 
             let obj = self.obj();
             obj.add_controller(obj.gesture_click());
-        }
-
-        fn dispose(&self) {
-            if let Some(popover) = self.popover.borrow().as_ref() {
-                popover.unparent();
-            };
         }
     }
 
@@ -382,12 +371,6 @@ impl TuItemOverlayPrelude for TuListItem {
 
     fn poster_type_ext(&self) -> PosterType {
         self.poster_type()
-    }
-}
-
-impl TuItemMenuPrelude for TuListItem {
-    fn popover(&self) -> &RefCell<Option<gtk::PopoverMenu>> {
-        &self.imp().popover
     }
 }
 

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -325,8 +325,7 @@ pub mod imp {
         pub fn set_item(&self, item: TuItem) {
             let obj = self.obj();
             self.item.replace(item);
-
-            obj.item_setted();
+            obj.refresh_item();
         }
 
         pub fn set_progress(&self, progress: f64) {
@@ -401,7 +400,7 @@ impl TuListItem {
         ));
     }
 
-    pub fn item_setted(&self) {
+    pub fn refresh_item(&self) {
         let imp = self.imp();
         let item = self.item();
 

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -346,7 +346,9 @@ pub mod imp {
 
         pub fn set_progress(&self, progress: f64) {
             self.progress.set(progress);
-            self.obj().set_progress_anim(progress);
+            if progress > 0.0 {
+                self.obj().set_progress_anim(progress);
+            }
         }
     }
 }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -22,10 +22,13 @@ use crate::{
     ui::{
         GlobalToast,
         provider::tu_item::TuItem,
-        widgets::{tu_item::TuItemAction, utils::{
-            TU_ITEM_BANNER_SIZE,
-            TU_ITEM_VIDEO_SIZE,
-        }},
+        widgets::{
+            tu_item::TuItemAction,
+            utils::{
+                TU_ITEM_BANNER_SIZE,
+                TU_ITEM_VIDEO_SIZE,
+            },
+        },
     },
     utils::spawn,
 };
@@ -459,7 +462,8 @@ impl TuListItem {
 
         imp.folder_mark.set_visible(item.has_folder_mark());
 
-        imp.direct_play_button.set_visible(item.has_direct_play_mark());
+        imp.direct_play_button
+            .set_visible(item.has_direct_play_mark());
 
         self.set_tooltip_text(Some(&item.name()));
 

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -1,5 +1,3 @@
-use std::cell::RefCell;
-
 use adw::prelude::*;
 use gettextrs::gettext;
 use glib::Object;
@@ -14,7 +12,6 @@ use imp::ViewGroup;
 use super::{
     tu_item::{
         TuItemBasic,
-        TuItemMenuPrelude,
         TuItemOverlay,
         TuItemOverlayPrelude,
         TuItemProgressbarAnimation,
@@ -39,7 +36,6 @@ pub mod imp {
     use glib::subclass::InitializingObject;
     use gtk::{
         CompositeTemplate,
-        PopoverMenu,
         glib,
         prelude::*,
     };
@@ -74,7 +70,6 @@ pub mod imp {
         pub inline_overview: TemplateChild<gtk::Label>,
         #[property(get, set = Self::set_view_group, builder(ViewGroup::default()))]
         pub view_group: Cell<ViewGroup>,
-        pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
         pub listlabel: TemplateChild<gtk::Label>,
         #[template_child]
@@ -118,9 +113,6 @@ pub mod imp {
 
         fn dispose(&self) {
             self.dispose_template();
-            if let Some(popover) = self.popover.borrow().as_ref() {
-                popover.unparent();
-            };
         }
     }
 
@@ -163,12 +155,6 @@ impl TuItemOverlayPrelude for TuOverviewItem {
             ViewGroup::EpisodesView => PosterType::NoRequest,
             ViewGroup::ListView => PosterType::Poster,
         }
-    }
-}
-
-impl TuItemMenuPrelude for TuOverviewItem {
-    fn popover(&self) -> &RefCell<Option<gtk::PopoverMenu>> {
-        &self.imp().popover
     }
 }
 

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -112,6 +112,8 @@ pub mod imp {
     impl ObjectImpl for TuOverviewItem {
         fn constructed(&self) {
             self.parent_constructed();
+            let obj = self.obj();
+            obj.add_controller(obj.gesture_click());
         }
 
         fn dispose(&self) {
@@ -129,9 +131,7 @@ pub mod imp {
     impl TuOverviewItem {
         pub fn set_item(&self, item: TuItem) {
             self.item.replace(item);
-            let obj = self.obj();
-            obj.set_up();
-            obj.gesture_click();
+            self.obj().set_up();
         }
 
         fn set_view_group(&self, view_group: ViewGroup) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,6 +26,14 @@ where
     runtime().spawn(fut).await.unwrap()
 }
 
+pub async fn spawn_tokio_blocking<F, R>(fut: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    runtime().spawn_blocking(fut).await.unwrap()
+}
+
 pub fn spawn_tokio_without_await<F>(fut: F)
 where
     F: std::future::Future + Send + 'static,


### PR DESCRIPTION
1. 避免 exists + create_dir_all 的组合，这样会存在 TOCTOU，直接去掉 exists 判断使用 create_dir_all 就好。此外 async fn jellyfin_cache_path 内使用 tokio::spawn_blocking 避免阻塞。
2. 去掉 `tu_item::loaded_picture_loader` 和 `tu_list_item::popover`，前者已经不再使用，后者现在每次右键实时构造 popover，不需要存储。
3. image_paintable 重构，将文件、bytes 解码与 image_paintable 的构造拆分。
4. 重构 picture_loader，现在 picture_loader 加载图片时会异步读取图片 bytes，接着交给 rayon 专有线程解码，解码后根据返回内容在 UI 线程中渲染。为了限制 rayon 的任务规模，目前使用 AtomicUsize 作为信号量，如果能获取到信号量则直接运行，获取不到会在 120ms 等待重新尝试运行，中间穿插对 cancel 和 generation 的检测，目前测试体验良好。
5. 为 picture_loader 加入 80ms 的加载延迟，这是因为高速滚动时会途径大量组件，加入短暂延迟可以允许组件在延迟完毕后检测自己的状态，如果未取消且 generation 相同（说明 80ms 内该 picture_loader 状态维持稳定）再进入实际的加载流程。
6. 优化了其它对性能有较大影响的部分，如进度条动画应仅在 > 0 时播放（几乎所有 item 的进度都是 0）、tooltip_text 应该在 hover 时再设置等。