### PR TITLE
feat: overhaul mpv MPRIS implementation

### DIFF
--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -592,7 +592,7 @@ impl JellyfinClient {
                 let path = if bytes.len() > 1000 {
                     self.save_image(id, image_type, tag, &bytes, etag).await
                 } else {
-                    String::new()
+                    bail!("Image data is too small, likely an error response");
                 };
 
                 Ok(path)
@@ -640,7 +640,7 @@ impl JellyfinClient {
         let cache_path = jellyfin_cache_path().await;
         let path = format!("{}-{}-{}", id, image_type, tag.unwrap_or(0));
         let path = cache_path.join(path);
-        std::fs::write(&path, bytes).unwrap();
+        tokio::fs::write(&path, bytes).await.unwrap();
         if let Some(etag) = etag {
             #[cfg(target_os = "linux")]
             xattr::set(&path, "user.etag", etag.as_bytes()).unwrap_or_else(|e| {

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -592,7 +592,7 @@ impl JellyfinClient {
                 let path = if bytes.len() > 1000 {
                     self.save_image(id, image_type, tag, &bytes, etag).await
                 } else {
-                    bail!("Image data is too small, likely an error response");
+                    String::new()
                 };
 
                 Ok(path)

--- a/src/ui/mpv/mpris/metadata.rs
+++ b/src/ui/mpv/mpris/metadata.rs
@@ -51,17 +51,17 @@ impl MPVPage {
     }
 
     pub(super) fn notify_mpris_art_changed(&self) {
-        let mut metadata = self.metadata().clone();
+        let Some(video) = self.current_video() else {
+            return;
+        };
+        let video_id = video.id();
+        let image_id = video.primary_image_item_id().unwrap_or_else(|| video.id());
+
         spawn(glib::clone!(
             #[weak(rename_to = obj)]
             self,
             async move {
-                let Some(video) = obj.current_video() else {
-                    return;
-                };
-
-                let id = video.primary_image_item_id().unwrap_or_else(|| video.id());
-                let path = get_image_with_cache(id, "Primary".to_string(), None)
+                let path = get_image_with_cache(image_id, "Primary".to_string(), None)
                     .await
                     .unwrap_or_default();
 
@@ -69,6 +69,10 @@ impl MPVPage {
                     return;
                 }
 
+                let Some(video) = obj.current_video().filter(|video| video.id() == video_id) else {
+                    return;
+                };
+                let mut metadata = obj.metadata_for_video(&video);
                 metadata.set_art_url(Some(format!("file://{path}")));
                 obj.mpris_properties_changed([Property::Metadata(metadata)]);
             }

--- a/src/ui/mpv/mpris/metadata.rs
+++ b/src/ui/mpv/mpris/metadata.rs
@@ -1,7 +1,4 @@
-use adw::subclass::prelude::{
-    ObjectSubclassExt,
-    ObjectSubclassIsExt,
-};
+use adw::subclass::prelude::ObjectSubclassIsExt;
 use gtk::glib;
 use mpris_server::{
     Metadata,
@@ -22,11 +19,14 @@ use crate::{
 
 impl MPVPage {
     pub(super) fn metadata(&self) -> Metadata {
-        self.imp()
-            .obj()
-            .current_video()
-            .as_ref()
-            .map_or_else(Metadata::new, |video| self.metadata_for_video(video))
+        let Some(video) = self.current_video() else {
+            return Metadata::new();
+        };
+        let mut metadata = self.metadata_for_video(&video);
+        if let Some(art_url) = self.imp().mpris_art_url.borrow().as_ref() {
+            metadata.set_art_url(Some(art_url.clone()));
+        }
+        metadata
     }
 
     pub(super) fn metadata_for_video(&self, video: &TuItem) -> Metadata {
@@ -49,7 +49,6 @@ impl MPVPage {
     pub(super) fn notify_mpris_art_changed(&self, video: TuItem, mut metadata: Metadata) {
         let video_id = video.id();
         let image_id = video.primary_image_item_id().unwrap_or_else(|| video.id());
-
         spawn(glib::clone!(
             #[weak(rename_to = obj)]
             self,
@@ -64,7 +63,9 @@ impl MPVPage {
                 {
                     return;
                 }
-                metadata.set_art_url(Some(format!("file://{path}")));
+                let art_url = format!("file://{path}");
+                obj.imp().mpris_art_url.replace(Some(art_url.clone()));
+                metadata.set_art_url(Some(art_url));
                 obj.mpris_properties_changed([Property::Metadata(metadata)]);
             }
         ));

--- a/src/ui/mpv/mpris/metadata.rs
+++ b/src/ui/mpv/mpris/metadata.rs
@@ -30,15 +30,22 @@ impl MPVPage {
     }
 
     pub(super) fn metadata_for_video(&self, video: &TuItem) -> Metadata {
-        let mut builder = Metadata::builder()
-            .trackid(self.track_id_for_video(video))
-            .title(Self::video_title(video));
+        let mut builder = Metadata::builder().trackid(self.track_id_for_video(video));
         let duration = video.run_time_ticks() / 10_000_000;
         if duration > 0 {
             builder = builder.length(Time::from_secs(duration as i64));
         }
         if let Some(series_name) = video.series_name() {
-            builder = builder.album(series_name);
+            builder = builder
+                .title(format!(
+                    "S{}E{}: {}",
+                    video.parent_index_number(),
+                    video.index_number(),
+                    video.name()
+                ))
+                .album(series_name);
+        } else {
+            builder = builder.title(video.name());
         }
         if let Some(artists) = video.artists() {
             builder = builder.artist([artists]);
@@ -69,19 +76,5 @@ impl MPVPage {
                 obj.mpris_properties_changed([Property::Metadata(metadata)]);
             }
         ));
-    }
-
-    fn video_title(video: &TuItem) -> String {
-        if let Some(series_name) = video.series_name() {
-            format!(
-                "{} - S{}E{}: {}",
-                series_name,
-                video.parent_index_number(),
-                video.index_number(),
-                video.name()
-            )
-        } else {
-            video.name()
-        }
     }
 }

--- a/src/ui/mpv/mpris/metadata.rs
+++ b/src/ui/mpv/mpris/metadata.rs
@@ -1,0 +1,91 @@
+use adw::subclass::prelude::{
+    ObjectSubclassExt,
+    ObjectSubclassIsExt,
+};
+use gtk::glib;
+use mpris_server::{
+    Metadata,
+    Property,
+    Time,
+};
+
+use crate::{
+    ui::{
+        mpv::page::MPVPage,
+        provider::tu_item::TuItem,
+    },
+    utils::{
+        get_image_with_cache,
+        spawn,
+    },
+};
+
+impl MPVPage {
+    pub(super) fn metadata(&self) -> Metadata {
+        self.imp()
+            .obj()
+            .current_video()
+            .as_ref()
+            .map_or_else(Metadata::new, |video| self.metadata_for_video(video))
+    }
+
+    pub(super) fn metadata_for_video(&self, video: &TuItem) -> Metadata {
+        let mut builder = Metadata::builder()
+            .trackid(self.track_id_for_video(video))
+            .title(Self::video_title(video));
+
+        let duration = video.run_time_ticks() / 10_000_000;
+        if duration > 0 {
+            builder = builder.length(Time::from_secs(duration as i64));
+        }
+
+        if let Some(series_name) = video.series_name() {
+            builder = builder.album(series_name);
+        }
+
+        if let Some(artists) = video.artists() {
+            builder = builder.artist([artists]);
+        }
+
+        builder.build()
+    }
+
+    pub(super) fn notify_mpris_art_changed(&self) {
+        let mut metadata = self.metadata().clone();
+        spawn(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            async move {
+                let Some(video) = obj.current_video() else {
+                    return;
+                };
+
+                let id = video.primary_image_item_id().unwrap_or_else(|| video.id());
+                let path = get_image_with_cache(id, "Primary".to_string(), None)
+                    .await
+                    .unwrap_or_default();
+
+                if path.is_empty() {
+                    return;
+                }
+
+                metadata.set_art_url(Some(format!("file://{path}")));
+                obj.mpris_properties_changed([Property::Metadata(metadata)]);
+            }
+        ));
+    }
+
+    fn video_title(video: &TuItem) -> String {
+        if let Some(series_name) = video.series_name() {
+            format!(
+                "{} - S{}E{}: {}",
+                series_name,
+                video.parent_index_number(),
+                video.index_number(),
+                video.name()
+            )
+        } else {
+            video.name()
+        }
+    }
+}

--- a/src/ui/mpv/mpris/metadata.rs
+++ b/src/ui/mpv/mpris/metadata.rs
@@ -33,27 +33,20 @@ impl MPVPage {
         let mut builder = Metadata::builder()
             .trackid(self.track_id_for_video(video))
             .title(Self::video_title(video));
-
         let duration = video.run_time_ticks() / 10_000_000;
         if duration > 0 {
             builder = builder.length(Time::from_secs(duration as i64));
         }
-
         if let Some(series_name) = video.series_name() {
             builder = builder.album(series_name);
         }
-
         if let Some(artists) = video.artists() {
             builder = builder.artist([artists]);
         }
-
         builder.build()
     }
 
-    pub(super) fn notify_mpris_art_changed(&self) {
-        let Some(video) = self.current_video() else {
-            return;
-        };
+    pub(super) fn notify_mpris_art_changed(&self, video: TuItem, mut metadata: Metadata) {
         let video_id = video.id();
         let image_id = video.primary_image_item_id().unwrap_or_else(|| video.id());
 
@@ -64,15 +57,13 @@ impl MPVPage {
                 let path = get_image_with_cache(image_id, "Primary".to_string(), None)
                     .await
                     .unwrap_or_default();
-
-                if path.is_empty() {
+                if path.is_empty()
+                    || obj
+                        .current_video()
+                        .is_none_or(|video| video.id() != video_id)
+                {
                     return;
                 }
-
-                let Some(video) = obj.current_video().filter(|video| video.id() == video_id) else {
-                    return;
-                };
-                let mut metadata = obj.metadata_for_video(&video);
                 metadata.set_art_url(Some(format!("file://{path}")));
                 obj.mpris_properties_changed([Property::Metadata(metadata)]);
             }

--- a/src/ui/mpv/mpris/mod.rs
+++ b/src/ui/mpv/mpris/mod.rs
@@ -34,10 +34,7 @@ use crate::{
     ui::mpv::page::MPVPage,
     utils::spawn,
 };
-use tracing::{
-    info,
-    warn,
-};
+use tracing::warn;
 
 mod metadata;
 mod track_list;
@@ -62,15 +59,11 @@ impl MPVPage {
             #[weak(rename_to=imp)]
             self,
             async move {
-                match imp.mpris_server() {
-                    Some(server) => {
-                        if let Err(err) = server.properties_changed(property).await {
-                            warn!("Failed to emit properties changed: {}", err);
-                        }
-                    }
-                    None => {
-                        info!("Failed to get MPRIS server.");
-                    }
+                let Some(server) = imp.mpris_server() else {
+                    return;
+                };
+                if let Err(err) = server.properties_changed(property).await {
+                    warn!("Failed to emit properties changed: {}", err);
                 }
             }
         ));
@@ -81,18 +74,14 @@ impl MPVPage {
             #[weak(rename_to=obj)]
             self,
             async move {
-                match obj.mpris_server() {
-                    Some(server) => {
-                        let signal = Signal::Seeked {
-                            position: Time::from_secs(position),
-                        };
-                        if let Err(err) = server.emit(signal).await {
-                            warn!("Failed to emit mpris_seeked: {}", err);
-                        }
-                    }
-                    None => {
-                        info!("Failed to get MPRIS server.");
-                    }
+                let Some(server) = obj.mpris_server() else {
+                    return;
+                };
+                let signal = Signal::Seeked {
+                    position: Time::from_secs(position),
+                };
+                if let Err(err) = server.emit(signal).await {
+                    warn!("Failed to emit mpris_seeked: {}", err);
                 }
             }
         ));

--- a/src/ui/mpv/mpris/mod.rs
+++ b/src/ui/mpv/mpris/mod.rs
@@ -236,8 +236,7 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn set_position(&self, _track_id: TrackId, position: Time) -> fdo::Result<()> {
-        let position = position.as_secs();
-        self.mpv().set_position(position as f64);
+        self.mpv().set_position(position.as_secs() as f64);
         Ok(())
     }
 
@@ -246,15 +245,13 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn playback_status(&self) -> fdo::Result<PlaybackStatus> {
-        if self.current_video().is_none() {
-            return Ok(PlaybackStatus::Stopped);
-        }
-
-        if self.imp().video.paused() {
-            Ok(PlaybackStatus::Paused)
+        Ok(if self.current_video().is_none() {
+            PlaybackStatus::Stopped
+        } else if self.imp().video.paused() {
+            PlaybackStatus::Paused
         } else {
-            Ok(PlaybackStatus::Playing)
-        }
+            PlaybackStatus::Playing
+        })
     }
 
     async fn loop_status(&self) -> fdo::Result<LoopStatus> {
@@ -262,7 +259,9 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn set_loop_status(&self, _status: LoopStatus) -> zbus::Result<()> {
-        Ok(())
+        Err(zbus::Error::from(fdo::Error::NotSupported(
+            "SetLoopStatus is not supported".into(),
+        )))
     }
 
     async fn rate(&self) -> fdo::Result<PlaybackRate> {

--- a/src/ui/mpv/mpris/mod.rs
+++ b/src/ui/mpv/mpris/mod.rs
@@ -39,9 +39,12 @@ use tracing::{
     warn,
 };
 
+mod metadata;
+mod track_list;
+
 impl MPVPage {
     pub async fn initialize_mpris(&self, app_id: &str) -> Result<()> {
-        let server = LocalServer::new(app_id, self.imp().obj().clone()).await?;
+        let server = LocalServer::new_with_track_list(app_id, self.imp().obj().clone()).await?;
         spawn(server.run());
         self.imp()
             .mpris_server
@@ -81,7 +84,7 @@ impl MPVPage {
                 match obj.mpris_server() {
                     Some(server) => {
                         let signal = Signal::Seeked {
-                            position: Time::from_millis(position),
+                            position: Time::from_secs(position),
                         };
                         if let Err(err) = server.emit(signal).await {
                             warn!("Failed to emit mpris_seeked: {}", err);
@@ -101,51 +104,31 @@ impl MPVPage {
             Property::CanPlay(true),
             Property::CanPause(true),
             Property::CanSeek(true),
+            Property::CanGoNext(self.has_next_video()),
+            Property::CanGoPrevious(self.has_previous_video()),
             Property::PlaybackStatus(PlaybackStatus::Playing),
         ]);
+        self.notify_mpris_art_changed();
     }
 
     pub fn notify_mpris_paused(&self) {
-        self.mpris_properties_changed([
-            Property::Metadata(self.metadata().clone()),
-            Property::CanPlay(true),
-            Property::CanPause(false),
-            Property::CanSeek(true),
-            Property::PlaybackStatus(PlaybackStatus::Paused),
-        ]);
+        self.mpris_properties_changed([Property::PlaybackStatus(PlaybackStatus::Paused)]);
     }
 
     pub fn notify_mpris_stopped(&self) {
         self.mpris_properties_changed([
-            Property::Metadata(self.metadata().clone()),
-            Property::CanPlay(true),
+            Property::Metadata(Metadata::new()),
+            Property::CanPlay(false),
             Property::CanPause(false),
             Property::CanSeek(false),
+            Property::CanGoNext(false),
+            Property::CanGoPrevious(false),
             Property::PlaybackStatus(PlaybackStatus::Stopped),
         ]);
     }
 
     pub fn notify_mpris_loop_status(&self, status: ListRepeatMode) {
         self.mpris_properties_changed([Property::LoopStatus(status.into())]);
-    }
-
-    pub fn notify_mpris_has_chapters(&self, has_chapters: bool) {
-        self.mpris_properties_changed([
-            Property::CanGoNext(has_chapters),
-            Property::CanGoPrevious(has_chapters),
-        ]);
-    }
-
-    pub fn notify_mpris_art_changed(&self) {}
-
-    pub fn metadata(&self) -> Metadata {
-        self.imp()
-            .obj()
-            .current_video()
-            .as_ref()
-            .map_or_else(Metadata::new, |video| {
-                Metadata::builder().title(video.name()).build()
-            })
     }
 }
 
@@ -202,12 +185,12 @@ impl LocalRootInterface for MPVPage {
 
 impl LocalPlayerInterface for MPVPage {
     async fn next(&self) -> fdo::Result<()> {
-        self.chapter_next();
+        self.on_next_video().await;
         Ok(())
     }
 
     async fn previous(&self) -> fdo::Result<()> {
-        self.chapter_next();
+        self.on_previous_video().await;
         Ok(())
     }
 
@@ -225,9 +208,7 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn stop(&self) -> fdo::Result<()> {
-        // same as pause
-        self.on_pause_update(true);
-        self.mpv().pause(true);
+        self.on_stop_clicked();
         Ok(())
     }
 
@@ -238,16 +219,21 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn seek(&self, offset: Time) -> fdo::Result<()> {
+        let offset_seconds = offset.abs().as_secs();
         if offset.is_positive() {
-            self.imp().video.seek_forward(offset.as_secs());
+            self.imp().video.seek_forward(offset_seconds);
         } else {
-            self.imp().video.seek_backward(offset.as_secs());
+            self.imp().video.seek_backward(offset_seconds);
         }
+        let position = (self.imp().video.position() as i64 + offset.as_secs()).max(0);
+        self.notify_mpris_seeked(position);
         Ok(())
     }
 
     async fn set_position(&self, _track_id: TrackId, position: Time) -> fdo::Result<()> {
-        self.mpv().set_position(position.as_secs() as f64);
+        let position = position.as_secs();
+        self.mpv().set_position(position as f64);
+        self.notify_mpris_seeked(position);
         Ok(())
     }
 
@@ -256,7 +242,15 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn playback_status(&self) -> fdo::Result<PlaybackStatus> {
-        Ok(PlaybackStatus::Stopped)
+        if self.current_video().is_none() {
+            return Ok(PlaybackStatus::Stopped);
+        }
+
+        if self.imp().video.paused() {
+            Ok(PlaybackStatus::Paused)
+        } else {
+            Ok(PlaybackStatus::Playing)
+        }
     }
 
     async fn loop_status(&self) -> fdo::Result<LoopStatus> {
@@ -268,7 +262,7 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn rate(&self) -> fdo::Result<PlaybackRate> {
-        Ok(1.0)
+        Ok(self.imp().speed_spin.value())
     }
 
     async fn set_rate(&self, rate: PlaybackRate) -> zbus::Result<()> {
@@ -291,17 +285,17 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn volume(&self) -> fdo::Result<Volume> {
-        Ok(1.0)
+        Ok(self.imp().volume_spin.value() / 100.0)
     }
 
     async fn set_volume(&self, volume: Volume) -> zbus::Result<()> {
-        self.mpv().set_volume(volume as i64);
+        self.mpv()
+            .set_volume((volume.clamp(0.0, 1.0) * 100.0).round() as i64);
         Ok(())
     }
 
     async fn position(&self) -> fdo::Result<Time> {
-        let position = Time::from_micros(self.imp().video.position() as i64);
-        Ok(position)
+        Ok(Time::from_secs(self.imp().video.position() as i64))
     }
 
     async fn minimum_rate(&self) -> fdo::Result<PlaybackRate> {
@@ -313,11 +307,11 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn can_go_next(&self) -> fdo::Result<bool> {
-        Ok(self.current_video().is_some())
+        Ok(self.has_next_video())
     }
 
     async fn can_go_previous(&self) -> fdo::Result<bool> {
-        Ok(self.current_video().is_some())
+        Ok(self.has_previous_video())
     }
 
     async fn can_play(&self) -> fdo::Result<bool> {

--- a/src/ui/mpv/mpris/mod.rs
+++ b/src/ui/mpv/mpris/mod.rs
@@ -98,29 +98,24 @@ impl MPVPage {
         ));
     }
 
-    pub fn notify_mpris_playing(&self) {
+    pub fn notify_mpris_track_changed(&self) {
+        let Some(current_video) = self.current_video() else {
+            return;
+        };
+        let metadata = self.metadata_for_video(&current_video);
         self.mpris_properties_changed([
-            Property::Metadata(self.metadata().clone()),
+            Property::Metadata(metadata.clone()),
             Property::CanPlay(true),
             Property::CanPause(true),
             Property::CanSeek(true),
             Property::CanGoNext(self.has_next_video()),
             Property::CanGoPrevious(self.has_previous_video()),
-            Property::PlaybackStatus(PlaybackStatus::Playing),
         ]);
-        self.notify_mpris_art_changed();
+        self.notify_mpris_art_changed(current_video, metadata);
     }
 
-    pub fn notify_mpris_track_changed(&self) {
-        self.mpris_properties_changed([
-            Property::Metadata(self.metadata().clone()),
-            Property::CanPlay(true),
-            Property::CanPause(true),
-            Property::CanSeek(true),
-            Property::CanGoNext(self.has_next_video()),
-            Property::CanGoPrevious(self.has_previous_video()),
-        ]);
-        self.notify_mpris_art_changed();
+    pub fn notify_mpris_playing(&self) {
+        self.mpris_properties_changed([Property::PlaybackStatus(PlaybackStatus::Playing)]);
     }
 
     pub fn notify_mpris_paused(&self) {

--- a/src/ui/mpv/mpris/mod.rs
+++ b/src/ui/mpv/mpris/mod.rs
@@ -111,6 +111,10 @@ impl MPVPage {
         self.mpris_properties_changed([Property::PlaybackStatus(PlaybackStatus::Paused)]);
     }
 
+    pub fn notify_mpris_volume(&self, volume: Volume) {
+        self.mpris_properties_changed([Property::Volume(volume.clamp(0.0, 1.0))]);
+    }
+
     pub fn notify_mpris_stopped(&self) {
         self.mpris_properties_changed([
             Property::Metadata(Metadata::new()),
@@ -277,12 +281,13 @@ impl LocalPlayerInterface for MPVPage {
     }
 
     async fn volume(&self) -> fdo::Result<Volume> {
-        Ok(self.imp().volume_spin.value() / 100.0)
+        Ok(self.imp().volume_bar.level().clamp(0.0, 1.0))
     }
 
     async fn set_volume(&self, volume: Volume) -> zbus::Result<()> {
-        self.mpv()
-            .set_volume((volume.clamp(0.0, 1.0) * 100.0).round() as i64);
+        self.imp()
+            .volume_spin
+            .set_value((volume.clamp(0.0, 1.0) * 100.0).round());
         Ok(())
     }
 

--- a/src/ui/mpv/mpris/mod.rs
+++ b/src/ui/mpv/mpris/mod.rs
@@ -232,15 +232,12 @@ impl LocalPlayerInterface for MPVPage {
         } else {
             self.imp().video.seek_backward(offset_seconds);
         }
-        let position = (self.imp().video.position() as i64 + offset.as_secs()).max(0);
-        self.notify_mpris_seeked(position);
         Ok(())
     }
 
     async fn set_position(&self, _track_id: TrackId, position: Time) -> fdo::Result<()> {
         let position = position.as_secs();
         self.mpv().set_position(position as f64);
-        self.notify_mpris_seeked(position);
         Ok(())
     }
 

--- a/src/ui/mpv/mpris/mod.rs
+++ b/src/ui/mpv/mpris/mod.rs
@@ -111,6 +111,18 @@ impl MPVPage {
         self.notify_mpris_art_changed();
     }
 
+    pub fn notify_mpris_track_changed(&self) {
+        self.mpris_properties_changed([
+            Property::Metadata(self.metadata().clone()),
+            Property::CanPlay(true),
+            Property::CanPause(true),
+            Property::CanSeek(true),
+            Property::CanGoNext(self.has_next_video()),
+            Property::CanGoPrevious(self.has_previous_video()),
+        ]);
+        self.notify_mpris_art_changed();
+    }
+
     pub fn notify_mpris_paused(&self) {
         self.mpris_properties_changed([Property::PlaybackStatus(PlaybackStatus::Paused)]);
     }

--- a/src/ui/mpv/mpris/track_list.rs
+++ b/src/ui/mpv/mpris/track_list.rs
@@ -8,10 +8,7 @@ use mpris_server::{
     Uri,
     zbus::fdo,
 };
-use tracing::{
-    info,
-    warn,
-};
+use tracing::warn;
 
 use crate::{
     ui::{
@@ -38,19 +35,15 @@ impl MPVPage {
             #[weak(rename_to=obj)]
             self,
             async move {
-                match obj.mpris_server() {
-                    Some(server) => {
-                        let signal = TrackListSignal::TrackListReplaced {
-                            tracks: obj.track_ids(),
-                            current_track: obj.current_track_id(),
-                        };
-                        if let Err(err) = server.track_list_emit(signal).await {
-                            warn!("Failed to emit mpris track list replaced: {}", err);
-                        }
-                    }
-                    None => {
-                        info!("Failed to get MPRIS server.");
-                    }
+                let Some(server) = obj.mpris_server() else {
+                    return;
+                };
+                let signal = TrackListSignal::TrackListReplaced {
+                    tracks: obj.track_ids(),
+                    current_track: obj.current_track_id(),
+                };
+                if let Err(err) = server.track_list_emit(signal).await {
+                    warn!("Failed to emit mpris track list replaced: {}", err);
                 }
             }
         ));

--- a/src/ui/mpv/mpris/track_list.rs
+++ b/src/ui/mpv/mpris/track_list.rs
@@ -81,7 +81,7 @@ impl MPVPage {
     }
 
     fn track_id(index: usize) -> TrackId {
-        TrackId::try_from(format!("{TRACK_ID_PREFIX}{index}")).expect("valid MPRIS track id")
+        TrackId::try_from(format!("{TRACK_ID_PREFIX}{index}")).expect("invalid MPRIS track id")
     }
 
     fn track_index(track_id: &TrackId) -> Option<usize> {

--- a/src/ui/mpv/mpris/track_list.rs
+++ b/src/ui/mpv/mpris/track_list.rs
@@ -1,0 +1,161 @@
+use adw::subclass::prelude::ObjectSubclassIsExt;
+use gtk::glib;
+use mpris_server::{
+    LocalTrackListInterface,
+    Metadata,
+    TrackId,
+    TrackListSignal,
+    Uri,
+    zbus::fdo,
+};
+use tracing::{
+    info,
+    warn,
+};
+
+use crate::{
+    ui::{
+        mpv::page::MPVPage,
+        provider::tu_item::TuItem,
+    },
+    utils::spawn,
+};
+
+const TRACK_ID_PREFIX: &str = "/moe/tsuna/Tsukimi/TrackList/track_";
+
+impl MPVPage {
+    pub(crate) fn notify_mpris_track_list_replaced(&self) {
+        spawn(glib::clone!(
+            #[weak(rename_to=obj)]
+            self,
+            async move {
+                match obj.mpris_server() {
+                    Some(server) => {
+                        let signal = TrackListSignal::TrackListReplaced {
+                            tracks: obj.track_ids(),
+                            current_track: obj.current_track_id(),
+                        };
+                        if let Err(err) = server.track_list_emit(signal).await {
+                            warn!("Failed to emit mpris track list replaced: {}", err);
+                        }
+                    }
+                    None => {
+                        info!("Failed to get MPRIS server.");
+                    }
+                }
+            }
+        ));
+    }
+
+    pub(super) fn track_id_for_video(&self, video: &TuItem) -> TrackId {
+        let video_list = self.imp().current_episode_list.borrow();
+        video_list
+            .iter()
+            .position(|item| item.id() == video.id())
+            .or_else(|| {
+                video_list.iter().position(|item| {
+                    item.index_number() == video.index_number()
+                        && item.parent_index_number() == video.parent_index_number()
+                })
+            })
+            .map(Self::track_id)
+            .unwrap_or(TrackId::NO_TRACK)
+    }
+
+    pub(super) fn has_next_video(&self) -> bool {
+        self.current_video_index()
+            .is_some_and(|index| index + 1 < self.imp().current_episode_list.borrow().len())
+    }
+
+    pub(super) fn has_previous_video(&self) -> bool {
+        self.current_video_index().is_some_and(|index| index > 0)
+    }
+
+    fn track_id(index: usize) -> TrackId {
+        TrackId::try_from(format!("{TRACK_ID_PREFIX}{index}")).expect("valid MPRIS track id")
+    }
+
+    fn track_index(track_id: &TrackId) -> Option<usize> {
+        track_id
+            .as_str()
+            .strip_prefix(TRACK_ID_PREFIX)
+            .and_then(|index| index.parse().ok())
+    }
+
+    fn track_ids(&self) -> Vec<TrackId> {
+        self.imp()
+            .current_episode_list
+            .borrow()
+            .iter()
+            .enumerate()
+            .map(|(index, _)| Self::track_id(index))
+            .collect()
+    }
+
+    fn current_video_index(&self) -> Option<usize> {
+        let current_video = self.current_video()?;
+        let video_list = self.imp().current_episode_list.borrow();
+
+        video_list
+            .iter()
+            .position(|video| video.id() == current_video.id())
+            .or_else(|| {
+                video_list.iter().position(|video| {
+                    video.index_number() == current_video.index_number()
+                        && video.parent_index_number() == current_video.parent_index_number()
+                })
+            })
+    }
+
+    fn current_track_id(&self) -> TrackId {
+        self.current_video_index()
+            .map(Self::track_id)
+            .unwrap_or(TrackId::NO_TRACK)
+    }
+}
+
+impl LocalTrackListInterface for MPVPage {
+    async fn get_tracks_metadata(&self, track_ids: Vec<TrackId>) -> fdo::Result<Vec<Metadata>> {
+        let video_list = self.imp().current_episode_list.borrow();
+        let metadata = track_ids
+            .iter()
+            .filter_map(Self::track_index)
+            .filter_map(|index| video_list.get(index))
+            .map(|video| self.metadata_for_video(video))
+            .collect();
+        Ok(metadata)
+    }
+
+    async fn add_track(
+        &self, _uri: Uri, _after_track: TrackId, _set_as_current: bool,
+    ) -> fdo::Result<()> {
+        Err(fdo::Error::NotSupported(
+            "Editing the video queue is not supported".into(),
+        ))
+    }
+
+    async fn remove_track(&self, _track_id: TrackId) -> fdo::Result<()> {
+        Err(fdo::Error::NotSupported(
+            "Editing the video queue is not supported".into(),
+        ))
+    }
+
+    async fn go_to(&self, track_id: TrackId) -> fdo::Result<()> {
+        let item = Self::track_index(&track_id)
+            .and_then(|index| self.imp().current_episode_list.borrow().get(index).cloned());
+
+        if let Some(item) = item {
+            self.in_play_item(item).await;
+        }
+
+        Ok(())
+    }
+
+    async fn tracks(&self) -> fdo::Result<Vec<TrackId>> {
+        Ok(self.track_ids())
+    }
+
+    async fn can_edit_tracks(&self) -> fdo::Result<bool> {
+        Ok(false)
+    }
+}

--- a/src/ui/mpv/mpris/track_list.rs
+++ b/src/ui/mpv/mpris/track_list.rs
@@ -24,6 +24,15 @@ use crate::{
 const TRACK_ID_PREFIX: &str = "/moe/tsuna/Tsukimi/TrackList/track_";
 
 impl MPVPage {
+    pub fn mpris_track_list_changed(&self, episode_list: &[TuItem]) -> bool {
+        let current_episode_list = self.imp().current_episode_list.borrow();
+        current_episode_list.len() != episode_list.len()
+            || current_episode_list
+                .iter()
+                .zip(episode_list)
+                .any(|(current, new)| current.id() != new.id())
+    }
+
     pub(crate) fn notify_mpris_track_list_replaced(&self) {
         spawn(glib::clone!(
             #[weak(rename_to=obj)]

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -218,6 +218,8 @@ mod imp {
         pub shortcuts_window: RefCell<Option<ShortcutsWindow>>,
         #[cfg(target_os = "linux")]
         pub mpris_server: OnceCell<LocalServer<super::MPVPage>>,
+        #[cfg(target_os = "linux")]
+        pub mpris_art_url: RefCell<Option<String>>,
 
         #[template_child]
         pub volume_adj: TemplateChild<gtk::Adjustment>,
@@ -515,6 +517,8 @@ impl MPVPage {
         }
 
         self.set_current_video(Some(item));
+        #[cfg(target_os = "linux")]
+        self.imp().mpris_art_url.take();
         self.imp().current_episode_list.replace(episode_list);
         self.notify_track_list_replaced();
         self.notify_track_changed();

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -1017,6 +1017,7 @@ impl MPVPage {
     fn volume_cb(&self, value: i64) {
         self.imp().volume_spin.set_value(value as f64);
         self.imp().volume_bar.set_level(value as f64 / 100.0);
+        self.notify_volume_changed(value as f64 / 100.0);
     }
 
     fn scale_cb(&self, value: i64) {
@@ -1469,6 +1470,11 @@ impl MPVPage {
     pub fn notify_player_paused(&self) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_paused();
+    }
+
+    pub fn notify_volume_changed(&self, volume: f64) {
+        #[cfg(target_os = "linux")]
+        self.notify_mpris_volume(volume);
     }
 
     pub fn notify_stopped(&self) {

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -761,7 +761,6 @@ impl MPVPage {
         self.imp().video_scale.set_value(end);
         self.imp().skip_segment_revealer.set_reveal_child(false);
         self.handle_callback(BackType::Back);
-        self.notify_seeked(end as i64);
     }
 
     async fn external_sub_url_without_selected_source(
@@ -939,6 +938,7 @@ impl MPVPage {
                             obj.update_seeking(false);
                             if was_seeking {
                                 obj.handle_callback(BackType::Back);
+                                obj.notify_seeked(obj.imp().video.position() as i64);
                             }
                         }
                         ListenEvent::Eof(value) => {
@@ -1043,11 +1043,6 @@ impl MPVPage {
             imp.video.add_sub(suburl);
         }
         self.notify_playing();
-        if let Some(start_seconds) = imp.pending_start_seconds.take()
-            && start_seconds > 0.0
-        {
-            self.notify_seeked(start_seconds as i64);
-        }
         self.update_timeout();
         self.handle_callback(BackType::Start);
     }
@@ -1435,14 +1430,12 @@ impl MPVPage {
         let video = &self.imp().video;
         let step = SETTINGS.mpv_seek_backward_step() as i64;
         video.seek_backward(step);
-        self.notify_seeked((video.position() as i64 - step).max(0));
     }
 
     pub fn on_forward(&self) {
         let video = &self.imp().video;
         let step = SETTINGS.mpv_seek_forward_step() as i64;
         video.seek_forward(step);
-        self.notify_seeked(video.position() as i64 + step);
     }
 
     pub fn chapter_prev(&self) {

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -515,11 +515,19 @@ impl MPVPage {
                 .replace(Some(video_matcher));
         }
 
-        self.set_current_video(Some(item));
         #[cfg(target_os = "linux")]
-        self.imp().mpris_art_url.take();
+        let track_list_changed = self.mpris_track_list_changed(&episode_list);
+
+        self.set_current_video(Some(item));
         self.imp().current_episode_list.replace(episode_list);
-        self.notify_track_list_replaced();
+
+        #[cfg(target_os = "linux")]
+        {
+            self.imp().mpris_art_url.take();
+            if track_list_changed {
+                self.notify_track_list_replaced();
+            }
+        }
         self.notify_track_changed();
         self.imp().fallback_context.replace(Some(FallbackContext {
             selected: selected.to_owned(),
@@ -893,7 +901,7 @@ impl MPVPage {
     }
 
     pub async fn in_play_item(&self, item: TuItem) {
-        let episode_list = self.imp().current_episode_list.take();
+        let episode_list = self.imp().current_episode_list.borrow().clone();
         self.play(None, item, episode_list, None, 0.0);
     }
 

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -234,6 +234,7 @@ mod imp {
 
         pub video_version_matcher: RefCell<Option<String>>,
         pub fallback_context: RefCell<Option<super::FallbackContext>>,
+        pub pending_start_seconds: Cell<Option<f64>>,
         pub playback_direct_mode: RefCell<super::PlaybackDirectMode>,
         pub queued_playback_direct_mode: RefCell<Option<super::PlaybackDirectMode>>,
         pub retrying_playback: Cell<bool>,
@@ -520,6 +521,7 @@ impl MPVPage {
             selected: selected.to_owned(),
             start_seconds,
         }));
+        self.imp().pending_start_seconds.set(Some(start_seconds));
         let direct_mode = self
             .imp()
             .queued_playback_direct_mode
@@ -751,6 +753,7 @@ impl MPVPage {
         self.imp().video_scale.set_value(end);
         self.imp().skip_segment_revealer.set_reveal_child(false);
         self.handle_callback(BackType::Back);
+        self.notify_seeked(end as i64);
     }
 
     async fn external_sub_url_without_selected_source(
@@ -1030,6 +1033,11 @@ impl MPVPage {
         imp.allow_fallback.set(false);
         if let Some(suburl) = imp.suburl.borrow().as_ref() {
             imp.video.add_sub(suburl);
+        }
+        if let Some(start_seconds) = imp.pending_start_seconds.take()
+            && start_seconds > 0.0
+        {
+            self.notify_seeked(start_seconds as i64);
         }
         self.update_timeout();
         self.handle_callback(BackType::Start);

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -236,7 +236,6 @@ mod imp {
 
         pub video_version_matcher: RefCell<Option<String>>,
         pub fallback_context: RefCell<Option<super::FallbackContext>>,
-        pub pending_start_seconds: Cell<Option<f64>>,
         pub playback_direct_mode: RefCell<super::PlaybackDirectMode>,
         pub queued_playback_direct_mode: RefCell<Option<super::PlaybackDirectMode>>,
         pub retrying_playback: Cell<bool>,
@@ -526,7 +525,6 @@ impl MPVPage {
             selected: selected.to_owned(),
             start_seconds,
         }));
-        self.imp().pending_start_seconds.set(Some(start_seconds));
         let direct_mode = self
             .imp()
             .queued_playback_direct_mode

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -517,6 +517,7 @@ impl MPVPage {
         self.set_current_video(Some(item));
         self.imp().current_episode_list.replace(episode_list);
         self.notify_track_list_replaced();
+        self.notify_track_changed();
         self.imp().fallback_context.replace(Some(FallbackContext {
             selected: selected.to_owned(),
             start_seconds,
@@ -564,6 +565,7 @@ impl MPVPage {
                     Err(e) => {
                         obj.mark_stream_failed();
                         obj.toast(e.to_user_facing());
+                        obj.notify_stopped();
                         return;
                     }
                 };
@@ -589,6 +591,7 @@ impl MPVPage {
                 let Some(media_source) = media_source else {
                     obj.mark_stream_failed();
                     obj.toast(gettext("No media source found"));
+                    obj.notify_stopped();
                     return;
                 };
 
@@ -656,6 +659,7 @@ impl MPVPage {
                     None => {
                         obj.mark_stream_failed();
                         obj.toast(gettext("No media source found"));
+                        obj.notify_stopped();
                         return;
                     }
                 };
@@ -1034,6 +1038,7 @@ impl MPVPage {
         if let Some(suburl) = imp.suburl.borrow().as_ref() {
             imp.video.add_sub(suburl);
         }
+        self.notify_playing();
         if let Some(start_seconds) = imp.pending_start_seconds.take()
             && start_seconds > 0.0
         {
@@ -1086,6 +1091,7 @@ impl MPVPage {
 
         self.mark_stream_failed();
         self.toast(value);
+        self.notify_stopped();
     }
 
     pub fn on_pause_update(&self, value: bool) {
@@ -1450,6 +1456,11 @@ impl MPVPage {
     pub fn notify_playing(&self) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_playing();
+    }
+
+    pub fn notify_track_changed(&self) {
+        #[cfg(target_os = "linux")]
+        self.notify_mpris_track_changed();
     }
 
     pub fn notify_player_paused(&self) {

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -515,6 +515,7 @@ impl MPVPage {
 
         self.set_current_video(Some(item));
         self.imp().current_episode_list.replace(episode_list);
+        self.notify_track_list_replaced();
         self.imp().fallback_context.replace(Some(FallbackContext {
             selected: selected.to_owned(),
             start_seconds,
@@ -660,7 +661,6 @@ impl MPVPage {
                 imp.video.play(&video_url, start_seconds);
             }
         ));
-        self.notify_playing();
     }
 
     fn reset_skippable_segments(&self) {
@@ -984,9 +984,7 @@ impl MPVPage {
     }
 
     fn on_chapter_list(&self, value: ChapterList) {
-        let chapter_len = value.0.len();
         self.imp().video_scale.set_chapter_list(value);
-        self.notify_has_chapters(chapter_len > 0);
     }
 
     fn update_duration(&self, value: f64) {
@@ -1265,7 +1263,7 @@ impl MPVPage {
     }
 
     #[template_callback]
-    fn on_stop_clicked(&self) {
+    pub fn on_stop_clicked(&self) {
         self.handle_callback(BackType::Stop);
         self.remove_timeout();
         self.reset_skippable_segments();
@@ -1419,14 +1417,14 @@ impl MPVPage {
         let video = &self.imp().video;
         let step = SETTINGS.mpv_seek_backward_step() as i64;
         video.seek_backward(step);
-        self.notify_seeked(step);
+        self.notify_seeked((video.position() as i64 - step).max(0));
     }
 
     pub fn on_forward(&self) {
         let video = &self.imp().video;
         let step = SETTINGS.mpv_seek_forward_step() as i64;
         video.seek_forward(step);
-        self.notify_seeked(step);
+        self.notify_seeked(video.position() as i64 + step);
     }
 
     pub fn chapter_prev(&self) {
@@ -1439,11 +1437,6 @@ impl MPVPage {
 
     pub fn mpv(&self) -> &TsukimiMPV {
         self.imp().video.imp().mpv()
-    }
-
-    pub fn notify_has_chapters(&self, has_chapters: bool) {
-        #[cfg(target_os = "linux")]
-        self.notify_mpris_has_chapters(has_chapters);
     }
 
     pub fn notify_playing(&self) {
@@ -1464,6 +1457,11 @@ impl MPVPage {
     pub fn notify_seeked(&self, position: i64) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_seeked(position);
+    }
+
+    pub fn notify_track_list_replaced(&self) {
+        #[cfg(target_os = "linux")]
+        self.notify_mpris_track_list_replaced();
     }
 }
 

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -20,7 +20,7 @@ use libmpv2::{
     render::RenderContext,
 };
 use tracing::{
-    info,
+    debug,
     warn,
 };
 
@@ -277,7 +277,7 @@ impl TsukimiMPV {
     pub fn press_key(&self, key: u32, state: gtk::gdk::ModifierType) {
         let keystr = get_full_keystr(key, state);
         if let Some(keystr) = keystr {
-            info!("MPV Catch Key pressed: {}", keystr);
+            debug!("MPV Catch Key pressed: {}", keystr);
             self.command("keypress", &[&keystr]);
         }
     }
@@ -285,7 +285,7 @@ impl TsukimiMPV {
     pub fn release_key(&self, key: u32, state: gtk::gdk::ModifierType) {
         let keystr = get_full_keystr(key, state);
         if let Some(keystr) = keystr {
-            info!("MPV Catch Key released: {}", keystr);
+            debug!("MPV Catch Key released: {}", keystr);
             self.command("keyup", &[&keystr]);
         }
     }
@@ -327,10 +327,10 @@ impl TsukimiMPV {
         let mpv = Arc::clone(&self.mpv);
         let cmd = cmd.to_string();
         let args = args.iter().map(|&arg| arg.to_string()).collect::<Vec<_>>();
-        spawn_tokio_without_await(async move {
+        spawn_tokio_blocking_without_await(move || {
             let args_ref: Vec<&str> = args.iter().map(|arg| arg.as_str()).collect();
             mpv.command(&cmd, &args_ref)
-                .map_err(|e| warn!("MPV command Error: {}, Command: {}", e, cmd))
+                .map_err(|e| warn!("MPV command Error: {}, Command: {} {:?}", e, cmd, args_ref))
                 .ok();
         });
     }
@@ -632,7 +632,10 @@ use super::options_matcher::{
 use crate::{
     client::error::UserFacingError,
     ui::models::SETTINGS,
-    utils::spawn_tokio_without_await,
+    utils::{
+        spawn_tokio_blocking_without_await,
+        spawn_tokio_without_await,
+    },
 };
 
 const KEYSTRING_MAP: &[(&str, &str)] = &[

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -579,7 +579,9 @@ fn node_to_chapter_list(node: MpvNode) -> ChapterList {
 fn get_full_keystr(key: u32, state: gtk::gdk::ModifierType) -> Option<String> {
     let modstr = get_modstr(state);
     let keystr = keyval_to_keystr(key);
-    if let Some(keystr) = keystr {
+    if let Some(keystr) = keystr
+        && !keystr.is_empty()
+    {
         return Some(format!("{modstr}{keystr}"));
     }
     None
@@ -679,6 +681,8 @@ const KEYSTRING_MAP: &[(&str, &str)] = &[
     ("", "Alt_R"),
     ("", "Meta_L"),
     ("", "Meta_R"),
+    ("", "Super_L"),
+    ("", "Super_R"),
     ("", "Shift_L"),
     ("", "Shift_R"),
     ("", "grave"),

--- a/src/ui/mpv/video_scale.rs
+++ b/src/ui/mpv/video_scale.rs
@@ -1,7 +1,6 @@
 use gtk::{
     glib,
     prelude::*,
-    subclass::prelude::*,
 };
 
 use super::tsukimi_mpv::ChapterList;
@@ -104,6 +103,7 @@ mod imp {
 
         fn on_seek_finished(&self, value: f64) {
             self.player.upgrade().unwrap().set_position(value);
+            self.obj().notify_seeked(value as i64);
         }
     }
 }
@@ -132,14 +132,6 @@ impl VideoScale {
         glib::ControlFlow::Continue
     }
 
-    pub fn on_smooth_scale_value_changed(&self) {
-        let value = self.value();
-        let position = value / 60.0;
-        if let Some(player) = self.imp().player.upgrade() {
-            player.set_position(position);
-        }
-    }
-
     pub fn set_cache_end_time(&self, end_time: i64) {
         self.set_fill_level(end_time as f64);
     }
@@ -155,5 +147,16 @@ impl VideoScale {
         for chapter in chapter_list {
             self.add_mark(chapter.time, gtk::PositionType::Top, None);
         }
+    }
+
+    fn notify_seeked(&self, position: i64) {
+        let Some(page) = self
+            .ancestor(crate::ui::mpv::page::MPVPage::static_type())
+            .and_downcast::<crate::ui::mpv::page::MPVPage>()
+        else {
+            return;
+        };
+
+        page.notify_seeked(position);
     }
 }

--- a/src/ui/mpv/video_scale.rs
+++ b/src/ui/mpv/video_scale.rs
@@ -103,7 +103,6 @@ mod imp {
 
         fn on_seek_finished(&self, value: f64) {
             self.player.upgrade().unwrap().set_position(value);
-            self.obj().notify_seeked(value as i64);
         }
     }
 }
@@ -147,16 +146,5 @@ impl VideoScale {
         for chapter in chapter_list {
             self.add_mark(chapter.time, gtk::PositionType::Top, None);
         }
-    }
-
-    fn notify_seeked(&self, position: i64) {
-        let Some(page) = self
-            .ancestor(crate::ui::mpv::page::MPVPage::static_type())
-            .and_downcast::<crate::ui::mpv::page::MPVPage>()
-        else {
-            return;
-        };
-
-        page.notify_seeked(position);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -43,6 +43,13 @@ where
     });
 }
 
+pub fn spawn_tokio_blocking_without_await<F>(fut: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    runtime().spawn_blocking(fut);
+}
+
 pub fn spawn<F>(fut: F)
 where
     F: std::future::Future + 'static,


### PR DESCRIPTION
The previous mpv MPRIS implementation was quite incomplete, with many unsupported features. This PR focuses on improving that area.

After these improvements, artwork, titles, progress synchronization, volume synchronization, previous/next episode controls, and related features should now work correctly.

Additionally, this PR refines mpv key handling. Dragging the window with `mod + left mouse button` no longer triggers unnecessary libmpv commands.

The only remaining issue is that the progress bars on both sides may differ by one or two seconds. This is mainly due to the current progress bar being limited to second-level precision. Increasing its precision would have a relatively broad impact, and I do not consider this discrepancy serious enough for now, so it has not been changed in this PR. It may be addressed later if needed.


Before:

<img width="3840" height="2160" alt="图片" src="https://github.com/user-attachments/assets/f55abc71-0bbe-4a69-a08f-8d8fba888699" />


After:

<img width="3840" height="2160" alt="图片" src="https://github.com/user-attachments/assets/58aa7030-722e-41dd-9bb9-62ba05efb8e6" />

