### PR TITLE
feat: support merging Continue Watching and Next Up into one row for Jellyfin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2171,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,6 +2505,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3255,6 +3290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +3630,7 @@ dependencies = [
  "libc",
  "libloading 0.9.0",
  "libmpv2",
+ "moka",
  "mpris-server",
  "once_cell",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ glow = "0.17"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 futures-util = "0.3.31"
 itertools = "0.14.0"
+moka = { version = "0.12.15", features = ["future"] }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -7,7 +7,6 @@ src/client/mod.rs
 src/client/proxy.rs
 src/client/runtime.rs
 src/client/structs.rs
-src/client/windows_compat.rs
 src/config.rs
 src/gstl/mod.rs
 src/gstl/mpris.rs
@@ -22,7 +21,9 @@ src/ui/models/settings.rs
 src/ui/mpv/control_sidebar.rs
 src/ui/mpv/menu_actions.rs
 src/ui/mpv/mod.rs
-src/ui/mpv/mpris.rs
+src/ui/mpv/mpris/metadata.rs
+src/ui/mpv/mpris/mod.rs
+src/ui/mpv/mpris/track_list.rs
 src/ui/mpv/mpvglarea.rs
 src/ui/mpv/options_matcher.rs
 src/ui/mpv/page.rs

--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -45,19 +45,19 @@ msgstr ""
 msgid "Pause"
 msgstr ""
 
-#: src/ui/mpv/page.rs:744
+#: src/ui/mpv/page.rs:746
 msgid "Skip Intro"
 msgstr ""
 
-#: src/ui/mpv/page.rs:745
+#: src/ui/mpv/page.rs:747
 msgid "Skip Outro"
 msgstr ""
 
-#: src/ui/mpv/page.rs:895
+#: src/ui/mpv/page.rs:897
 msgid "No more video found"
 msgstr ""
 
-#: src/ui/mpv/page.rs:995
+#: src/ui/mpv/page.rs:998
 msgid ""
 "MPV has been shutdown, Application will exit.\n"
 "Tsukimi can't restart MPV."
@@ -130,15 +130,15 @@ msgid "Disc"
 msgstr ""
 
 #. if merged, next up will contain resume items, so change title to continue watching
-#: src/ui/widgets/home.rs:218 resources/ui/home.ui:25 resources/ui/item.ui:294
+#: src/ui/widgets/home.rs:230 resources/ui/home.ui:25 resources/ui/item.ui:294
 msgid "Continue Watching"
 msgstr ""
 
-#: src/ui/widgets/home.rs:220 resources/ui/home.ui:33
+#: src/ui/widgets/home.rs:232 resources/ui/home.ui:33
 msgid "Next Up"
 msgstr ""
 
-#: src/ui/widgets/home.rs:381
+#: src/ui/widgets/home.rs:395
 msgid "Latest"
 msgstr ""
 
@@ -154,14 +154,14 @@ msgstr ""
 
 #: src/ui/widgets/identify/search_page.rs:126
 #: src/ui/widgets/image_dialog/search_page.rs:148
-#: src/ui/widgets/metadata_dialog.rs:290 src/ui/widgets/tu_item/action.rs:479
+#: src/ui/widgets/metadata_dialog.rs:290 src/ui/widgets/tu_item/action.rs:485
 msgid "Are you sure you wish to continue?"
 msgstr ""
 
 #: src/ui/widgets/identify/search_page.rs:129
 #: src/ui/widgets/image_dialog/search_page.rs:151
-#: src/ui/widgets/metadata_dialog.rs:293 src/ui/widgets/tu_item/action.rs:483
-#: src/ui/widgets/tu_item/action.rs:543 resources/ui/account_settings.ui:510
+#: src/ui/widgets/metadata_dialog.rs:293 src/ui/widgets/tu_item/action.rs:489
+#: src/ui/widgets/tu_item/action.rs:549 resources/ui/account_settings.ui:510
 #: resources/ui/account_settings.ui:620
 msgid "Cancel"
 msgstr ""
@@ -406,32 +406,32 @@ msgstr ""
 msgid "Add to favorites"
 msgstr ""
 
-#: src/ui/widgets/tu_item/action.rs:92
+#: src/ui/widgets/tu_item/action.rs:98
 msgid "Success"
 msgstr ""
 
-#: src/ui/widgets/tu_item/action.rs:473
+#: src/ui/widgets/tu_item/action.rs:479
 msgid "Delete Item"
 msgstr ""
 
-#: src/ui/widgets/tu_item/action.rs:477
+#: src/ui/widgets/tu_item/action.rs:483
 msgid ""
 "Deleting this item will delete it from both the file system and your media "
 "library.\n"
 "The following files and folders will be deleted:"
 msgstr ""
 
-#: src/ui/widgets/tu_item/action.rs:484 resources/ui/image_info_card.ui:139
+#: src/ui/widgets/tu_item/action.rs:490 resources/ui/image_info_card.ui:139
 #: resources/ui/pop-menu.ui:92 resources/ui/server_action_row.ui:52
 msgid "Delete"
 msgstr ""
 
-#: src/ui/widgets/tu_item/action.rs:538 src/ui/widgets/tu_item/action.rs:539
-#: src/ui/widgets/tu_item/action.rs:544 resources/ui/pop-menu.ui:62
+#: src/ui/widgets/tu_item/action.rs:544 src/ui/widgets/tu_item/action.rs:545
+#: src/ui/widgets/tu_item/action.rs:550 resources/ui/pop-menu.ui:62
 msgid "Remove Identification"
 msgstr ""
 
-#: src/ui/widgets/tu_item/action.rs:540
+#: src/ui/widgets/tu_item/action.rs:546
 msgid "Are you sure you wish to reset all metadata?"
 msgstr ""
 

--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -34,46 +34,46 @@ msgstr ""
 msgid "Failed to get GLContext"
 msgstr ""
 
-#: src/ui/mpv/page.rs:382 src/ui/mpv/page.rs:384 src/ui/widgets/item.rs:707
+#: src/ui/mpv/page.rs:384 src/ui/mpv/page.rs:386 src/ui/widgets/item.rs:707
 #: resources/ui/album_widget.ui:94 resources/ui/item.ui:186
 #: resources/ui/mpv_menu_actions.ui:27 resources/ui/other.ui:76
 #: resources/ui/player_toolbar.ui:90
 msgid "Play"
 msgstr ""
 
-#: src/ui/mpv/page.rs:387 src/ui/mpv/page.rs:389 resources/ui/mpvpage.ui:227
+#: src/ui/mpv/page.rs:389 src/ui/mpv/page.rs:391 resources/ui/mpvpage.ui:227
 msgid "Pause"
 msgstr ""
 
-#: src/ui/mpv/page.rs:728
+#: src/ui/mpv/page.rs:744
 msgid "Skip Intro"
 msgstr ""
 
-#: src/ui/mpv/page.rs:729
+#: src/ui/mpv/page.rs:745
 msgid "Skip Outro"
 msgstr ""
 
-#: src/ui/mpv/page.rs:879
+#: src/ui/mpv/page.rs:895
 msgid "No more video found"
 msgstr ""
 
-#: src/ui/mpv/page.rs:978
+#: src/ui/mpv/page.rs:995
 msgid ""
 "MPV has been shutdown, Application will exit.\n"
 "Tsukimi can't restart MPV."
 msgstr ""
 
-#: src/ui/provider/tu_item.rs:555
+#: src/ui/provider/tu_item.rs:547
 msgid "No next up video found"
 msgstr ""
 
-#: src/ui/provider/tu_item.rs:584 src/ui/widgets/tu_overview_item.rs:254
+#: src/ui/provider/tu_item.rs:576 src/ui/widgets/tu_overview_item.rs:254
 msgid "Present"
 msgstr ""
 
-#: src/ui/provider/tu_item.rs:592 src/ui/provider/tu_item.rs:610
-#: src/ui/provider/tu_item.rs:633 src/ui/provider/tu_item.rs:656
-#: src/ui/provider/tu_item.rs:659
+#: src/ui/provider/tu_item.rs:584 src/ui/provider/tu_item.rs:602
+#: src/ui/provider/tu_item.rs:625 src/ui/provider/tu_item.rs:648
+#: src/ui/provider/tu_item.rs:651
 msgid "Unknown"
 msgstr ""
 
@@ -89,39 +89,39 @@ msgstr ""
 msgid "Server added successfully"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:225
+#: src/ui/widgets/account_settings.rs:227
 msgid "Password cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:229
+#: src/ui/widgets/account_settings.rs:231
 msgid "Passwords do not match!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:236
+#: src/ui/widgets/account_settings.rs:238
 msgid "Password changed successfully! Please login again."
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:240
+#: src/ui/widgets/account_settings.rs:242
 msgid "Failed to change password"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:276
+#: src/ui/widgets/account_settings.rs:278
 msgid "Cache Cleared"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:297
+#: src/ui/widgets/account_settings.rs:299
 msgid "No file selected"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:515
 #: src/ui/widgets/account_settings.rs:524
-#: src/ui/widgets/account_settings.rs:558
+#: src/ui/widgets/account_settings.rs:533
 #: src/ui/widgets/account_settings.rs:567
+#: src/ui/widgets/account_settings.rs:576
 msgid "Descriptor cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:529
-#: src/ui/widgets/account_settings.rs:572
+#: src/ui/widgets/account_settings.rs:538
+#: src/ui/widgets/account_settings.rs:581
 msgid "Invalid regex"
 msgstr ""
 
@@ -129,7 +129,16 @@ msgstr ""
 msgid "Disc"
 msgstr ""
 
-#: src/ui/widgets/home.rs:356
+#. if merged, next up will contain resume items, so change title to continue watching
+#: src/ui/widgets/home.rs:218 resources/ui/home.ui:25 resources/ui/item.ui:294
+msgid "Continue Watching"
+msgstr ""
+
+#: src/ui/widgets/home.rs:220 resources/ui/home.ui:33
+msgid "Next Up"
+msgstr ""
+
+#: src/ui/widgets/home.rs:381
 msgid "Latest"
 msgstr ""
 
@@ -152,8 +161,8 @@ msgstr ""
 #: src/ui/widgets/identify/search_page.rs:129
 #: src/ui/widgets/image_dialog/search_page.rs:151
 #: src/ui/widgets/metadata_dialog.rs:293 src/ui/widgets/tu_item/action.rs:483
-#: src/ui/widgets/tu_item/action.rs:543 resources/ui/account_settings.ui:499
-#: resources/ui/account_settings.ui:609
+#: src/ui/widgets/tu_item/action.rs:543 resources/ui/account_settings.ui:510
+#: resources/ui/account_settings.ui:620
 msgid "Cancel"
 msgstr ""
 
@@ -273,7 +282,7 @@ msgstr ""
 msgid "Season not found. Is this a continue watching list?"
 msgstr ""
 
-#: src/ui/widgets/liked.rs:159
+#: src/ui/widgets/liked.rs:158
 msgid "Favourite"
 msgstr ""
 
@@ -299,7 +308,7 @@ msgstr ""
 msgid "Genres"
 msgstr ""
 
-#: src/ui/widgets/list.rs:134 src/ui/widgets/window.rs:330
+#: src/ui/widgets/list.rs:134 src/ui/widgets/window.rs:323
 #: resources/ui/window.ui:350
 msgid "Liked"
 msgstr ""
@@ -329,7 +338,7 @@ msgstr ""
 msgid "Scanning..."
 msgstr ""
 
-#: src/ui/widgets/search.rs:209
+#: src/ui/widgets/search.rs:199
 msgid "No overview"
 msgstr ""
 
@@ -385,7 +394,7 @@ msgstr ""
 msgid "Task started"
 msgstr ""
 
-#: src/ui/widgets/single_grid.rs:500
+#: src/ui/widgets/single_grid.rs:498
 msgid "Items"
 msgstr ""
 
@@ -430,52 +439,30 @@ msgstr ""
 msgid "Waiting for mediasource ..."
 msgstr ""
 
-#: src/ui/widgets/window.rs:318 resources/ui/window.ui:304
+#: src/ui/widgets/window.rs:311 resources/ui/window.ui:304
 msgid "Home"
 msgstr ""
 
-#: src/ui/widgets/window.rs:342 resources/ui/identify_dialog.ui:94
+#: src/ui/widgets/window.rs:335 resources/ui/identify_dialog.ui:94
 #: resources/ui/image_info_card.ui:127 resources/ui/search.ui:23
 #: resources/ui/window.ui:21 resources/ui/window.ui:396
 msgid "Search"
 msgstr ""
 
-#: src/ui/widgets/window.rs:831
+#: src/ui/widgets/window.rs:824
 msgid "Server Panel"
 msgstr ""
 
-#: src/ui/widgets/window.rs:1006
+#: src/ui/widgets/window.rs:973
 msgid "Fatal Error"
 msgstr ""
 
-#: src/ui/widgets/window.rs:1009
+#: src/ui/widgets/window.rs:976
 msgid "Copy Error & Close"
 msgstr ""
 
-#: src/ui/widgets/window.rs:1034
-msgid "Windows Alert"
-msgstr ""
-
-#: src/ui/widgets/window.rs:1035
-msgid ""
-"It seems you're using Tsukimi on Windows. Please note that GTK used by this "
-"application is designed for Linux, and no functionality is guaranteed to "
-"work on Windows, including but not limited to video rendering, audio "
-"playback, network connections, and external links. Additionally, there are "
-"known issues that cannot be fixed, such as black borders, image rendering, "
-"font rendering, DPI scaling, video rendering, GL renderer, fullscreen mode, "
-"HDR, and locale detection. \n"
-"If you wish to open an issue, please ensure that it is related to this "
-"software and not an upstream issue. Choose the appropriate issue template "
-"and fill in all required fields without any omissions."
-msgstr ""
-
-#: src/ui/widgets/window.rs:1037
-msgid "Close"
-msgstr ""
-
 #. TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-#: src/ui/widgets/window.rs:1058
+#: src/ui/widgets/window.rs:1005
 msgid "translator-credits"
 msgstr ""
 
@@ -508,7 +495,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: resources/ui/account.ui:108 resources/ui/account_settings.ui:505
+#: resources/ui/account.ui:108 resources/ui/account_settings.ui:516
 msgid "Add"
 msgstr ""
 
@@ -533,7 +520,7 @@ msgid "Preferred Audio Language"
 msgstr ""
 
 #: resources/ui/account_settings.ui:30 resources/ui/account_settings.ui:55
-#: resources/ui/account_settings.ui:139
+#: resources/ui/account_settings.ui:150
 msgid "Default"
 msgstr ""
 
@@ -562,194 +549,206 @@ msgid "Auto Select Last Server"
 msgstr ""
 
 #: resources/ui/account_settings.ui:105
-msgid "Network"
+msgid "Home Page"
 msgstr ""
 
 #: resources/ui/account_settings.ui:108
-msgid "Threads"
-msgstr ""
-
-#: resources/ui/account_settings.ui:109
-msgid "Excessive thread counts may exhaust the system's connection pool"
-msgstr ""
-
-#: resources/ui/account_settings.ui:123
 msgid "Refresh when returning to home page"
 msgstr ""
 
-#: resources/ui/account_settings.ui:130 resources/ui/mpv_control_sidebar.ui:378
+#: resources/ui/account_settings.ui:113
+msgid "Merge Continue Watching and Next Up"
+msgstr ""
+
+#: resources/ui/account_settings.ui:114
+msgid "Jellyfin only"
+msgstr ""
+
+#: resources/ui/account_settings.ui:121
+msgid "Network"
+msgstr ""
+
+#: resources/ui/account_settings.ui:124
+msgid "Threads"
+msgstr ""
+
+#: resources/ui/account_settings.ui:125
+msgid "Excessive thread counts may exhaust the system's connection pool"
+msgstr ""
+
+#: resources/ui/account_settings.ui:141 resources/ui/mpv_control_sidebar.ui:378
 msgid "Background"
 msgstr ""
 
-#: resources/ui/account_settings.ui:162
+#: resources/ui/account_settings.ui:173
 msgid "Opacity"
 msgstr ""
 
-#: resources/ui/account_settings.ui:176
+#: resources/ui/account_settings.ui:187
 msgid "Blur"
 msgstr ""
 
-#: resources/ui/account_settings.ui:181
+#: resources/ui/account_settings.ui:192
 msgid "Blur Radius"
 msgstr ""
 
-#: resources/ui/account_settings.ui:197 resources/ui/mpv_control_sidebar.ui:63
+#: resources/ui/account_settings.ui:208 resources/ui/mpv_control_sidebar.ui:63
 msgid "Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:200
+#: resources/ui/account_settings.ui:211
 msgid "Clear Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:215 resources/ui/account_settings.ui:334
+#: resources/ui/account_settings.ui:226 resources/ui/account_settings.ui:345
 msgid "Others"
 msgstr ""
 
-#: resources/ui/account_settings.ui:218 resources/ui/account_settings.ui:410
+#: resources/ui/account_settings.ui:229 resources/ui/account_settings.ui:421
 msgid "Preferred Video Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:230
+#: resources/ui/account_settings.ui:241
 msgid "Account"
 msgstr ""
 
-#: resources/ui/account_settings.ui:243 resources/ui/account_settings.ui:260
+#: resources/ui/account_settings.ui:254 resources/ui/account_settings.ui:271
 msgid "Change Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:246
+#: resources/ui/account_settings.ui:257
 msgid "New Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:251
+#: resources/ui/account_settings.ui:262
 msgid "Confirm Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:274
+#: resources/ui/account_settings.ui:285
 msgid "Media"
 msgstr ""
 
-#: resources/ui/account_settings.ui:279
+#: resources/ui/account_settings.ui:290
 msgid "Music Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:282 resources/ui/player_toolbar.ui:197
+#: resources/ui/account_settings.ui:293 resources/ui/player_toolbar.ui:197
 msgid "Repeat Mode"
 msgstr ""
 
-#: resources/ui/account_settings.ui:286 resources/ui/player_toolbar.ui:231
+#: resources/ui/account_settings.ui:297 resources/ui/player_toolbar.ui:231
 msgid "Repeat One"
 msgstr ""
 
-#: resources/ui/account_settings.ui:287 resources/ui/player_toolbar.ui:235
+#: resources/ui/account_settings.ui:298 resources/ui/player_toolbar.ui:235
 msgid "Repeat All"
 msgstr ""
 
-#: resources/ui/account_settings.ui:288 resources/ui/account_settings.ui:316
+#: resources/ui/account_settings.ui:299 resources/ui/account_settings.ui:327
 #: resources/ui/player_toolbar.ui:239
 msgid "None"
 msgstr ""
 
-#: resources/ui/account_settings.ui:298
+#: resources/ui/account_settings.ui:309
 msgid "Video Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:299
+#: resources/ui/account_settings.ui:310
 msgid "Requires restart"
 msgstr ""
 
-#: resources/ui/account_settings.ui:302
+#: resources/ui/account_settings.ui:313
 msgid "Enable external config"
 msgstr ""
 
-#: resources/ui/account_settings.ui:307
+#: resources/ui/account_settings.ui:318
 msgid "Config dir"
 msgstr ""
 
-#: resources/ui/account_settings.ui:339
+#: resources/ui/account_settings.ui:350
 msgid "Video Output"
 msgstr ""
 
-#: resources/ui/account_settings.ui:340
+#: resources/ui/account_settings.ui:351
 msgid "Only for debugging"
 msgstr ""
 
-#: resources/ui/account_settings.ui:343
+#: resources/ui/account_settings.ui:354
 msgid "libmpv (default)"
 msgstr ""
 
-#: resources/ui/account_settings.ui:388
+#: resources/ui/account_settings.ui:399
 msgid "Preferred Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:411
+#: resources/ui/account_settings.ui:422
 msgid ""
 "Weight is ordered from high to low, until a specific version is matched, or "
 "the highest matching version is obtained before clearing the match list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:426
+#: resources/ui/account_settings.ui:437
 msgid "Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:448
+#: resources/ui/account_settings.ui:459
 msgid "It is recommended to set no more than 3 lines"
 msgstr ""
 
-#: resources/ui/account_settings.ui:469
+#: resources/ui/account_settings.ui:480
 msgid "No Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:488
+#: resources/ui/account_settings.ui:499
 msgid "Add a descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:530 resources/ui/account_settings.ui:640
+#: resources/ui/account_settings.ui:541 resources/ui/account_settings.ui:651
 msgid "This will use exact matching to obtain a list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:533 resources/ui/account_settings.ui:643
+#: resources/ui/account_settings.ui:544 resources/ui/account_settings.ui:654
 msgid "Descriptor Type"
 msgstr ""
 
-#: resources/ui/account_settings.ui:538 resources/ui/account_settings.ui:648
+#: resources/ui/account_settings.ui:549 resources/ui/account_settings.ui:659
 msgid "String"
 msgstr ""
 
-#: resources/ui/account_settings.ui:539 resources/ui/account_settings.ui:649
+#: resources/ui/account_settings.ui:550 resources/ui/account_settings.ui:660
 msgid "Regular Expression"
 msgstr ""
 
-#: resources/ui/account_settings.ui:551 resources/ui/account_settings.ui:661
+#: resources/ui/account_settings.ui:562 resources/ui/account_settings.ui:672
 msgid "Descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:556 resources/ui/account_settings.ui:666
+#: resources/ui/account_settings.ui:567 resources/ui/account_settings.ui:677
 msgid "Descriptor should not be too long"
 msgstr ""
 
-#: resources/ui/account_settings.ui:567 resources/ui/account_settings.ui:677
+#: resources/ui/account_settings.ui:578 resources/ui/account_settings.ui:688
 msgid "eg. 1080p"
 msgstr ""
 
-#: resources/ui/account_settings.ui:578 resources/ui/account_settings.ui:688
+#: resources/ui/account_settings.ui:589 resources/ui/account_settings.ui:699
 msgid "eg. 1080p.*WebDL"
 msgstr ""
 
-#: resources/ui/account_settings.ui:598
+#: resources/ui/account_settings.ui:609
 msgid "Edit descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:615
+#: resources/ui/account_settings.ui:626
 #: resources/ui/image_dialog_edit_page.ui:37
 msgid "Save"
 msgstr ""
 
-#: resources/ui/account_settings.ui:708
+#: resources/ui/account_settings.ui:719
 msgid "Change folder"
 msgstr ""
 
-#: resources/ui/account_settings.ui:710
+#: resources/ui/account_settings.ui:721
 msgid "Select new mpv config folder"
 msgstr ""
 
@@ -821,14 +820,6 @@ msgstr ""
 
 #: resources/ui/home.ui:17
 msgid "Library"
-msgstr ""
-
-#: resources/ui/home.ui:22 resources/ui/item.ui:294
-msgid "Continue Watching"
-msgstr ""
-
-#: resources/ui/home.ui:30
-msgid "Next Up"
 msgstr ""
 
 #: resources/ui/identify_dialog.ui:57

--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <schemalist>
   <schema id="moe.tsuna.tsukimi" path="/moe/tsukimi/">
     <key name="window-width" type="i">
@@ -170,7 +170,8 @@
     </key>
     <key name="mpv-video-scale" type="i">
       <summary>Video Upscale Method</summary>
-      <description>0: lanczos, 1: bilinear, 2: ewa_lanczos, 3: mitchell, 4: hermite, 5: oversample, 6: linear, 7: ewa_hanning, 8: ewa_lanczossharp</description>
+      <description
+            >0: lanczos, 1: bilinear, 2: ewa_lanczos, 3: mitchell, 4: hermite, 5: oversample, 6: linear, 7: ewa_hanning, 8: ewa_lanczossharp</description>
       <default>0</default>
     </key>
     <key name="mpv-force-stereo" type="b">
@@ -214,7 +215,11 @@
       <summary>Frefresh when returning to home page</summary>
       <default>false</default>
     </key>
-<key name="is-danmaku-enabled" type="b">
+    <key name="merge-resume-and-next-up" type="b">
+      <summary>Merge Continue Watching and Next Up on Jellyfin</summary>
+      <default>false</default>
+    </key>
+    <key name="is-danmaku-enabled" type="b">
       <summary>Whether the danmaku is enabled</summary>
       <default>false</default>
     </key>

--- a/resources/ui/account_settings.ui
+++ b/resources/ui/account_settings.ui
@@ -102,6 +102,22 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">Home Page</property>
+            <child>
+              <object class="AdwSwitchRow" id="refresh_control">
+                <property name="title" translatable="yes">Refresh when returning to home page</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwSwitchRow" id="merge_resume_next_up_control">
+                <property name="title" translatable="yes">Merge Continue Watching and Next Up</property>
+                <property name="subtitle" translatable="yes">Jellyfin only</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Network</property>
             <child>
               <object class="AdwSpinRow" id="threadspinrow">
@@ -116,11 +132,6 @@
                     <property name="step-increment">1</property>
                   </object>
                 </property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwSwitchRow" id="refresh_control">
-                <property name="title" translatable="yes">Refresh when returning to home page</property>
               </object>
             </child>
           </object>

--- a/resources/ui/home.ui
+++ b/resources/ui/home.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <interface>
   <template parent="AdwNavigationPage" class="HomePage">
     <property name="title">Tsukimi</property>
@@ -19,8 +19,11 @@
                 </child>
                 <child>
                   <object class="HortuScrolled" id="hishortu">
-                    <property name="title" translatable="yes">Continue Watching</property>
-                    <property name="isresume">True</property>
+                    <property
+                                            name="title"
+                                            translatable="yes"
+                                        >Continue Watching</property>
+                    <property name="is-resume">True</property>
                     <property name="prefer-poster">ParentVideo</property>
                     <property name="unify-size">ForceVideo</property>
                   </object>
@@ -28,6 +31,7 @@
                 <child>
                   <object class="HortuScrolled" id="nextuphortu">
                     <property name="title" translatable="yes">Next Up</property>
+                    <property name="is-resume">True</property>
                     <property name="prefer-poster">ParentVideo</property>
                     <property name="unify-size">ForceVideo</property>
                   </object>

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -470,7 +470,7 @@ impl JellyfinClient {
         self.post(&path, &[], body).await
     }
 
-    pub async fn get_resume(&self) -> Result<List> {
+    pub async fn get_resume(&self, limit: u32) -> Result<List> {
         let s = self.session();
         let path = format!("Users/{}/Items/Resume", s.account.user_id);
         let params = [
@@ -482,6 +482,7 @@ impl JellyfinClient {
             ("EnableImageTypes", "Primary,Backdrop,Thumb,Banner"),
             ("ImageTypeLimit", "1"),
             ("MediaTypes", "Video"),
+            ("Limit", &limit.to_string()),
         ];
         self.request(&path, &params).await
     }
@@ -491,15 +492,12 @@ impl JellyfinClient {
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
     }
 
-    pub async fn get_next_up(
-        &self, start: u32, limit: u32, next_up_date_cutoff: &str,
-    ) -> Result<List> {
+    pub async fn get_next_up(&self, limit: u32, next_up_date_cutoff: &str) -> Result<List> {
         if !self.is_jellyfin() {
             bail!("Next up is not supported on Emby");
         }
         let s = self.session();
         let limit = limit.to_string();
-        let start = start.to_string();
         let params = [
             ("Limit", limit.as_str()),
             (
@@ -514,7 +512,6 @@ impl JellyfinClient {
             ("NextUpDateCutoff", next_up_date_cutoff),
             ("EnableResumable", "false"),
             ("EnableRewatching", "false"),
-            ("StartIndex", start.as_str()),
         ];
         self.request("Shows/NextUp", &params).await
     }

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Reverse,
     collections::HashMap,
+    future,
     hash::Hasher,
     time::Duration,
 };
@@ -20,7 +21,10 @@ use chrono::{
     DateTime,
     Utc,
 };
-use futures_util::future;
+use futures_util::{
+    StreamExt,
+    stream::FuturesUnordered,
+};
 use moka::future::Cache;
 use once_cell::sync::Lazy;
 use reqwest::{
@@ -545,19 +549,21 @@ impl JellyfinClient {
         if !self.is_jellyfin() {
             bail!("Next up is not supported on Emby");
         }
-        let resume = self.get_resume(limit).await?;
-        let next_up = self.get_next_up(limit, next_up_date_cutoff).await?;
+        let (resume, next_up) = tokio::try_join!(
+            self.get_resume(limit),
+            self.get_next_up(limit, next_up_date_cutoff)
+        )?;
 
         let date_futures = next_up
             .items
             .iter()
-            .map(|item| async move { (item.id.clone(), self.get_next_up_date(item).await) });
+            .map(|item| async move { (item.id.clone(), self.get_next_up_date(item).await) })
+            .collect::<FuturesUnordered<_>>();
 
-        let next_up_dates = future::join_all(date_futures)
-            .await
-            .into_iter()
-            .filter_map(|(id, date)| Some((id, date?)))
-            .collect::<HashMap<_, _>>();
+        let next_up_dates = date_futures
+            .filter_map(|(id, date)| future::ready(date.map(|d| (id, d))))
+            .collect::<HashMap<_, _>>()
+            .await;
 
         let mut items = resume.items;
         items.extend(next_up.items);

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -1,4 +1,8 @@
-use std::hash::Hasher;
+use std::{
+    cmp::Reverse,
+    collections::HashMap,
+    hash::Hasher,
+};
 
 use crate::{
     client::account::ServerType,
@@ -11,6 +15,11 @@ use anyhow::{
     bail,
 };
 use arc_swap::ArcSwap;
+use chrono::{
+    DateTime,
+    Utc,
+};
+use futures_util::future;
 use once_cell::sync::Lazy;
 use reqwest::{
     Client,
@@ -507,13 +516,79 @@ impl JellyfinClient {
             ("UserId", &s.account.user_id),
             ("ImageTypeLimit", "1"),
             ("EnableImageTypes", "Primary,Backdrop,Banner,Thumb"),
-            ("EnableTotalRecordCount", "true"),
-            ("DisableFirstEpisode", "false"),
+            ("EnableTotalRecordCount", "false"),
+            ("DisableFirstEpisode", "true"),
             ("NextUpDateCutoff", next_up_date_cutoff),
             ("EnableResumable", "false"),
             ("EnableRewatching", "false"),
         ];
         self.request("Shows/NextUp", &params).await
+    }
+
+    /// Get next up and resume items, merge them and sort by last played date in client side.
+    pub async fn get_next_up_merged(&self, limit: u32, next_up_date_cutoff: &str) -> Result<List> {
+        if !self.is_jellyfin() {
+            bail!("Next up is not supported on Emby");
+        }
+
+        let resume = self.get_resume(limit).await?;
+        let next_up = self.get_next_up(limit, next_up_date_cutoff).await?;
+
+        let last_play_time_futures = next_up.items.iter().map(|item| async move {
+            let last_play_time = self.get_next_up_last_play_time(item).await.ok().flatten();
+            (item.id.clone(), last_play_time)
+        });
+
+        let next_up_last_play_times = future::join_all(last_play_time_futures)
+            .await
+            .into_iter()
+            .filter_map(|(id, last_play_time)| Some((id, last_play_time?)))
+            .collect::<HashMap<_, _>>();
+
+        let mut items = resume.items;
+        items.extend(next_up.items);
+        items.sort_by_key(|item| {
+            Reverse(
+                next_up_last_play_times
+                    .get(&item.id)
+                    .copied()
+                    .or_else(|| {
+                        item.user_data
+                            .as_ref()
+                            .and_then(|user_data| user_data.last_played_date)
+                    })
+                    .unwrap_or(DateTime::<Utc>::MIN_UTC),
+            )
+        });
+        items.truncate(limit as usize);
+
+        Ok(List {
+            total_record_count: items.len() as u32,
+            items,
+        })
+    }
+
+    async fn get_next_up_last_play_time(
+        &self, item: &SimpleListItem,
+    ) -> Result<Option<DateTime<Utc>>> {
+        let Some(series_id) = item.series_id.as_deref() else {
+            return Ok(None);
+        };
+        let s = self.session();
+        let path = format!("Shows/{series_id}/Episodes");
+        let params = [
+            ("UserId", s.account.user_id.as_str()),
+            ("AdjacentTo", item.id.as_str()),
+            ("Limit", "1"),
+            ("EnableUserData", "true"),
+        ];
+        let list: List = self.request(&path, &params).await?;
+        Ok(list.items.first().and_then(|episode| {
+            episode
+                .user_data
+                .as_ref()
+                .and_then(|user_data| user_data.last_played_date)
+        }))
     }
 
     pub async fn get_image_items(&self, id: &str) -> Result<Vec<ImageItem>> {

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -2,6 +2,7 @@ use std::{
     cmp::Reverse,
     collections::HashMap,
     hash::Hasher,
+    time::Duration,
 };
 
 use crate::{
@@ -20,6 +21,7 @@ use chrono::{
     Utc,
 };
 use futures_util::future;
+use moka::future::Cache;
 use once_cell::sync::Lazy;
 use reqwest::{
     Client,
@@ -145,6 +147,13 @@ pub struct JellyfinClient {
     pub session: ArcSwap<Session>,
     pub semaphore: tokio::sync::Semaphore,
     pub client: Client,
+    next_up_date_cache: Cache<NextUpDateKey, Option<DateTime<Utc>>>,
+}
+
+#[derive(Hash, PartialEq, Eq)]
+struct NextUpDateKey {
+    series_id: String,
+    item_id: String,
 }
 
 fn generate_jellyfin_authorization(
@@ -167,6 +176,11 @@ impl Default for JellyfinClient {
             session: ArcSwap::from_pointee(Session::empty()),
             semaphore: tokio::sync::Semaphore::new(SETTINGS.threads() as usize),
             client: ReqClient::build(),
+            next_up_date_cache: Cache::builder()
+                .max_capacity(256)
+                .time_to_live(Duration::from_hours(2))
+                .support_invalidation_closures()
+                .build(),
         }
     }
 }
@@ -215,6 +229,7 @@ impl JellyfinClient {
             headers,
             server_name_hash: generate_hash(&account.servername),
         }));
+        self.next_up_date_cache.invalidate_all();
 
         crate::ui::provider::set_admin(false);
         spawn_tokio_without_await(async move {
@@ -530,26 +545,25 @@ impl JellyfinClient {
         if !self.is_jellyfin() {
             bail!("Next up is not supported on Emby");
         }
-
         let resume = self.get_resume(limit).await?;
         let next_up = self.get_next_up(limit, next_up_date_cutoff).await?;
 
-        let last_play_time_futures = next_up.items.iter().map(|item| async move {
-            let last_play_time = self.get_next_up_last_play_time(item).await.ok().flatten();
-            (item.id.clone(), last_play_time)
-        });
+        let date_futures = next_up
+            .items
+            .iter()
+            .map(|item| async move { (item.id.clone(), self.get_next_up_date(item).await) });
 
-        let next_up_last_play_times = future::join_all(last_play_time_futures)
+        let next_up_dates = future::join_all(date_futures)
             .await
             .into_iter()
-            .filter_map(|(id, last_play_time)| Some((id, last_play_time?)))
+            .filter_map(|(id, date)| Some((id, date?)))
             .collect::<HashMap<_, _>>();
 
         let mut items = resume.items;
         items.extend(next_up.items);
         items.sort_by_key(|item| {
             Reverse(
-                next_up_last_play_times
+                next_up_dates
                     .get(&item.id)
                     .copied()
                     .or_else(|| {
@@ -568,27 +582,43 @@ impl JellyfinClient {
         })
     }
 
-    async fn get_next_up_last_play_time(
-        &self, item: &SimpleListItem,
-    ) -> Result<Option<DateTime<Utc>>> {
-        let Some(series_id) = item.series_id.as_deref() else {
-            return Ok(None);
+    async fn get_next_up_date(&self, item: &SimpleListItem) -> Option<DateTime<Utc>> {
+        let series_id = item.series_id.as_ref()?;
+        let user_id = &self.session().account.user_id;
+        let item_id = &item.id;
+        let key = NextUpDateKey {
+            series_id: series_id.to_owned(),
+            item_id: item_id.to_owned(),
         };
-        let s = self.session();
-        let path = format!("Shows/{series_id}/Episodes");
-        let params = [
-            ("UserId", s.account.user_id.as_str()),
-            ("AdjacentTo", item.id.as_str()),
-            ("Limit", "1"),
-            ("EnableUserData", "true"),
-        ];
-        let list: List = self.request(&path, &params).await?;
-        Ok(list.items.first().and_then(|episode| {
-            episode
-                .user_data
-                .as_ref()
-                .and_then(|user_data| user_data.last_played_date)
-        }))
+        self.next_up_date_cache
+            .get_with(key, async move {
+                let path = format!("Shows/{series_id}/Episodes");
+                let params = [
+                    ("UserId", user_id.as_str()),
+                    ("AdjacentTo", item_id.as_str()),
+                    ("Limit", "1"),
+                ];
+                let list: Result<List> = self.request(&path, &params).await;
+                list.inspect_err(|e| {
+                    warn!("Failed to get next up last played time: {}", e);
+                })
+                .ok()
+                .and_then(|list| {
+                    list.items.first().and_then(|episode| {
+                        episode
+                            .user_data
+                            .as_ref()
+                            .and_then(|user_data| user_data.last_played_date)
+                    })
+                })
+            })
+            .await
+    }
+
+    fn invalidate_next_up_date(&self, series_id: String) {
+        let _ = self
+            .next_up_date_cache
+            .invalidate_entries_if(move |key, _| key.series_id == series_id);
     }
 
     pub async fn get_image_items(&self, id: &str) -> Result<Vec<ImageItem>> {
@@ -1017,14 +1047,21 @@ impl JellyfinClient {
         Ok(())
     }
 
-    pub async fn set_as_played(&self, id: &str) -> Result<()> {
+    pub async fn set_as_played<T: Into<String>>(
+        &self, id: &str, series_id: Option<T>,
+    ) -> Result<()> {
         let s = self.session();
         let path = format!("Users/{}/PlayedItems/{}", s.account.user_id, id);
         self.post(&path, &[], json!({})).await?;
+        if let Some(series_id) = series_id {
+            self.invalidate_next_up_date(series_id.into());
+        }
         Ok(())
     }
 
-    pub async fn set_as_unplayed(&self, id: &str) -> Result<()> {
+    pub async fn set_as_unplayed<T: Into<String>>(
+        &self, id: &str, series_id: Option<T>,
+    ) -> Result<()> {
         let s = self.session();
         match self.server_type() {
             ServerType::Emby => {
@@ -1035,6 +1072,9 @@ impl JellyfinClient {
                 let path = format!("Users/{}/PlayedItems/{}", s.account.user_id, id);
                 self.delete(&path, &[]).await?;
             }
+        }
+        if let Some(series_id) = series_id {
+            self.invalidate_next_up_date(series_id.into());
         }
         Ok(())
     }
@@ -1068,6 +1108,11 @@ impl JellyfinClient {
             "Shuffle":false
         });
         self.post(path, &params, body).await?;
+        if matches!(backtype, BackType::Stop)
+            && let Some(series_id) = back.series_id.as_deref()
+        {
+            self.invalidate_next_up_date(series_id.to_owned());
+        }
         Ok(())
     }
 
@@ -1292,11 +1337,16 @@ impl JellyfinClient {
         Ok(())
     }
 
-    pub async fn hide_from_resume(&self, id: &str) -> Result<()> {
+    pub async fn hide_from_resume<T: Into<String>>(
+        &self, id: &str, series_id: Option<T>,
+    ) -> Result<()> {
         let s = self.session();
         let path = format!("Users/{}/Items/{}/HideFromResume", s.account.user_id, id);
         let params = [("Hide", "true")];
         self.post(&path, &params, json!({})).await?;
+        if let Some(series_id) = series_id {
+            self.invalidate_next_up_date(series_id.into());
+        }
         Ok(())
     }
 

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -548,6 +548,7 @@ pub struct ActivityLogs {
 #[derive(Deserialize, Debug, Clone, Builder)]
 pub struct Back {
     pub id: String,
+    pub series_id: Option<String>,
     pub playsessionid: Option<String>,
     pub mediasourceid: String,
     pub livestreamid: Option<String>,

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -275,6 +275,8 @@ pub struct UserData {
     pub played_percentage: Option<f64>,
     #[serde(rename = "PlaybackPositionTicks")]
     pub playback_position_ticks: Option<u64>,
+    #[serde(rename = "LastPlayedDate")]
+    pub last_played_date: Option<DateTime<Utc>>,
     #[serde(rename = "Played")]
     pub played: bool,
     #[serde(rename = "UnplayedItemCount")]

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -115,7 +115,6 @@ impl Settings {
         self.boolean(Self::KEY_IS_REFRESH)
     }
 
-    #[allow(dead_code)]
     pub fn merge_resume_and_next_up(&self) -> bool {
         self.boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP)
     }

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -54,7 +54,6 @@ impl Settings {
     const KEY_MPV_VIDEO_SCALE: &'static str = "mpv-video-scale"; // i32
     const KEY_MPV_CONFIG_DIR: &'static str = "mpv-config-path"; // String
     const KEY_IS_REFRESH: &'static str = "is-refresh"; // bool
-    #[allow(dead_code)]
     const KEY_MERGE_RESUME_AND_NEXT_UP: &'static str = "merge-resume-and-next-up"; // bool
     const KEY_DEVICE_UUID: &'static str = "device-uuid"; // String
     const KEY_MAIN_THEME: &'static str = "main-theme"; // i32
@@ -117,13 +116,6 @@ impl Settings {
 
     pub fn merge_resume_and_next_up(&self) -> bool {
         self.boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP)
-    }
-
-    #[allow(dead_code)]
-    pub fn set_merge_resume_and_next_up(
-        &self, merge_resume_and_next_up: bool,
-    ) -> Result<(), glib::BoolError> {
-        self.set_boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP, merge_resume_and_next_up)
     }
 
     pub fn mpv_config_dir(&self) -> String {

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -54,6 +54,8 @@ impl Settings {
     const KEY_MPV_VIDEO_SCALE: &'static str = "mpv-video-scale"; // i32
     const KEY_MPV_CONFIG_DIR: &'static str = "mpv-config-path"; // String
     const KEY_IS_REFRESH: &'static str = "is-refresh"; // bool
+    #[allow(dead_code)]
+    const KEY_MERGE_RESUME_AND_NEXT_UP: &'static str = "merge-resume-and-next-up"; // bool
     const KEY_DEVICE_UUID: &'static str = "device-uuid"; // String
     const KEY_MAIN_THEME: &'static str = "main-theme"; // i32
     const KEY_WINDOW_WIDTH: &'static str = "window-width"; // i32
@@ -111,6 +113,18 @@ impl Settings {
 
     pub fn is_refresh(&self) -> bool {
         self.boolean(Self::KEY_IS_REFRESH)
+    }
+
+    #[allow(dead_code)]
+    pub fn merge_resume_and_next_up(&self) -> bool {
+        self.boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP)
+    }
+
+    #[allow(dead_code)]
+    pub fn set_merge_resume_and_next_up(
+        &self, merge_resume_and_next_up: bool,
+    ) -> Result<(), glib::BoolError> {
+        self.set_boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP, merge_resume_and_next_up)
     }
 
     pub fn mpv_config_dir(&self) -> String {

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -505,6 +505,7 @@ impl MPVPage {
         self.mpv().set_property("force-media-title", media_title);
 
         let id = item.id();
+        let series_id = item.series_id();
         self.imp().video_scale.reset_scale();
         self.reset_skippable_segments();
 
@@ -607,6 +608,7 @@ impl MPVPage {
 
                 let back = Back {
                     id: id.to_owned(),
+                    series_id,
                     playsessionid: playback_info.play_session_id.to_owned(),
                     mediasourceid: media_source.id.to_owned(),
                     livestreamid: media_source.live_stream_id.to_owned(),
@@ -901,6 +903,7 @@ impl MPVPage {
     }
 
     pub async fn in_play_item(&self, item: TuItem) {
+        self.handle_callback(BackType::Stop);
         let episode_list = self.imp().current_episode_list.borrow().clone();
         self.play(None, item, episode_list, None, 0.0);
     }

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -66,6 +66,8 @@ mod imp {
         #[template_child]
         pub refresh_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub merge_resume_next_up_control: TemplateChild<adw::SwitchRow>,
+        #[template_child]
         pub selectlastcontrol: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub backgroundblurspinrow: TemplateChild<adw::SpinRow>,
@@ -384,6 +386,13 @@ impl AccountSettings {
             .build();
         SETTINGS
             .bind("is-refresh", &imp.refresh_control.get(), "active")
+            .build();
+        SETTINGS
+            .bind(
+                "merge-resume-and-next-up",
+                &imp.merge_resume_next_up_control.get(),
+                "active",
+            )
             .build();
 
         let action_group = gio::SimpleActionGroup::new();

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -50,7 +50,10 @@ use crate::{
 mod imp {
 
     use std::{
-        cell::RefCell,
+        cell::{
+            Cell,
+            RefCell,
+        },
         collections::HashMap,
     };
 
@@ -85,6 +88,7 @@ mod imp {
 
         pub libs_hortu: RefCell<HashMap<String, WeakRef<HortuScrolled>>>,
         pub next_up_date_cutoff: RefCell<String>,
+        pub last_merge_resume_and_next_up: Cell<Option<bool>>,
     }
 
     #[glib::object_subclass]
@@ -163,15 +167,21 @@ impl HomePage {
 
     pub async fn setup(&self, enable_cache: bool) {
         fraction_reset!(self);
+        let merge_resume_and_next_up = SETTINGS.merge_resume_and_next_up();
+        let merge_resume_and_next_up_changed = self
+            .imp()
+            .last_merge_resume_and_next_up
+            .replace(Some(merge_resume_and_next_up))
+            .is_some_and(|previous| previous != merge_resume_and_next_up);
         futures_util::join!(
-            self.setup_history(enable_cache),
-            self.setup_next_up(enable_cache),
+            self.setup_history(enable_cache, merge_resume_and_next_up_changed),
+            self.setup_next_up(enable_cache, merge_resume_and_next_up_changed),
             self.setup_library(enable_cache)
         );
         fraction!(self);
     }
 
-    pub async fn setup_history(&self, enable_cache: bool) {
+    pub async fn setup_history(&self, enable_cache: bool, force_cache_emit: bool) {
         let hortu = self.imp().hishortu.get();
 
         if SETTINGS.merge_resume_and_next_up() && JELLYFIN_CLIENT.is_jellyfin() {
@@ -185,6 +195,8 @@ impl HomePage {
             "history",
             if enable_cache {
                 CachePolicy::ReadCacheAndRefresh
+            } else if force_cache_emit {
+                CachePolicy::RefreshAndEmitLatest
             } else {
                 CachePolicy::RefreshIfChanged
             },
@@ -205,7 +217,7 @@ impl HomePage {
         }
     }
 
-    pub async fn setup_next_up(&self, enable_cache: bool) {
+    pub async fn setup_next_up(&self, enable_cache: bool, force_cache_emit: bool) {
         let hortu = self.imp().nextuphortu.get();
 
         if !JELLYFIN_CLIENT.is_jellyfin() {
@@ -229,6 +241,8 @@ impl HomePage {
 
         let cache_policy = if enable_cache {
             CachePolicy::ReadCacheAndRefresh
+        } else if force_cache_emit {
+            CachePolicy::RefreshAndEmitLatest
         } else {
             CachePolicy::RefreshIfChanged
         };

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -30,9 +30,12 @@ use crate::{
     },
     fraction,
     fraction_reset,
-    ui::provider::tu_item::{
-        PreferPoster,
-        TuItem,
+    ui::{
+        SETTINGS,
+        provider::tu_item::{
+            PreferPoster,
+            TuItem,
+        },
     },
     utils::{
         CacheEvent,
@@ -171,6 +174,13 @@ impl HomePage {
     pub async fn setup_history(&self, enable_cache: bool) {
         let hortu = self.imp().hishortu.get();
 
+        if SETTINGS.merge_resume_and_next_up() && JELLYFIN_CLIENT.is_jellyfin() {
+            // if merged, next up will contain resume items, so hide history
+            hortu.set_visible(false);
+            return;
+        }
+        hortu.set_visible(true);
+
         let mut events = fetch_with_cache(
             "history",
             if enable_cache {
@@ -203,21 +213,39 @@ impl HomePage {
             return;
         }
 
+        if SETTINGS.merge_resume_and_next_up() {
+            // if merged, next up will contain resume items, so change title to continue watching
+            hortu.set_title(gettext("Continue Watching"));
+        } else {
+            hortu.set_title(gettext("Next Up"));
+        }
+
+        hortu.set_visible(true);
+
         let next_up_date_cutoff = JELLYFIN_CLIENT.next_up_date_cutoff();
         self.imp()
             .next_up_date_cutoff
             .replace(next_up_date_cutoff.clone());
 
-        let mut events = fetch_with_cache(
-            "next_up",
-            if enable_cache {
-                CachePolicy::ReadCacheAndRefresh
-            } else {
-                CachePolicy::RefreshIfChanged
-            },
-            async move { JELLYFIN_CLIENT.get_next_up(12, &next_up_date_cutoff).await },
-        )
-        .await;
+        let cache_policy = if enable_cache {
+            CachePolicy::ReadCacheAndRefresh
+        } else {
+            CachePolicy::RefreshIfChanged
+        };
+
+        let mut events = if SETTINGS.merge_resume_and_next_up() {
+            fetch_with_cache("next_up_merged", cache_policy, async move {
+                JELLYFIN_CLIENT
+                    .get_next_up_merged(12, &next_up_date_cutoff)
+                    .await
+            })
+            .await
+        } else {
+            fetch_with_cache("next_up", cache_policy, async move {
+                JELLYFIN_CLIENT.get_next_up(12, &next_up_date_cutoff).await
+            })
+            .await
+        };
 
         while let Some(event) = events.recv().await {
             match event {
@@ -242,22 +270,37 @@ impl HomePage {
                 let Some(window) = obj.root().and_downcast::<Window>() else {
                     return;
                 };
-
-                let title = gettext("Next Up");
                 let next_up_date_cutoff = obj.imp().next_up_date_cutoff.borrow().clone();
+
                 let page = SingleGrid::new();
+
                 page.set_list_type(ListType::NextUp);
                 page.set_unify_size(UnifySize::ForceVideo);
                 page.set_prefer_poster(PreferPoster::ParentVideo);
-                let next_up_date_cutoff_initial = next_up_date_cutoff.clone();
-                page.connect_sort_changed_tokio(move |_, _, _| {
-                    let next_up_date_cutoff_initial = next_up_date_cutoff_initial.clone();
-                    async move {
-                        JELLYFIN_CLIENT
-                            .get_next_up(100, &next_up_date_cutoff_initial)
-                            .await
-                    }
-                });
+
+                let title = if SETTINGS.merge_resume_and_next_up() {
+                    page.set_is_resume(true);
+                    page.connect_sort_changed_tokio(move |_, _, _| {
+                        let next_up_date_cutoff_initial = next_up_date_cutoff.clone();
+                        async move {
+                            JELLYFIN_CLIENT
+                                .get_next_up_merged(100, &next_up_date_cutoff_initial)
+                                .await
+                        }
+                    });
+                    gettext("Continue Watching")
+                } else {
+                    page.connect_sort_changed_tokio(move |_, _, _| {
+                        let next_up_date_cutoff_initial = next_up_date_cutoff.clone();
+                        async move {
+                            JELLYFIN_CLIENT
+                                .get_next_up(100, &next_up_date_cutoff_initial)
+                                .await
+                        }
+                    });
+                    gettext("Next Up")
+                };
+
                 window.push_page(&page, "next_up", &title);
             }
         ));

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -178,7 +178,7 @@ impl HomePage {
             } else {
                 CachePolicy::RefreshIfChanged
             },
-            async { JELLYFIN_CLIENT.get_resume().await },
+            async { JELLYFIN_CLIENT.get_resume(12).await },
         )
         .await;
 
@@ -215,11 +215,7 @@ impl HomePage {
             } else {
                 CachePolicy::RefreshIfChanged
             },
-            async move {
-                JELLYFIN_CLIENT
-                    .get_next_up(0, 12, &next_up_date_cutoff)
-                    .await
-            },
+            async move { JELLYFIN_CLIENT.get_next_up(12, &next_up_date_cutoff).await },
         )
         .await;
 
@@ -258,7 +254,7 @@ impl HomePage {
                     let next_up_date_cutoff_initial = next_up_date_cutoff_initial.clone();
                     async move {
                         JELLYFIN_CLIENT
-                            .get_next_up(0, 100, &next_up_date_cutoff_initial)
+                            .get_next_up(100, &next_up_date_cutoff_initial)
                             .await
                     }
                 });

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -217,7 +217,7 @@ impl HomePage {
             },
             async move {
                 JELLYFIN_CLIENT
-                    .get_next_up(0, 24, &next_up_date_cutoff)
+                    .get_next_up(0, 12, &next_up_date_cutoff)
                     .await
             },
         )
@@ -258,15 +258,7 @@ impl HomePage {
                     let next_up_date_cutoff_initial = next_up_date_cutoff_initial.clone();
                     async move {
                         JELLYFIN_CLIENT
-                            .get_next_up(0, 50, &next_up_date_cutoff_initial)
-                            .await
-                    }
-                });
-                page.connect_end_edge_overshot_tokio(move |_, _, n_items, _| {
-                    let next_up_date_cutoff = next_up_date_cutoff.clone();
-                    async move {
-                        JELLYFIN_CLIENT
-                            .get_next_up(n_items, 50, &next_up_date_cutoff)
+                            .get_next_up(0, 100, &next_up_date_cutoff_initial)
                             .await
                     }
                 });

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -87,7 +87,7 @@ mod imp {
     #[properties(wrapper_type = super::HortuScrolled)]
     pub struct HortuScrolled {
         #[property(get, set, construct_only, default_value = false)]
-        pub isresume: OnceCell<bool>,
+        pub is_resume: OnceCell<bool>,
         #[template_child]
         pub label: TemplateChild<gtk::Label>,
         #[template_child]
@@ -248,7 +248,7 @@ impl HortuScrolled {
                 };
                 let tu_item = object.item();
                 tu_item.update_user_data(&item.user_data);
-                tu_item.set_is_resume(self.isresume());
+                tu_item.set_is_resume(self.is_resume());
                 tu_item.set_prefer_size(prefer_size);
                 tu_item.set_prefer_poster(self.prefer_poster());
                 object

--- a/src/ui/widgets/item_actionbox.rs
+++ b/src/ui/widgets/item_actionbox.rs
@@ -21,6 +21,7 @@ use crate::{
         spawn_tokio,
     },
 };
+
 mod imp {
     use std::cell::RefCell;
 
@@ -37,6 +38,8 @@ mod imp {
         pub favourite_button: TemplateChild<StarToggle>,
         #[property(get, set, nullable)]
         pub id: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        pub series_id: RefCell<Option<String>>,
         #[property(get, set, construct, default = false)]
         pub is_playable: RefCell<bool>,
         #[property(get, set, default = false)]
@@ -89,12 +92,17 @@ impl ItemActionsBox {
     pub fn new() -> Self {
         glib::Object::builder()
             .property("id", None::<String>)
+            .property("series-id", None::<String>)
             .build()
+    }
+
+    fn target_id(&self) -> Option<String> {
+        self.id().or_else(|| self.series_id())
     }
 
     #[template_callback]
     pub async fn on_favourite_button_toggled(&self, btn: &StarToggle) {
-        let id = self.id();
+        let id = self.target_id();
 
         if let Some(id) = id {
             let result = if btn.is_active() {
@@ -125,7 +133,7 @@ impl ItemActionsBox {
                         insert_editm_dialog,
                         ui::widgets::metadata_dialog::MetadataDialog,
                     };
-                    let id = obj.id();
+                    let id = obj.target_id();
                     if let Some(id) = id {
                         let dialog = MetadataDialog::new(&id);
                         insert_editm_dialog!(obj, dialog);
@@ -142,7 +150,7 @@ impl ItemActionsBox {
                         insert_editm_dialog,
                         ui::widgets::image_dialog::ImageDialog,
                     };
-                    let id = obj.id();
+                    let id = obj.target_id();
                     if let Some(id) = id {
                         let dialog = ImageDialog::new(&id);
                         insert_editm_dialog!(obj, dialog);
@@ -157,14 +165,15 @@ impl ItemActionsBox {
                         #[weak(rename_to = obj)]
                         self,
                         move |_, _, _| {
-                            let id = obj.id();
+                            let id = obj.target_id();
+                            let series_id = obj.series_id();
                             if let Some(id) = id {
                                 spawn(glib::clone!(
                                     #[weak]
                                     obj,
                                     async move {
                                         match spawn_tokio(async move {
-                                            JELLYFIN_CLIENT.set_as_unplayed(&id).await
+                                            JELLYFIN_CLIENT.set_as_unplayed(&id, series_id).await
                                         })
                                         .await
                                         {
@@ -189,14 +198,15 @@ impl ItemActionsBox {
                         #[weak(rename_to = obj)]
                         self,
                         move |_, _, _| {
-                            let id = obj.id();
+                            let id = obj.target_id();
+                            let series_id = obj.series_id();
                             if let Some(id) = id {
                                 spawn(glib::clone!(
                                     #[weak]
                                     obj,
                                     async move {
                                         match spawn_tokio(async move {
-                                            JELLYFIN_CLIENT.set_as_played(&id).await
+                                            JELLYFIN_CLIENT.set_as_played(&id, series_id).await
                                         })
                                         .await
                                         {

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -550,10 +550,16 @@ impl SingleGrid {
                     obj.imp().stack.set_visible_child_name("loading");
                     match spawn_tokio(future).await {
                         Ok(item) => {
+                            let total_record_count = item.total_record_count;
                             obj.add_items::<true>(item.items);
-                            obj.imp()
-                                .count
-                                .set_text(&format!("{} Items", item.total_record_count));
+                            let item_number =
+                                if matches!(obj.list_type(), ListType::Resume | ListType::NextUp) {
+                                    // Scroll loading is disabled for Resume and NextUp, so we use the number of items instead of total_record_count
+                                    obj.imp().scrolled.get().n_items()
+                                } else {
+                                    total_record_count
+                                };
+                            obj.set_item_number(item_number);
                         }
                         Err(e) => {
                             obj.toast(e.to_user_facing());

--- a/src/ui/widgets/tu_item/action.rs
+++ b/src/ui/widgets/tu_item/action.rs
@@ -47,7 +47,9 @@ pub enum Action {
 }
 
 pub trait TuItemAction {
-    async fn perform_action_inner(id: &str, action: &Action) -> Result<()>;
+    async fn perform_action_inner(
+        id: String, series_id: Option<String>, action: &Action,
+    ) -> Result<()>;
 
     async fn perform_action(&self, action: Action);
 
@@ -73,20 +75,24 @@ where
     T: TuItemBasic + TuItemMenuPrelude + IsA<gtk::Widget> + glib::clone::Downgrade,
     <T as glib::clone::Downgrade>::Weak: glib::clone::Upgrade<Strong = T>,
 {
-    async fn perform_action_inner(id: &str, action: &Action) -> Result<()> {
+    async fn perform_action_inner(
+        id: String, series_id: Option<String>, action: &Action,
+    ) -> Result<()> {
         match action {
-            Action::Like => JELLYFIN_CLIENT.like(id).await,
-            Action::Unlike => JELLYFIN_CLIENT.unlike(id).await,
-            Action::Played => JELLYFIN_CLIENT.set_as_played(id).await,
-            Action::Unplayed => JELLYFIN_CLIENT.set_as_unplayed(id).await,
-            Action::Remove => JELLYFIN_CLIENT.hide_from_resume(id).await,
+            Action::Like => JELLYFIN_CLIENT.like(&id).await,
+            Action::Unlike => JELLYFIN_CLIENT.unlike(&id).await,
+            Action::Played => JELLYFIN_CLIENT.set_as_played(&id, series_id).await,
+            Action::Unplayed => JELLYFIN_CLIENT.set_as_unplayed(&id, series_id).await,
+            Action::Remove => JELLYFIN_CLIENT.hide_from_resume(&id, series_id).await,
         }
     }
 
     async fn perform_action(&self, action: Action) {
-        let id = self.item().id().to_owned();
+        let id = self.item().id();
+        let series_id = self.item().series_id();
         self.update_state(&action);
-        let result = spawn_tokio(async move { Self::perform_action_inner(&id, &action).await });
+        let result =
+            spawn_tokio(async move { Self::perform_action_inner(id, series_id, &action).await });
 
         match result.await {
             Ok(_) => self.toast(gettext("Success")),

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -180,10 +180,10 @@ impl TuItemProgressbarAnimationPrelude for TuOverviewItem {
 
 #[template_callbacks]
 impl TuOverviewItem {
-    pub fn new(item: TuItem, isresume: bool) -> Self {
+    pub fn new(item: TuItem, is_resume: bool) -> Self {
         Object::builder()
             .property("item", item)
-            .property("isresume", isresume)
+            .property("is_resume", is_resume)
             .build()
     }
 


### PR DESCRIPTION
close #602

~~This is currently a draft and still missing part of the implementation:~~

~~1. The current logic follows Wholphin’s approach: each Next Up item needs to load the play time of the “previous item” individually, then use that timestamp to merge with Continue Watching. This is a typical 1+n query problem, so an in-memory cache is needed to avoid performance issues.~~

~~2. For some reason, progress updates on the home page have animation but do not actually take effect. This needs further investigation.~~

---

This PR supports merging Jellyfin’s Continue Watching and Next Up into a single row.

The implementation follows a path similar to Wholphin: it loads Continue Watching and Next Up separately, then loads the latest episode playback date for each Next Up entry individually. This is necessary because Next Up shows unwatched episodes, which do not have their own playback dates. The playback date is then used as the key to interleave all entries. Since Next Up can contain many items, the merged row reuses the existing Next Up logic to support expanding and showing more items. In essence, this implementation is not “Continue Watching including Next Up”, but rather “Next Up including Continue Watching, named Continue Watching”.

The overall feature in this PR is simple. Most of the complexity comes from the cache introduced to mitigate the Next Up N+1 issue. This cache records the latest playback date corresponding to each Next Up entry, and manually invalidates the entire series when a Next Up item’s playback state changes, such as marking watched, marking unwatched, or playing through mpv. Movies do not need to be considered here, because items appearing in Next Up can only be series content.

Additionally, while working on this feature, I found that switching episodes in a playlist did not trigger a stop event. This PR also includes a small fix in `in_play_item` to cover that case.