### PR TITLE
feat: support MPV progress bar dragging and fix position reporting

### DIFF
--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -207,6 +207,7 @@ mod imp {
         pub back_timeout: RefCell<Option<glib::source::SourceId>>,
         pub back: RefCell<Option<Back>>,
         pub seeking: RefCell<bool>,
+        pub last_playback_position: Cell<f64>,
         pub x: RefCell<f64>,
         pub y: RefCell<f64>,
         pub last_motion_time: RefCell<i64>,
@@ -507,6 +508,7 @@ impl MPVPage {
         let id = item.id();
         let series_id = item.series_id();
         self.imp().video_scale.reset_scale();
+        self.imp().last_playback_position.set(start_seconds);
         self.reset_skippable_segments();
 
         // If the video_matcher is None, field wont be updated
@@ -748,9 +750,6 @@ impl MPVPage {
                 _ => unreachable!(),
             };
             self.imp().skip_segment_button.set_label(&label);
-            self.imp()
-                .skip_segment_button
-                .set_tooltip_text(Some(&label));
         }
         let segment_end = current_segment.map(|(_, end)| end);
         self.imp().current_segment_end.set(segment_end);
@@ -767,6 +766,7 @@ impl MPVPage {
 
         self.imp().video.set_position(end);
         self.imp().video_scale.set_value(end);
+        self.imp().last_playback_position.set(end);
         self.imp().skip_segment_revealer.set_reveal_child(false);
         self.handle_callback(BackType::Back);
     }
@@ -1024,7 +1024,10 @@ impl MPVPage {
     }
 
     fn scale_cb(&self, value: i64) {
-        self.imp().video_scale.set_value(value as f64);
+        self.imp().last_playback_position.set(value as f64);
+        if !self.imp().video_scale.is_dragging() {
+            self.imp().video_scale.set_value(value as f64);
+        }
         self.update_skip_segment_button(value as f64);
     }
 
@@ -1326,7 +1329,7 @@ impl MPVPage {
     }
 
     fn handle_callback(&self, backtype: BackType) {
-        let position = self.imp().video_scale.value();
+        let position = self.imp().last_playback_position.get();
         let back = self.imp().back.borrow();
 
         if let Some(back) = back.as_ref() {

--- a/src/ui/mpv/video_scale.rs
+++ b/src/ui/mpv/video_scale.rs
@@ -1,6 +1,7 @@
 use gtk::{
     glib,
     prelude::*,
+    subclass::prelude::*,
 };
 
 use super::tsukimi_mpv::ChapterList;
@@ -71,16 +72,7 @@ mod imp {
         }
     }
     impl WidgetImpl for VideoScale {}
-    impl RangeImpl for VideoScale {
-        fn change_value(&self, scroll_type: gtk::ScrollType, new_value: f64) -> glib::Propagation {
-            if self.is_dragging.get() {
-                glib::Propagation::Stop
-            } else {
-                self.parent_change_value(scroll_type, new_value);
-                glib::Propagation::Proceed
-            }
-        }
-    }
+    impl RangeImpl for VideoScale {}
     impl ScaleImpl for VideoScale {}
 
     impl VideoScale {
@@ -138,6 +130,10 @@ impl VideoScale {
     pub fn reset_scale(&self) {
         self.set_value(0.0);
         self.set_fill_level(0.0);
+    }
+
+    pub fn is_dragging(&self) -> bool {
+        self.imp().is_dragging.get()
     }
 
     pub fn set_chapter_list(&self, chapter_list: ChapterList) {


### PR DESCRIPTION
1. Correctly implement MPV progress bar dragging.

2. Use `last_playback_position` as the trusted source for video progress reporting. The progress bar value is unreliable because users may drag it at any time, while reading the MPV video position directly can return `0` after playback ends. `last_playback_position` records the last confirmed playback position instead.