### PR TITLE
fix: prevent flicker from progress text width changes

### DIFF
--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -1009,8 +1009,12 @@ impl MPVPage {
 
     fn update_duration(&self, value: f64) {
         let imp = self.imp();
+        let duration = format_duration(value as i64);
+        let width_chars = duration.chars().count() as i32;
         imp.video_scale.set_range(0.0, value);
-        imp.duration_label.set_text(&format_duration(value as i64));
+        imp.progress_time_label.set_width_chars(width_chars);
+        imp.duration_label.set_width_chars(width_chars);
+        imp.duration_label.set_text(&duration);
     }
 
     fn speed_cb(&self, value: f64) {

--- a/src/ui/widgets/player_toolbar.rs
+++ b/src/ui/widgets/player_toolbar.rs
@@ -174,16 +174,19 @@ impl PlayerToolbarBox {
     }
 
     pub fn change_view(&self, duration: ClockTime) {
-        let duration = duration.seconds();
+        let duration_seconds = duration.seconds();
         let Some(core_song) = self.imp().player.active_core_song() else {
             return;
         };
         let imp = self.imp();
         imp.title_label.set_text(&core_song.name());
         imp.artist_label.set_text(&core_song.artist());
-        imp.duration_label
-            .set_text(&format_duration(duration as i64));
-        imp.progress_scale.set_range(0.0, duration as f64);
+        let duration = format_duration(duration_seconds as i64);
+        let width_chars = duration.chars().count() as i32;
+        imp.progress_time_label.set_width_chars(width_chars);
+        imp.duration_label.set_width_chars(width_chars);
+        imp.duration_label.set_text(&duration);
+        imp.progress_scale.set_range(0.0, duration_seconds as f64);
         spawn(glib::clone!(
             #[weak]
             imp,


### PR DESCRIPTION
Dragging the progress bar across the `9:59` → `10:00` boundary caused the progress label to grow from four to five characters. That layout change shifted the seek bar itself, which changed the timestamp under the stationary cursor back across the boundary. The label then shrank again, shifting the seek bar back and creating a rapid flicker loop.

This PR fixes the issue by reserving a stable width for the progress labels.


https://github.com/user-attachments/assets/0e1a1a92-53cf-4a72-b6fa-54f30d63b6e5

