### PR TITLE
ui: fix season view scrolling by converting to AdwCarousel

### DIFF
--- a/resources/ui/other.ui
+++ b/resources/ui/other.ui
@@ -3,193 +3,211 @@
   <template parent="AdwNavigationPage" class="OtherPage">
     <property name="title">Tsukimi</property>
     <child>
-      <object class="AdwToolbarView">
+      <object class="GtkOverlay">
+        <property name="overflow">hidden</property>
+        <child type="overlay">
+          <object class="AdwCarouselIndicatorDots">
+            <property name="margin-end">10</property>
+            <property name="halign">end</property>
+            <property name="valign">center</property>
+            <property name="orientation">vertical</property>
+            <property name="carousel">main_carousel</property>
+          </object>
+        </child>
         <child>
-          <object class="AdwToastOverlay" id="toast">
+          <object class="AdwToolbarView">
             <child>
-              <object class="GtkScrolledWindow">
-                <property name="hscrollbar-policy">never</property>
+              <object class="AdwToastOverlay" id="toast">
                 <child>
-                  <object class="GtkBox" id="listbox">
+                  <object class="AdwCarousel" id="main_carousel">
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
                     <property name="orientation">vertical</property>
-                    <property name="spacing">9</property>
-                    <property name="margin-bottom">18</property>
                     <child>
-                      <object class="GtkRevealer" id="inforevealer">
-                        <property name="transition-duration">300</property>
-                        <property name="reveal-child">False</property>
-                        <property name="vexpand-set">True</property>
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">9</property>
+                        <property name="hexpand">true</property>
                         <child>
-                          <object class="GtkBox">
-                            <property name="orientation">horizontal</property>
-                            <property name="spacing">6</property>
-                            <property name="margin-end">32</property>
-                            <property name="margin-start">18</property>
-                            <property name="spacing">32</property>
-                            <property name="margin-bottom">20</property>
-                            <property name="halign">fill</property>
-                            <property name="valign">start</property>
-                            <child>
-                              <object class="GtkBox" id="picbox">
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">6</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-top">12</property>
-                                <property name="halign">fill</property>
-                                <property name="valign">start</property>
-                                <property name="height-request">328</property>
-                                <property name="width-request">218</property>
-                              </object>
-                            </child>
+                          <object class="GtkRevealer" id="inforevealer">
+                            <property name="transition-duration">300</property>
+                            <property name="reveal-child">False</property>
+                            <property name="vexpand-set">True</property>
                             <child>
                               <object class="GtkBox">
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">20</property>
+                                <property name="orientation">horizontal</property>
+                                <property name="spacing">6</property>
+                                <property name="margin-end">32</property>
+                                <property name="margin-start">18</property>
+                                <property name="spacing">32</property>
+                                <property name="margin-bottom">20</property>
+                                <property name="halign">fill</property>
+                                <property name="valign">start</property>
                                 <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">horizontal</property>
+                                  <object class="GtkBox" id="picbox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">6</property>
+                                    <property name="margin-start">12</property>
                                     <property name="margin-top">12</property>
-                                    <child>
-                                      <object class="GtkLabel" id="title">
-                                        <property name="label" translatable="yes">Name</property>
-                                        <property name="halign">start</property>
-                                        <property name="valign">end</property>
-                                        <property name="wrap">true</property>
-                                        <attributes>
-                                          <attribute name="weight" value="PANGO_WEIGHT_BOLD"/>
-                                          <attribute name="scale" value="1.5"/>
-                                        </attributes>
-                                      </object>
-                                    </child>
+                                    <property name="halign">fill</property>
+                                    <property name="valign">start</property>
+                                    <property name="height-request">328</property>
+                                    <property name="width-request">218</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="orientation">horizontal</property>
-                                    <property name="spacing">12</property>
-                                    <property name="margin-top">6</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">20</property>
                                     <child>
-                                      <object class="GtkButton" id="play_button">
-                                        <property name="width-request">44</property>
-                                        <property name="height-request">44</property>
-                                        <property name="icon-name">media-playback-start-symbolic</property>
-                                        <property name="tooltip-text" translatable="yes">Play</property>
-                                        <property name="valign">center</property>
-                                        <property name="visible">False</property>
+                                      <object class="GtkBox">
+                                        <property name="orientation">horizontal</property>
+                                        <property name="margin-top">12</property>
+                                        <child>
+                                          <object class="GtkLabel" id="title">
+                                            <property name="label" translatable="yes">Name</property>
+                                            <property name="halign">start</property>
+                                            <property name="valign">end</property>
+                                            <property name="wrap">true</property>
+                                            <attributes>
+                                              <attribute name="weight" value="PANGO_WEIGHT_BOLD"/>
+                                              <attribute name="scale" value="1.5"/>
+                                            </attributes>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="orientation">horizontal</property>
+                                        <property name="spacing">12</property>
+                                        <property name="margin-top">6</property>
+                                        <child>
+                                          <object class="GtkButton" id="play_button">
+                                            <property name="width-request">44</property>
+                                            <property name="height-request">44</property>
+                                            <property name="icon-name">media-playback-start-symbolic</property>
+                                            <property name="tooltip-text" translatable="yes">Play</property>
+                                            <property name="valign">center</property>
+                                            <property name="visible">False</property>
+                                            <style>
+                                              <class name="circular"/>
+                                              <class name="suggested-action"/>
+                                            </style>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="ItemActionsBox" id="actionbox">
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkInscription" id="inscription">
+                                        <property name="tooltip-text" bind-source="inscription" bind-property="text" bind-flags="sync-create" translatable="yes"/>
+                                        <property name="text" translatable="yes">No Inscriptions</property>
+                                        <property name="valign">fill</property>
+                                        <property name="yalign">0.20</property>
+                                        <property name="margin-top">12</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="vexpand">True</property>
+                                        <property name="min-lines">3</property>
+                                        <property name="text-overflow">ellipsize-end</property>
                                         <style>
-                                          <class name="circular"/>
-                                          <class name="suggested-action"/>
+                                          <class name="caption-heading"/>
                                         </style>
                                       </object>
                                     </child>
-                                    <child>
-                                      <object class="ItemActionsBox" id="actionbox">
-                                      </object>
-                                    </child>
                                   </object>
                                 </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HortuScrolled" id="moviehortu">
+                            <property name="title" translatable="yes">Movie</property>
+                            <property name="moreview">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HortuScrolled" id="serieshortu">
+                            <property name="title" translatable="yes">Series</property>
+                            <property name="moreview">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HortuScrolled" id="episodehortu">
+                            <property name="title" translatable="yes">Episode</property>
+                            <property name="moreview">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HortuScrolled" id="videohortu">
+                            <property name="title" translatable="yes">Video</property>
+                            <property name="moreview">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HortuScrolled" id="actorhortu">
+                            <property name="title" translatable="yes">Actors</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HorbuScrolled" id="studioshorbu">
+                            <property name="title" translatable="yes">Studios</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HorbuScrolled" id="tagshorbu">
+                            <property name="title" translatable="yes">Tags</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HorbuScrolled" id="genreshorbu">
+                            <property name="title" translatable="yes">Genres</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="HorbuScrolled" id="linkshorbu">
+                            <property name="title" translatable="yes">Links</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <property name="hscrollbar-policy">never</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">9</property>
+                            <property name="margin-bottom">18</property>
+                            <child>
+                              <object class="GtkRevealer" id="episode_list_revealer">
+                                <property name="reveal-child">False</property>
                                 <child>
-                                  <object class="GtkInscription" id="inscription">
-                                    <property name="tooltip-text" bind-source="inscription" bind-property="text" bind-flags="sync-create" translatable="yes"/>
-                                    <property name="text" translatable="yes">No Inscriptions</property>
-                                    <property name="valign">fill</property>
-                                    <property name="yalign">0.20</property>
-                                    <property name="margin-top">12</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="vexpand">True</property>
-                                    <property name="min-lines">3</property>
-                                    <property name="text-overflow">ellipsize-end</property>
+                                  <object class="GtkListView" id="episode_list">
+                                    <property name="margin-start">18</property>
+                                    <property name="margin-end">18</property>
+                                    <property name="single-click-activate">True</property>
+                                    <signal name="activate" handler="on_listview_item_activated" swapped="yes"/>
                                     <style>
-                                      <class name="caption-heading"/>
+                                      <class name="tu-listview"/>
                                     </style>
                                   </object>
                                 </child>
-
                               </object>
                             </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HortuScrolled" id="moviehortu">
-                        <property name="title" translatable="yes">Movie</property>
-                        <property name="moreview">True</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HortuScrolled" id="serieshortu">
-                        <property name="title" translatable="yes">Series</property>
-                        <property name="moreview">True</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HortuScrolled" id="episodehortu">
-                        <property name="title" translatable="yes">Episode</property>
-                        <property name="moreview">True</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HortuScrolled" id="videohortu">
-                        <property name="title" translatable="yes">Video</property>
-                        <property name="moreview">True</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HortuScrolled" id="actorhortu">
-                        <property name="title" translatable="yes">Actors</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HorbuScrolled" id="studioshorbu">
-                        <property name="title" translatable="yes">Studios</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HorbuScrolled" id="tagshorbu">
-                        <property name="title" translatable="yes">Tags</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HorbuScrolled" id="genreshorbu">
-                        <property name="title" translatable="yes">Genres</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="HorbuScrolled" id="linkshorbu">
-                        <property name="title" translatable="yes">Links</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkRevealer" id="episode_list_revealer">
-                        <property name="reveal-child">False</property>
-                        <property name="vexpand-set">True</property>
-                        <child>
-                          <object class="GtkScrolledWindow">
-                            <property name="hscrollbar-policy">never</property>
-                            <property name="vscrollbar-policy">always</property>
-                            <property name="overlay-scrolling">False</property>
-                            <property name="vexpand">True</property>
                             <child>
-                              <object class="GtkListView" id="episode_list">
+                              <object class="GtkBox" id="information_box">
                                 <property name="margin-start">18</property>
-                                <property name="margin-end">18</property>
-                                <property name="single-click-activate">True</property>
-                                <signal name="activate" handler="on_listview_item_activated" swapped="yes"/>
-                                <style>
-                                  <class name="tu-listview"/>
-                                </style>
+                                <property name="spacing">30</property>
+                                <property name="orientation">vertical</property>
                               </object>
                             </child>
                           </object>
                         </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="information_box">
-                        <property name="margin-start">18</property>
-                        <property name="spacing">30</property>
-                        <property name="orientation">vertical</property>
                       </object>
                     </child>
                   </object>

--- a/resources/ui/other.ui
+++ b/resources/ui/other.ui
@@ -33,7 +33,6 @@
                             <property name="spacing">9</property>
                             <property name="margin-bottom">18</property>
                             <property name="hexpand">true</property>
-                            <property name="vexpand">true</property>
                             <child>
                           <object class="GtkRevealer" id="inforevealer">
                             <property name="transition-duration">300</property>
@@ -204,8 +203,6 @@
                               <object class="GtkListView" id="episode_list">
                                 <property name="margin-start">18</property>
                                 <property name="margin-end">18</property>
-                                <property name="valign">fill</property>
-                                <property name="vexpand">True</property>
                                 <property name="single-click-activate">True</property>
                                 <signal name="activate" handler="on_listview_item_activated" swapped="yes"/>
                                 <style>

--- a/resources/ui/other.ui
+++ b/resources/ui/other.ui
@@ -24,11 +24,17 @@
                     <property name="vexpand">true</property>
                     <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkBox">
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">9</property>
-                        <property name="hexpand">true</property>
+                      <object class="GtkScrolledWindow">
+                        <property name="hscrollbar-policy">never</property>
+                        <property name="vexpand">True</property>
                         <child>
+                          <object class="GtkBox" id="listbox">
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">9</property>
+                            <property name="margin-bottom">18</property>
+                            <property name="hexpand">true</property>
+                            <property name="vexpand">true</property>
+                            <child>
                           <object class="GtkRevealer" id="inforevealer">
                             <property name="transition-duration">300</property>
                             <property name="reveal-child">False</property>
@@ -124,79 +130,53 @@
                             </child>
                           </object>
                         </child>
-                        <child>
-                          <object class="HortuScrolled" id="moviehortu">
-                            <property name="title" translatable="yes">Movie</property>
-                            <property name="moreview">True</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HortuScrolled" id="serieshortu">
-                            <property name="title" translatable="yes">Series</property>
-                            <property name="moreview">True</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HortuScrolled" id="episodehortu">
-                            <property name="title" translatable="yes">Episode</property>
-                            <property name="moreview">True</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HortuScrolled" id="videohortu">
-                            <property name="title" translatable="yes">Video</property>
-                            <property name="moreview">True</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HortuScrolled" id="actorhortu">
-                            <property name="title" translatable="yes">Actors</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HorbuScrolled" id="studioshorbu">
-                            <property name="title" translatable="yes">Studios</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HorbuScrolled" id="tagshorbu">
-                            <property name="title" translatable="yes">Tags</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HorbuScrolled" id="genreshorbu">
-                            <property name="title" translatable="yes">Genres</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="HorbuScrolled" id="linkshorbu">
-                            <property name="title" translatable="yes">Links</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkScrolledWindow">
-                        <property name="hscrollbar-policy">never</property>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">9</property>
-                            <property name="margin-bottom">18</property>
                             <child>
-                              <object class="GtkRevealer" id="episode_list_revealer">
-                                <property name="reveal-child">False</property>
-                                <child>
-                                  <object class="GtkListView" id="episode_list">
-                                    <property name="margin-start">18</property>
-                                    <property name="margin-end">18</property>
-                                    <property name="single-click-activate">True</property>
-                                    <signal name="activate" handler="on_listview_item_activated" swapped="yes"/>
-                                    <style>
-                                      <class name="tu-listview"/>
-                                    </style>
-                                  </object>
-                                </child>
+                              <object class="HortuScrolled" id="moviehortu">
+                                <property name="title" translatable="yes">Movie</property>
+                                <property name="moreview">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HortuScrolled" id="serieshortu">
+                                <property name="title" translatable="yes">Series</property>
+                                <property name="moreview">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HortuScrolled" id="episodehortu">
+                                <property name="title" translatable="yes">Episode</property>
+                                <property name="moreview">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HortuScrolled" id="videohortu">
+                                <property name="title" translatable="yes">Video</property>
+                                <property name="moreview">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HortuScrolled" id="actorhortu">
+                                <property name="title" translatable="yes">Actors</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HorbuScrolled" id="studioshorbu">
+                                <property name="title" translatable="yes">Studios</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HorbuScrolled" id="tagshorbu">
+                                <property name="title" translatable="yes">Tags</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HorbuScrolled" id="genreshorbu">
+                                <property name="title" translatable="yes">Genres</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="HorbuScrolled" id="linkshorbu">
+                                <property name="title" translatable="yes">Links</property>
                               </object>
                             </child>
                             <child>
@@ -204,6 +184,33 @@
                                 <property name="margin-start">18</property>
                                 <property name="spacing">30</property>
                                 <property name="orientation">vertical</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="episode_page">
+                        <property name="hscrollbar-policy">never</property>
+                        <property name="vscrollbar-policy">always</property>
+                        <property name="overlay-scrolling">False</property>
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="GtkRevealer" id="episode_list_revealer">
+                            <property name="reveal-child">False</property>
+                            <property name="vexpand">True</property>
+                            <child>
+                              <object class="GtkListView" id="episode_list">
+                                <property name="margin-start">18</property>
+                                <property name="margin-end">18</property>
+                                <property name="valign">fill</property>
+                                <property name="vexpand">True</property>
+                                <property name="single-click-activate">True</property>
+                                <signal name="activate" handler="on_listview_item_activated" swapped="yes"/>
+                                <style>
+                                  <class name="tu-listview"/>
+                                </style>
                               </object>
                             </child>
                           </object>

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -879,7 +879,11 @@ impl ItemPage {
                         .iter()
                         .map(|season| season.name.as_str())
                         .collect::<Vec<_>>();
-                    season_list_store.splice(1, season_list_store.n_items().saturating_sub(1), &names);
+                    season_list_store.splice(
+                        1,
+                        season_list_store.n_items().saturating_sub(1),
+                        &names,
+                    );
                     imp.seasonshortu.set_items(season_list.to_owned());
                     imp.season_list_vec.replace(season_list);
                     self.on_season_selected(None, imp.seasonlist.get()).await;

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -341,7 +341,6 @@ impl OtherPage {
                         store.append(&tu_item);
                     }
 
-                    self.imp().episode_list_revealer.set_vexpand(true);
                     self.imp().episode_list_revealer.set_reveal_child(true);
                 }
                 CacheEvent::Error(e) => {

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -361,7 +361,6 @@ impl OtherPage {
                     if episode_page.parent().is_none() {
                         self.imp().main_carousel.append(&episode_page);
                     }
-                    self.imp().episode_list_revealer.set_vexpand(true);
                     self.imp().episode_list_revealer.set_reveal_child(true);
                 }
                 CacheEvent::Error(e) => {

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -106,6 +106,10 @@ pub(crate) mod imp {
         pub play_button: TemplateChild<gtk::Button>,
 
         #[template_child]
+        pub main_carousel: TemplateChild<adw::Carousel>,
+        #[template_child]
+        pub episode_page: TemplateChild<gtk::ScrolledWindow>,
+        #[template_child]
         pub information_box: TemplateChild<gtk::Box>,
 
         #[template_child]
@@ -113,6 +117,7 @@ pub(crate) mod imp {
         #[template_child]
         pub episode_list_revealer: TemplateChild<gtk::Revealer>,
 
+        pub episode_page_holder: OnceCell<gtk::ScrolledWindow>,
         pub selection: gtk::SingleSelection,
     }
 
@@ -141,6 +146,12 @@ pub(crate) mod imp {
             self.parent_constructed();
             let obj = self.obj();
             let store = gio::ListStore::new::<TuObject>();
+
+            let episode_page = self.episode_page.get();
+            self.episode_page_holder
+                .set(episode_page.clone())
+                .expect("episode page should only be stored once");
+            self.main_carousel.remove(&episode_page);
 
             spawn_g_timeout(glib::clone!(
                 #[weak]
@@ -341,6 +352,16 @@ impl OtherPage {
                         store.append(&tu_item);
                     }
 
+                    let episode_page = self
+                        .imp()
+                        .episode_page_holder
+                        .get()
+                        .expect("episode page should be stored during construction")
+                        .clone();
+                    if episode_page.parent().is_none() {
+                        self.imp().main_carousel.append(&episode_page);
+                    }
+                    self.imp().episode_list_revealer.set_vexpand(true);
                     self.imp().episode_list_revealer.set_reveal_child(true);
                 }
                 CacheEvent::Error(e) => {


### PR DESCRIPTION
Currently the season view has the episodes in an unreachable area at the bottom. I assume there used to be possible to scroll there. But it is no longer possible to do so: 
<img width="3122" height="1792" alt="image" src="https://github.com/user-attachments/assets/409ff889-3642-4d1a-9137-3131bcbbf6c6" />
I tried both a scrollable version and a carousel version. The later being the PR. The scrollable is a lot less code change but the application seems to be heading into carousel way. Thats why I decided to PR the later.