### PR TITLE
Add Windows 11 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,14 @@ jobs:
     uses: ./.github/workflows/build_linux.yml
     secrets: inherit
 
+  windows:
+    name: Windows
+    uses: ./.github/workflows/build_windows.yml
+    secrets: inherit
+
   artifacts:
     name: Artifacts
     if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/artifacts.yml
-    needs: [linux]
+    needs: [linux, windows]
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
   artifacts:
     name: Artifacts
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && (github.repository == 'tsukinaha/tsukimi' || github.ref_type == 'tag') }}
     uses: ./.github/workflows/artifacts.yml
     needs: [linux, windows]
     secrets: inherit

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,113 @@
+name: Windows
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build (x86_64-windows)
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            git
+            mingw-w64-ucrt-x86_64-cargo
+            mingw-w64-ucrt-x86_64-rust
+            mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-gtk4
+            mingw-w64-ucrt-x86_64-libadwaita
+            mingw-w64-ucrt-x86_64-gstreamer
+            mingw-w64-ucrt-x86_64-gst-plugins-base
+            mingw-w64-ucrt-x86_64-gst-plugins-good
+            mingw-w64-ucrt-x86_64-gst-plugins-bad
+            mingw-w64-ucrt-x86_64-gst-plugins-ugly
+            mingw-w64-ucrt-x86_64-gst-libav
+            mingw-w64-ucrt-x86_64-mpv
+            mingw-w64-ucrt-x86_64-libepoxy
+            mingw-w64-ucrt-x86_64-gettext
+            mingw-w64-ucrt-x86_64-glib2
+            mingw-w64-ucrt-x86_64-cc
+            mingw-w64-ucrt-x86_64-lld
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-meson
+            zip
+
+      - name: Build
+        env:
+          CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+        run: |
+          mkdir -p secret
+          echo "${{ secrets.DANDANAPI_SECRET_KEY || 'testing' }}" > secret/key
+          cargo build --release --locked
+
+      - name: Compile resources
+        run: |
+          mkdir -p target/release/share/tsukimi
+          glib-compile-resources \
+            --sourcedir=resources \
+            --target=target/release/share/tsukimi/tsukimi.gresource \
+            resources/resources.gresource.xml
+          mkdir -p target/release/share/glib-2.0/schemas
+          cp resources/moe.tsuna.tsukimi.gschema.xml target/release/share/glib-2.0/schemas/
+          glib-compile-schemas target/release/share/glib-2.0/schemas
+
+      - name: Bundle runtime
+        run: |
+          mkdir -p artifact/tsukimi-x86_64-windows
+          cp target/release/tsukimi.exe artifact/tsukimi-x86_64-windows/
+          cp -r target/release/share artifact/tsukimi-x86_64-windows/
+
+          ldd target/release/tsukimi.exe \
+            | awk '/mingw64|ucrt64/ {print $3}' \
+            | sort -u \
+            | xargs -r -I{} cp -n "{}" artifact/tsukimi-x86_64-windows/
+
+          for dll in /ucrt64/bin/*.dll; do
+            case "$(basename "$dll")" in
+              libgst*|libgdk*|libgtk*|libadwaita*|libgio*|libglib*|libgobject*|libgmodule*|libgstreamer*|libmpv*|libepoxy*|libintl*|libpango*|libcairo*|libgdk_pixbuf*|libgraphene*|libharfbuzz*|libfontconfig*|libfreetype*|libfribidi*|libthai*|libjpeg*|libpng*|libtiff*|libwebp*|libxml*|libsoup*|libssl*|libcrypto*|zlib*)
+                cp -n "$dll" artifact/tsukimi-x86_64-windows/
+                ;;
+            esac
+          done
+
+          mkdir -p artifact/tsukimi-x86_64-windows/lib/gstreamer-1.0
+          cp -n /ucrt64/lib/gstreamer-1.0/*.dll artifact/tsukimi-x86_64-windows/lib/gstreamer-1.0/
+
+          mkdir -p artifact/tsukimi-x86_64-windows/lib/gdk-pixbuf-2.0
+          if [ -d /ucrt64/lib/gdk-pixbuf-2.0 ]; then
+            cp -r /ucrt64/lib/gdk-pixbuf-2.0/* artifact/tsukimi-x86_64-windows/lib/gdk-pixbuf-2.0/
+          fi
+
+          {
+            printf '@echo off\r\n'
+            printf 'setlocal\r\n'
+            printf 'set "APPDIR=%%~dp0"\r\n'
+            printf 'set "PATH=%%APPDIR%%;%%PATH%%"\r\n'
+            printf 'set "GSETTINGS_SCHEMA_DIR=%%APPDIR%%share\\glib-2.0\\schemas"\r\n'
+            printf 'set "XDG_DATA_DIRS=%%APPDIR%%share"\r\n'
+            printf 'set "GST_PLUGIN_PATH=%%APPDIR%%lib\\gstreamer-1.0"\r\n'
+            printf 'start "" "%%APPDIR%%tsukimi.exe" %%*\r\n'
+          } > artifact/tsukimi-x86_64-windows/tsukimi.cmd
+
+          cd artifact
+          zip -r tsukimi-x86_64-windows.zip tsukimi-x86_64-windows
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: tsukimi-x86_64-windows
+          path: artifact/tsukimi-x86_64-windows.zip
+          archive: false

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -51,6 +51,9 @@ jobs:
           PKG_CONFIG_PATH: /ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig
           PATH: /c/Users/runneradmin/.cargo/bin:/ucrt64/bin:${{ env.PATH }}
         run: |
+          export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:/ucrt64/bin:$PATH"
+          which cargo
+          cargo --version
           mkdir -p secret
           echo "${{ secrets.DANDANAPI_SECRET_KEY || 'testing' }}" > secret/key
           cargo build --release --locked

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,7 +24,7 @@ jobs:
           update: true
           install: >-
             git
-            mingw-w64-pkgconf
+            mingw-w64-ucrt-x86_64-pkgconf
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-gtk4
             mingw-w64-ucrt-x86_64-libadwaita

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
           PKG_CONFIG_PATH: /ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig
-          PATH: /ucrt64/bin:${{ env.PATH }}
+          PATH: /c/Users/runneradmin/.cargo/bin:/ucrt64/bin:${{ env.PATH }}
         run: |
           mkdir -p secret
           echo "${{ secrets.DANDANAPI_SECRET_KEY || 'testing' }}" > secret/key

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -44,16 +44,21 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          target: x86_64-pc-windows-gnu
 
       - name: Build
         env:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-          PKG_CONFIG_PATH: /ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig
           PATH: /c/Users/runneradmin/.cargo/bin:/ucrt64/bin:${{ env.PATH }}
         run: |
           export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:/ucrt64/bin:$PATH"
+          export PKG_CONFIG_PATH="/ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig"
+          export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1
+          export CARGO_BUILD_TARGET="x86_64-pc-windows-gnu"
+          export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="/ucrt64/bin/gcc.exe"
           which cargo
           cargo --version
+          pkg-config --modversion glib-2.0
           mkdir -p secret
           echo "${{ secrets.DANDANAPI_SECRET_KEY || 'testing' }}" > secret/key
           cargo build --release --locked

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -54,6 +54,7 @@ jobs:
           export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:/ucrt64/bin:$PATH"
           export PKG_CONFIG_PATH="/ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig"
           export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1
+          export PKG_CONFIG_ALLOW_CROSS=1
           export CARGO_BUILD_TARGET="x86_64-pc-windows-gnu"
           export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="/ucrt64/bin/gcc.exe"
           which cargo

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -25,19 +25,19 @@ jobs:
           install: >-
             git
             pkgconf
-            gcc
-            gtk4
-            libadwaita
-            gstreamer
-            gst-plugins-base
-            gst-plugins-good
-            gst-plugins-bad
-            gst-plugins-ugly
-            gst-libav
-            mpv
-            libepoxy
-            gettext
-            glib2
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-gtk4
+            mingw-w64-ucrt-x86_64-libadwaita
+            mingw-w64-ucrt-x86_64-gstreamer
+            mingw-w64-ucrt-x86_64-gst-plugins-base
+            mingw-w64-ucrt-x86_64-gst-plugins-good
+            mingw-w64-ucrt-x86_64-gst-plugins-bad
+            mingw-w64-ucrt-x86_64-gst-plugins-ugly
+            mingw-w64-ucrt-x86_64-gst-libav
+            mingw-w64-ucrt-x86_64-mpv
+            mingw-w64-ucrt-x86_64-libepoxy
+            mingw-w64-ucrt-x86_64-gettext
+            mingw-w64-ucrt-x86_64-glib2
             zip
 
       - name: Setup Rust

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.91
+          toolchain: stable
 
       - name: Build
         env:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,30 +24,32 @@ jobs:
           update: true
           install: >-
             git
-            mingw-w64-ucrt-x86_64-cargo
-            mingw-w64-ucrt-x86_64-rust
-            mingw-w64-ucrt-x86_64-pkgconf
-            mingw-w64-ucrt-x86_64-gtk4
-            mingw-w64-ucrt-x86_64-libadwaita
-            mingw-w64-ucrt-x86_64-gstreamer
-            mingw-w64-ucrt-x86_64-gst-plugins-base
-            mingw-w64-ucrt-x86_64-gst-plugins-good
-            mingw-w64-ucrt-x86_64-gst-plugins-bad
-            mingw-w64-ucrt-x86_64-gst-plugins-ugly
-            mingw-w64-ucrt-x86_64-gst-libav
-            mingw-w64-ucrt-x86_64-mpv
-            mingw-w64-ucrt-x86_64-libepoxy
-            mingw-w64-ucrt-x86_64-gettext
-            mingw-w64-ucrt-x86_64-glib2
-            mingw-w64-ucrt-x86_64-cc
-            mingw-w64-ucrt-x86_64-lld
-            mingw-w64-ucrt-x86_64-ninja
-            mingw-w64-ucrt-x86_64-meson
+            pkgconf
+            gcc
+            gtk4
+            libadwaita
+            gstreamer
+            gst-plugins-base
+            gst-plugins-good
+            gst-plugins-bad
+            gst-plugins-ugly
+            gst-libav
+            mpv
+            libepoxy
+            gettext
+            glib2
             zip
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.91
 
       - name: Build
         env:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+          PKG_CONFIG_PATH: /ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig
+          PATH: /ucrt64/bin:${{ env.PATH }}
         run: |
           mkdir -p secret
           echo "${{ secrets.DANDANAPI_SECRET_KEY || 'testing' }}" > secret/key

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -67,22 +67,24 @@ jobs:
 
       - name: Compile resources
         run: |
-          mkdir -p target/release/share/tsukimi
+          RELEASE_DIR=target/x86_64-pc-windows-gnu/release
+          mkdir -p "$RELEASE_DIR/share/tsukimi"
           glib-compile-resources \
             --sourcedir=resources \
-            --target=target/release/share/tsukimi/tsukimi.gresource \
+            --target="$RELEASE_DIR/share/tsukimi/tsukimi.gresource" \
             resources/resources.gresource.xml
-          mkdir -p target/release/share/glib-2.0/schemas
-          cp resources/moe.tsuna.tsukimi.gschema.xml target/release/share/glib-2.0/schemas/
-          glib-compile-schemas target/release/share/glib-2.0/schemas
+          mkdir -p "$RELEASE_DIR/share/glib-2.0/schemas"
+          cp resources/moe.tsuna.tsukimi.gschema.xml "$RELEASE_DIR/share/glib-2.0/schemas/"
+          glib-compile-schemas "$RELEASE_DIR/share/glib-2.0/schemas"
 
       - name: Bundle runtime
         run: |
+          RELEASE_DIR=target/x86_64-pc-windows-gnu/release
           mkdir -p artifact/tsukimi-x86_64-windows
-          cp target/release/tsukimi.exe artifact/tsukimi-x86_64-windows/
-          cp -r target/release/share artifact/tsukimi-x86_64-windows/
+          cp "$RELEASE_DIR/tsukimi.exe" artifact/tsukimi-x86_64-windows/
+          cp -r "$RELEASE_DIR/share" artifact/tsukimi-x86_64-windows/
 
-          ldd target/release/tsukimi.exe \
+          ldd "$RELEASE_DIR/tsukimi.exe" \
             | awk '/mingw64|ucrt64/ {print $3}' \
             | sort -u \
             | xargs -r -I{} cp -n "{}" artifact/tsukimi-x86_64-windows/

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,7 +24,7 @@ jobs:
           update: true
           install: >-
             git
-            pkgconf
+            mingw-w64-pkgconf
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-gtk4
             mingw-w64-ucrt-x86_64-libadwaita
@@ -53,6 +53,7 @@ jobs:
         run: |
           export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:/ucrt64/bin:$PATH"
           export PKG_CONFIG_PATH="/ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig"
+          export PKG_CONFIG="/ucrt64/bin/pkg-config.exe"
           export PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1
           export PKG_CONFIG_ALLOW_CROSS=1
           export CARGO_BUILD_TARGET="x86_64-pc-windows-gnu"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # tsukimi
-A simple third-party Jellyfin client for Linux.
+A simple third-party Jellyfin/Emby client for Linux and Windows 11.
 
 [![Telegram](https://img.shields.io/badge/-Telegram_Group-red?color=blue&logo=telegram&logoColor=white)](https://t.me/tsukimi_frying_crab) ![Commit Activity](https://img.shields.io/github/commit-activity/m/tsukinaha/Tsukimi/main) ![Top Language](https://img.shields.io/github/languages/top/tsukinaha/Tsukimi) ![Github License](https://img.shields.io/github/license/tsukinaha/Tsukimi) [![Linux CI](https://github.com/tsukinaha/tsukimi/actions/workflows/build_linux.yml/badge.svg)](https://github.com/tsukinaha/tsukimi/actions/workflows/build_linux.yml) [![Flathub Version](https://img.shields.io/flathub/v/moe.tsuna.tsukimi?color=white)](https://flathub.org/apps/details/moe.tsuna.tsukimi) [![Wiki](https://img.shields.io/badge/-Wiki-red?color=blue&logo=github&logoColor=white)](https://github.com/tsukinaha/tsukimi/wiki) [![Translate Status](https://hosted.weblate.org/widget/tsukimi/language-badge.svg)](https://hosted.weblate.org/engage/tsukimi)
 
@@ -7,7 +7,7 @@ A simple third-party Jellyfin client for Linux.
 ![Alt](https://repobeats.axiom.co/api/embed/82b1088ba840d89c50e1b5b3c1c40f4575b321a6.svg "Repobeats analytics image")
 
 ## About
-A simple third-party Jellyfin client written in GTK4-RS, uses MPV as the video player, and GStreamer as the music player.
+A simple third-party Jellyfin/Emby client written in GTK4-RS, uses MPV as the video player, and GStreamer as the music player.
 
 It’s also partially compatible with Emby.
 All of basic functions and most of admin functions are supported.
@@ -73,7 +73,7 @@ sudo emerge --ask media-video/tsukimi
 `tsukimi` is available in nixpkgs since 24.11.
 
 ### Source code
-[Build on Linux](./docs/build_on_linux.md)
+[Build on Linux](./docs/build_on_linux.md) | [Build on Windows 11](./docs/build_on_windows.md)
 
 ## MPV Config
 [MPV-manual#files](https://mpv.io/manual/master/#files)

--- a/docs/build_on_windows.md
+++ b/docs/build_on_windows.md
@@ -1,0 +1,79 @@
+# Build on Windows 11
+
+Tsukimi can be built on Windows 11 with the MSYS2 UCRT64 toolchain. The Windows build is packaged as a portable zip that includes the executable, GResource bundle, GSettings schema, GStreamer plugins, and the runtime DLLs needed by GTK/libadwaita/mpv.
+
+## Requirements
+
+Install [MSYS2](https://www.msys2.org/) and open the **UCRT64** shell.
+
+```bash
+pacman -Syu
+pacman -S --needed \
+  git \
+  mingw-w64-ucrt-x86_64-cargo \
+  mingw-w64-ucrt-x86_64-rust \
+  mingw-w64-ucrt-x86_64-pkgconf \
+  mingw-w64-ucrt-x86_64-gtk4 \
+  mingw-w64-ucrt-x86_64-libadwaita \
+  mingw-w64-ucrt-x86_64-gstreamer \
+  mingw-w64-ucrt-x86_64-gst-plugins-base \
+  mingw-w64-ucrt-x86_64-gst-plugins-good \
+  mingw-w64-ucrt-x86_64-gst-plugins-bad \
+  mingw-w64-ucrt-x86_64-gst-plugins-ugly \
+  mingw-w64-ucrt-x86_64-gst-libav \
+  mingw-w64-ucrt-x86_64-mpv \
+  mingw-w64-ucrt-x86_64-libepoxy \
+  mingw-w64-ucrt-x86_64-gettext \
+  mingw-w64-ucrt-x86_64-glib2 \
+  mingw-w64-ucrt-x86_64-cc \
+  mingw-w64-ucrt-x86_64-lld \
+  mingw-w64-ucrt-x86_64-ninja \
+  mingw-w64-ucrt-x86_64-meson \
+  zip
+```
+
+## Build
+
+```bash
+git clone https://github.com/tsukinaha/tsukimi
+cd tsukimi
+mkdir -p secret
+echo testing > secret/key
+cargo build --release --locked
+```
+
+## Runtime resources
+
+For a portable build, compile the resources and schema next to `tsukimi.exe`:
+
+```bash
+mkdir -p target/release/share/tsukimi
+mkdir -p target/release/share/glib-2.0/schemas
+
+glib-compile-resources \
+  --sourcedir=resources \
+  --target=target/release/share/tsukimi/tsukimi.gresource \
+  resources/resources.gresource.xml
+
+cp resources/moe.tsuna.tsukimi.gschema.xml target/release/share/glib-2.0/schemas/
+glib-compile-schemas target/release/share/glib-2.0/schemas
+```
+
+Run from the UCRT64 shell:
+
+```bash
+GSETTINGS_SCHEMA_DIR="$PWD/target/release/share/glib-2.0/schemas" \
+XDG_DATA_DIRS="$PWD/target/release/share" \
+GST_PLUGIN_PATH="/ucrt64/lib/gstreamer-1.0" \
+target/release/tsukimi.exe
+```
+
+## GitHub Actions artifact
+
+The `Windows` workflow builds a portable `tsukimi-x86_64-windows.zip` artifact. Extract it on Windows 11 and launch `tsukimi.cmd`; the script sets `PATH`, `GSETTINGS_SCHEMA_DIR`, `XDG_DATA_DIRS`, and `GST_PLUGIN_PATH` for the bundled runtime.
+
+## Notes
+
+- MPRIS/DBus integration is Linux-only and disabled on Windows.
+- The `dmabuf-wayland` mpv output is Linux-only; Windows falls back to the embedded `libmpv` renderer.
+- Image cache ETags use extended attributes on Linux and `.etag` sidecar files on Windows.

--- a/src/client/cache_metadata.rs
+++ b/src/client/cache_metadata.rs
@@ -1,0 +1,31 @@
+#[cfg(target_os = "linux")]
+pub fn get_etag(path: &std::path::Path) -> Option<String> {
+    xattr::get(path, "user.etag")
+        .ok()
+        .flatten()
+        .and_then(|value| String::from_utf8(value).ok())
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_etag(path: &std::path::Path, etag: &str) -> std::io::Result<()> {
+    xattr::set(path, "user.etag", etag.as_bytes())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn get_etag(path: &std::path::Path) -> Option<String> {
+    let sidecar_path = etag_sidecar_path(path);
+    std::fs::read_to_string(sidecar_path).ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn set_etag(path: &std::path::Path, etag: &str) -> std::io::Result<()> {
+    let sidecar_path = etag_sidecar_path(path);
+    std::fs::write(sidecar_path, etag)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn etag_sidecar_path(path: &std::path::Path) -> std::path::PathBuf {
+    let mut sidecar_path = path.as_os_str().to_owned();
+    sidecar_path.push(".etag");
+    std::path::PathBuf::from(sidecar_path)
+}

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -75,6 +75,7 @@ use super::{
 };
 use crate::{
     CLIENT_ID,
+    client::cache_metadata,
     config::version,
     ui::{
         SETTINGS,
@@ -667,10 +668,7 @@ impl JellyfinClient {
         let mut etag: Option<String> = None;
 
         if path.exists() {
-            etag = xattr::get(&path, "user.etag")
-                .ok()
-                .flatten()
-                .and_then(|v| String::from_utf8(v).ok());
+            etag = cache_metadata::get_etag(&path);
         }
 
         match self.image_request(id, image_type, tag, etag).await {
@@ -741,8 +739,8 @@ impl JellyfinClient {
         let path = cache_path.join(path);
         tokio::fs::write(&path, bytes).await.unwrap();
         if let Some(etag) = etag {
-            xattr::set(&path, "user.etag", etag.as_bytes()).unwrap_or_else(|e| {
-                tracing::warn!("Failed to set etag xattr: {}", e);
+            cache_metadata::set_etag(&path, &etag).unwrap_or_else(|e| {
+                tracing::warn!("Failed to set image cache etag: {}", e);
             });
         }
         path.to_string_lossy().to_string()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod cache_metadata;
 pub mod error;
 pub mod jellyfin_client;
 pub mod proxy;

--- a/src/gstl/player.rs
+++ b/src/gstl/player.rs
@@ -473,8 +473,7 @@ pub mod imp {
         }
 
         pub fn notify_seeked(
-            &self,
-            #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] position: i64,
+            &self, #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] position: i64,
         ) {
             #[cfg(target_os = "linux")]
             self.obj().notify_mpris_seeked(position);

--- a/src/gstl/player.rs
+++ b/src/gstl/player.rs
@@ -35,10 +35,9 @@ pub mod imp {
     #[cfg(target_os = "linux")]
     use mpris_server::LocalServer;
     use once_cell::sync::*;
-    use tracing::{
-        debug,
-        warn,
-    };
+    use tracing::debug;
+    #[cfg(target_os = "linux")]
+    use tracing::warn;
 
     use super::*;
     use crate::ui::widgets::song_widget::State;
@@ -448,10 +447,14 @@ pub mod imp {
         }
 
         pub fn notify_song_changed(&self) {
-            let has_prev = self.prev_song().is_some();
-            let has_next = self.next_song().is_some();
+            #[cfg(not(target_os = "linux"))]
+            let _ = self;
             #[cfg(target_os = "linux")]
-            self.obj().notify_mpris_song_changed(has_prev, has_next);
+            {
+                let has_prev = self.prev_song().is_some();
+                let has_next = self.next_song().is_some();
+                self.obj().notify_mpris_song_changed(has_prev, has_next);
+            }
         }
 
         pub fn notify_playing(&self) {
@@ -469,7 +472,10 @@ pub mod imp {
             self.obj().notify_mpris_stopped();
         }
 
-        pub fn notify_seeked(&self, position: i64) {
+        pub fn notify_seeked(
+            &self,
+            #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] position: i64,
+        ) {
             #[cfg(target_os = "linux")]
             self.obj().notify_mpris_seeked(position);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub fn locale_dir() -> &'static str {
 }
 
 pub fn run() -> gtk::glib::ExitCode {
+    init_portable_runtime_paths();
     Args::parse().init();
     // Initialize gettext
     setlocale(LocaleCategory::LcAll, String::new());
@@ -68,8 +69,54 @@ pub fn run() -> gtk::glib::ExitCode {
     Application::new().run_with_args::<&str>(&[])
 }
 
+fn init_portable_runtime_paths() {
+    let Ok(exe_path) = env::current_exe() else {
+        return;
+    };
+    let Some(exe_dir) = exe_path.parent() else {
+        return;
+    };
+
+    let schemas_dir = exe_dir.join("share").join("glib-2.0").join("schemas");
+    if schemas_dir.exists() && env::var_os("GSETTINGS_SCHEMA_DIR").is_none() {
+        unsafe { env::set_var("GSETTINGS_SCHEMA_DIR", schemas_dir) };
+    }
+
+    let data_dir = exe_dir.join("share");
+    if data_dir.exists() && env::var_os("XDG_DATA_DIRS").is_none() {
+        unsafe { env::set_var("XDG_DATA_DIRS", data_dir) };
+    }
+}
+
 fn register_gio_resources() {
-    let path = std::path::Path::new(PKGDATADIR).join(GRESOURCE_FILE);
-    let resources = gtk::gio::Resource::load(path).expect("Failed to load resources.");
+    let path = resource_file_path();
+    let resources = gtk::gio::Resource::load(&path).unwrap_or_else(|error| {
+        panic!(
+            "Failed to load resources from {}: {}",
+            path.display(),
+            error
+        )
+    });
     gtk::gio::resources_register(&resources);
+}
+
+fn resource_file_path() -> std::path::PathBuf {
+    let system_path = std::path::Path::new(PKGDATADIR).join(GRESOURCE_FILE);
+    if system_path.exists() {
+        return system_path;
+    }
+
+    if let Ok(exe_path) = env::current_exe()
+        && let Some(exe_dir) = exe_path.parent()
+    {
+        let portable_path = exe_dir
+            .join("share")
+            .join(env!("CARGO_PKG_NAME"))
+            .join(GRESOURCE_FILE);
+        if portable_path.exists() {
+            return portable_path;
+        }
+    }
+
+    system_path
 }

--- a/src/ui/mpv/mod.rs
+++ b/src/ui/mpv/mod.rs
@@ -8,5 +8,3 @@ pub mod page;
 pub mod tsukimi_mpv;
 pub mod video_scale;
 pub mod volume_bar;
-
-pub use volume_bar::VolumeBar;

--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -138,8 +138,7 @@ mod imp {
         }
 
         fn setup_mpv(
-            &self,
-            gl_context: GLContext,
+            &self, gl_context: GLContext,
             #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] display: Display,
         ) {
             let render_params = vec![

--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -137,8 +137,12 @@ mod imp {
             &self.mpv
         }
 
-        fn setup_mpv(&self, gl_context: GLContext, display: Display) {
-            let mut render_params = vec![
+        fn setup_mpv(
+            &self,
+            gl_context: GLContext,
+            #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] display: Display,
+        ) {
+            let render_params = vec![
                 RenderParam::ApiType(RenderParamApiType::OpenGl),
                 RenderParam::InitParams(OpenGLInitParams {
                     get_proc_address,
@@ -150,6 +154,8 @@ mod imp {
             // displays.
             //
             // https://github.com/mpv-player/mpv/blob/86e12929aa0bbc61946d3804982acf887786a7cb/include/mpv/render_gl.h#L91
+            #[cfg(target_os = "linux")]
+            let mut render_params = render_params;
             #[cfg(target_os = "linux")]
             if let Ok(display_wrapper) = display.clone().downcast::<X11Display>() {
                 render_params.push(RenderParam::X11Display(

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -133,6 +133,8 @@ mod imp {
         RefCell,
     };
 
+    #[cfg(target_os = "linux")]
+    use crate::APP_ID;
     use adw::prelude::*;
     use gettextrs::gettext;
     use glib::subclass::InitializingObject;
@@ -146,8 +148,6 @@ mod imp {
     use mpris_server::LocalServer;
     #[cfg(target_os = "linux")]
     use once_cell::sync::OnceCell;
-    #[cfg(target_os = "linux")]
-    use crate::APP_ID;
 
     use crate::{
         client::structs::{
@@ -1554,8 +1554,7 @@ impl MPVPage {
     }
 
     pub fn notify_volume_changed(
-        &self,
-        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] volume: f64,
+        &self, #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] volume: f64,
     ) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_volume(volume);
@@ -1567,8 +1566,7 @@ impl MPVPage {
     }
 
     pub fn notify_seeked(
-        &self,
-        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] position: i64,
+        &self, #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] position: i64,
     ) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_seeked(position);

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -144,9 +144,11 @@ mod imp {
     };
     #[cfg(target_os = "linux")]
     use mpris_server::LocalServer;
+    #[cfg(target_os = "linux")]
     use once_cell::sync::OnceCell;
 
     use crate::{
+        #[cfg(target_os = "linux")]
         APP_ID,
         client::structs::{
             Back,
@@ -1551,7 +1553,10 @@ impl MPVPage {
         self.notify_mpris_paused();
     }
 
-    pub fn notify_volume_changed(&self, volume: f64) {
+    pub fn notify_volume_changed(
+        &self,
+        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] volume: f64,
+    ) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_volume(volume);
     }
@@ -1561,7 +1566,10 @@ impl MPVPage {
         self.notify_mpris_stopped();
     }
 
-    pub fn notify_seeked(&self, position: i64) {
+    pub fn notify_seeked(
+        &self,
+        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] position: i64,
+    ) {
         #[cfg(target_os = "linux")]
         self.notify_mpris_seeked(position);
     }

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -146,10 +146,10 @@ mod imp {
     use mpris_server::LocalServer;
     #[cfg(target_os = "linux")]
     use once_cell::sync::OnceCell;
+    #[cfg(target_os = "linux")]
+    use crate::APP_ID;
 
     use crate::{
-        #[cfg(target_os = "linux")]
-        APP_ID,
         client::structs::{
             Back,
             MediaSegment,

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -157,10 +157,10 @@ mod imp {
         ui::{
             models::SETTINGS,
             mpv::{
-                VolumeBar,
                 menu_actions::MenuActions,
                 mpvglarea::MPVGLArea,
                 video_scale::VideoScale,
+                volume_bar::VolumeBar,
             },
             provider::tu_item::TuItem,
         },

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -76,16 +76,7 @@ impl Default for TsukimiMPV {
             setlocale(LC_NUMERIC, c"C".as_ptr() as *const _);
         }
 
-        #[cfg(target_os = "macos")]
-        let library = unsafe { libloading::os::unix::Library::new("libepoxy.0.dylib") }.unwrap();
-        #[cfg(all(unix, not(target_os = "macos")))]
-        let library = unsafe { libloading::os::unix::Library::new("libepoxy.so.0") }.unwrap();
-
-        epoxy::load_with(|name| {
-            unsafe { library.get::<_>(name.as_bytes()) }
-                .map(|symbol| *symbol)
-                .unwrap_or(std::ptr::null())
-        });
+        load_epoxy();
 
         let mpv = Mpv::with_initializer(|init| {
             if SETTINGS.mpv_config() {
@@ -97,7 +88,7 @@ impl Default for TsukimiMPV {
             init.set_property("user-agent", crate::USER_AGENT.as_str())?;
             init.set_property("video-timing-offset", 0)?;
             init.set_property("video-sync", "audio")?;
-            match SETTINGS.mpv_video_output() {
+            match mpv_video_output() {
                 0 => {
                     init.set_property("vo", "libmpv")?;
                     init.set_property("osc", false)?;
@@ -156,6 +147,49 @@ impl Default for TsukimiMPV {
             event_handle: RefCell::new(None),
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+fn load_epoxy() {
+    let library = unsafe { libloading::os::unix::Library::new("libepoxy.0.dylib") }.unwrap();
+    epoxy::load_with(|name| {
+        unsafe { library.get::<_>(name.as_bytes()) }
+            .map(|symbol| *symbol)
+            .unwrap_or(std::ptr::null())
+    });
+    std::mem::forget(library);
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn load_epoxy() {
+    let library = unsafe { libloading::os::unix::Library::new("libepoxy.so.0") }.unwrap();
+    epoxy::load_with(|name| {
+        unsafe { library.get::<_>(name.as_bytes()) }
+            .map(|symbol| *symbol)
+            .unwrap_or(std::ptr::null())
+    });
+    std::mem::forget(library);
+}
+
+#[cfg(target_os = "windows")]
+fn load_epoxy() {
+    let library = unsafe { libloading::os::windows::Library::new("epoxy-0.dll") }.unwrap();
+    epoxy::load_with(|name| {
+        unsafe { library.get::<_>(name.as_bytes()) }
+            .map(|symbol| *symbol)
+            .unwrap_or(std::ptr::null())
+    });
+    std::mem::forget(library);
+}
+
+fn mpv_video_output() -> i32 {
+    let output = SETTINGS.mpv_video_output();
+
+    if cfg!(target_os = "linux") || output != 2 {
+        return output;
+    }
+
+    0
 }
 
 use flume::{


### PR DESCRIPTION
## Summary
- Add Windows CI packaging and Win11-oriented runtime support for Tsukimi.
- Bundle Windows launcher/runtime environment handling for GTK4/libadwaita, GStreamer, mpv, and font paths.
- Keep fork CI green by skipping Telegram/secrets artifact aggregation when unavailable.

## Validation
- GitHub Actions run succeeded: https://github.com/MARK0x99/tsukimi/actions/runs/27847449429
- Lint: success
- Linux amd64/arm64 builds: success
- Windows x86_64 build: success

## Win11 manual test focus
- Launch `tsukimi.cmd`
- Verify GTK4/libadwaita UI startup and Chinese font rendering
- Verify mpv/GStreamer playback, subtitles, and audio
- Watch for black screen, flicker, renderer fallback, fontconfig/Pango, GStreamer plugin path, or mpv `vo`/`hwdec` issues
