### PR TITLE
Skip avatar fetch before login

### DIFF
--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -431,6 +431,10 @@ impl AccountSettings {
         action_group.add_action_entries([action_vo]);
         self.insert_action_group("setting", Some(&action_group));
 
+        if JELLYFIN_CLIENT.session().account.user_id.is_empty() {
+            return;
+        }
+
         spawn(glib::clone!(
             #[weak(rename_to = obj)]
             self,


### PR DESCRIPTION
Avoid fetching user avatar when no server session is active.

Opening preferences at server selection could try to fetch user avatar, then  trigger `Value accessed from different thread than where it was created` at `src/utils.rs:26` and report `Lazy instance has previously been poisoned`.  This prevents server selection until app restart. I found about this while trying to turn on  "Auto Select Last Server" on the server selection and could not log in.

I built the app from source, and confirmed I can log in fine now and same errors are gone, though I didn't check this with flatpak