### PR TITLE
Quality: Panic in insert_editm_dialog! macro will crash application

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,8 +33,6 @@ macro_rules! insert_editm_dialog {
         if let Some(root) = $widget.root() {
             if let Some(window) = root.downcast_ref::<$crate::ui::widgets::window::Window>() {
                 $dialog.present(Some(window));
-            } else {
-                panic!("Trying to display a dialog when the parent doesn't support it");
             }
         }
     }};


### PR DESCRIPTION
## Problem

The `insert_editm_dialog!` macro contains an unconditional `panic!()` if the widget's root can be found but cannot be downcast to a Window. Every other macro in the same file (fraction!, fraction_reset!, close_on_error!, bing_song_model!, alert_dialog!) handles this case gracefully with a silent early return. This panic will crash the entire application at runtime if triggered — for example, during widget teardown, or if a dialog is triggered from a widget in a non-standard container. A failed dialog presentation should never crash a GUI application.


**Severity**: `high`
**File**: `src/macros.rs`

## Solution

Replace the panic with an early return, consistent with all sibling macros:


## Changes

- `src/macros.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
