### PR TITLE
feat: adjust the progress bar and episode overview styles, support always displaying item titles

### DIFF
--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -89,39 +89,39 @@ msgstr ""
 msgid "Server added successfully"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:235
+#: src/ui/widgets/account_settings.rs:237
 msgid "Password cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:239
+#: src/ui/widgets/account_settings.rs:241
 msgid "Passwords do not match!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:246
+#: src/ui/widgets/account_settings.rs:248
 msgid "Password changed successfully! Please login again."
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:250
+#: src/ui/widgets/account_settings.rs:252
 msgid "Failed to change password"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:286
+#: src/ui/widgets/account_settings.rs:288
 msgid "Cache Cleared"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:307
+#: src/ui/widgets/account_settings.rs:309
 msgid "No file selected"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:553
 #: src/ui/widgets/account_settings.rs:562
-#: src/ui/widgets/account_settings.rs:596
+#: src/ui/widgets/account_settings.rs:571
 #: src/ui/widgets/account_settings.rs:605
+#: src/ui/widgets/account_settings.rs:614
 msgid "Descriptor cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:567
-#: src/ui/widgets/account_settings.rs:610
+#: src/ui/widgets/account_settings.rs:576
+#: src/ui/widgets/account_settings.rs:619
 msgid "Invalid regex"
 msgstr ""
 
@@ -161,8 +161,8 @@ msgstr ""
 #: src/ui/widgets/identify/search_page.rs:129
 #: src/ui/widgets/image_dialog/search_page.rs:148
 #: src/ui/widgets/metadata_dialog.rs:293 src/ui/widgets/tu_item/action.rs:489
-#: src/ui/widgets/tu_item/action.rs:549 resources/ui/account_settings.ui:523
-#: resources/ui/account_settings.ui:633
+#: src/ui/widgets/tu_item/action.rs:549 resources/ui/account_settings.ui:561
+#: resources/ui/account_settings.ui:671
 msgid "Cancel"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: resources/ui/account.ui:108 resources/ui/account_settings.ui:529
+#: resources/ui/account.ui:108 resources/ui/account_settings.ui:567
 msgid "Add"
 msgstr ""
 
@@ -516,7 +516,7 @@ msgid "Preferred Audio Language"
 msgstr ""
 
 #: resources/ui/account_settings.ui:30 resources/ui/account_settings.ui:56
-#: resources/ui/account_settings.ui:163
+#: resources/ui/account_settings.ui:201
 msgid "Default"
 msgstr ""
 
@@ -549,214 +549,230 @@ msgid "Auto Select Last Server"
 msgstr ""
 
 #: resources/ui/account_settings.ui:110
-msgid "Full Display Mode"
+msgid "Text Display"
 msgstr ""
 
-#: resources/ui/account_settings.ui:111
-msgid "Show item titles on all cards, turn off for compact mode"
+#: resources/ui/account_settings.ui:116
+msgid "Compact"
 msgstr ""
 
-#: resources/ui/account_settings.ui:118
-msgid "Home Page"
+#: resources/ui/account_settings.ui:122
+msgid "Full"
 msgstr ""
 
-#: resources/ui/account_settings.ui:121
-msgid "Refresh when returning to home page"
-msgstr ""
-
-#: resources/ui/account_settings.ui:126
-msgid "Merge Continue Watching and Next Up"
-msgstr ""
-
-#: resources/ui/account_settings.ui:127
-msgid "Jellyfin only"
-msgstr ""
-
-#: resources/ui/account_settings.ui:134
-msgid "Network"
-msgstr ""
-
-#: resources/ui/account_settings.ui:137
-msgid "Threads"
+#: resources/ui/account_settings.ui:132
+msgid "Card Style"
 msgstr ""
 
 #: resources/ui/account_settings.ui:138
+msgid "Integrated"
+msgstr ""
+
+#: resources/ui/account_settings.ui:144
+msgid "Separated"
+msgstr ""
+
+#: resources/ui/account_settings.ui:156
+msgid "Home Page"
+msgstr ""
+
+#: resources/ui/account_settings.ui:159
+msgid "Refresh when returning to home page"
+msgstr ""
+
+#: resources/ui/account_settings.ui:164
+msgid "Merge Continue Watching and Next Up"
+msgstr ""
+
+#: resources/ui/account_settings.ui:165
+msgid "Jellyfin only"
+msgstr ""
+
+#: resources/ui/account_settings.ui:172
+msgid "Network"
+msgstr ""
+
+#: resources/ui/account_settings.ui:175
+msgid "Threads"
+msgstr ""
+
+#: resources/ui/account_settings.ui:176
 msgid "Excessive thread counts may exhaust the system's connection pool"
 msgstr ""
 
-#: resources/ui/account_settings.ui:154 resources/ui/mpv_control_sidebar.ui:399
+#: resources/ui/account_settings.ui:192 resources/ui/mpv_control_sidebar.ui:399
 msgid "Background"
 msgstr ""
 
-#: resources/ui/account_settings.ui:186
+#: resources/ui/account_settings.ui:224
 msgid "Opacity"
 msgstr ""
 
-#: resources/ui/account_settings.ui:200
+#: resources/ui/account_settings.ui:238
 msgid "Blur"
 msgstr ""
 
-#: resources/ui/account_settings.ui:205
+#: resources/ui/account_settings.ui:243
 msgid "Blur Radius"
 msgstr ""
 
-#: resources/ui/account_settings.ui:221 resources/ui/mpv_control_sidebar.ui:84
+#: resources/ui/account_settings.ui:259 resources/ui/mpv_control_sidebar.ui:84
 msgid "Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:224
+#: resources/ui/account_settings.ui:262
 msgid "Clear Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:239 resources/ui/account_settings.ui:358
+#: resources/ui/account_settings.ui:277 resources/ui/account_settings.ui:396
 msgid "Others"
 msgstr ""
 
-#: resources/ui/account_settings.ui:242 resources/ui/account_settings.ui:434
+#: resources/ui/account_settings.ui:280 resources/ui/account_settings.ui:472
 msgid "Preferred Video Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:254
+#: resources/ui/account_settings.ui:292
 msgid "Account"
 msgstr ""
 
-#: resources/ui/account_settings.ui:267 resources/ui/account_settings.ui:284
+#: resources/ui/account_settings.ui:305 resources/ui/account_settings.ui:322
 msgid "Change Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:270
+#: resources/ui/account_settings.ui:308
 msgid "New Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:275
+#: resources/ui/account_settings.ui:313
 msgid "Confirm Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:298
+#: resources/ui/account_settings.ui:336
 msgid "Media"
 msgstr ""
 
-#: resources/ui/account_settings.ui:303
+#: resources/ui/account_settings.ui:341
 msgid "Music Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:306 resources/ui/player_toolbar.ui:197
+#: resources/ui/account_settings.ui:344 resources/ui/player_toolbar.ui:197
 msgid "Repeat Mode"
 msgstr ""
 
-#: resources/ui/account_settings.ui:310 resources/ui/player_toolbar.ui:231
+#: resources/ui/account_settings.ui:348 resources/ui/player_toolbar.ui:231
 msgid "Repeat One"
 msgstr ""
 
-#: resources/ui/account_settings.ui:311 resources/ui/player_toolbar.ui:235
+#: resources/ui/account_settings.ui:349 resources/ui/player_toolbar.ui:235
 msgid "Repeat All"
 msgstr ""
 
-#: resources/ui/account_settings.ui:312 resources/ui/account_settings.ui:340
+#: resources/ui/account_settings.ui:350 resources/ui/account_settings.ui:378
 #: resources/ui/player_toolbar.ui:239
 msgid "None"
 msgstr ""
 
-#: resources/ui/account_settings.ui:322
+#: resources/ui/account_settings.ui:360
 msgid "Video Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:323
+#: resources/ui/account_settings.ui:361
 msgid "Requires restart"
 msgstr ""
 
-#: resources/ui/account_settings.ui:326
+#: resources/ui/account_settings.ui:364
 msgid "Enable external config"
 msgstr ""
 
-#: resources/ui/account_settings.ui:331
+#: resources/ui/account_settings.ui:369
 msgid "Config dir"
 msgstr ""
 
-#: resources/ui/account_settings.ui:363
+#: resources/ui/account_settings.ui:401
 msgid "Video Output"
 msgstr ""
 
-#: resources/ui/account_settings.ui:364
+#: resources/ui/account_settings.ui:402
 msgid "Only for debugging"
 msgstr ""
 
-#: resources/ui/account_settings.ui:367
+#: resources/ui/account_settings.ui:405
 msgid "libmpv (default)"
 msgstr ""
 
-#: resources/ui/account_settings.ui:412
+#: resources/ui/account_settings.ui:450
 msgid "Preferred Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:435
+#: resources/ui/account_settings.ui:473
 msgid ""
 "Weight is ordered from high to low, until a specific version is matched, or "
 "the highest matching version is obtained before clearing the match list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:450
+#: resources/ui/account_settings.ui:488
 msgid "Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:472
+#: resources/ui/account_settings.ui:510
 msgid "It is recommended to set no more than 3 lines"
 msgstr ""
 
-#: resources/ui/account_settings.ui:493
+#: resources/ui/account_settings.ui:531
 msgid "No Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:512
+#: resources/ui/account_settings.ui:550
 msgid "Add a descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:554 resources/ui/account_settings.ui:664
+#: resources/ui/account_settings.ui:592 resources/ui/account_settings.ui:702
 msgid "This will use exact matching to obtain a list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:557 resources/ui/account_settings.ui:667
+#: resources/ui/account_settings.ui:595 resources/ui/account_settings.ui:705
 msgid "Descriptor Type"
 msgstr ""
 
-#: resources/ui/account_settings.ui:562 resources/ui/account_settings.ui:672
+#: resources/ui/account_settings.ui:600 resources/ui/account_settings.ui:710
 msgid "String"
 msgstr ""
 
-#: resources/ui/account_settings.ui:563 resources/ui/account_settings.ui:673
+#: resources/ui/account_settings.ui:601 resources/ui/account_settings.ui:711
 msgid "Regular Expression"
 msgstr ""
 
-#: resources/ui/account_settings.ui:575 resources/ui/account_settings.ui:685
+#: resources/ui/account_settings.ui:613 resources/ui/account_settings.ui:723
 msgid "Descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:580 resources/ui/account_settings.ui:690
+#: resources/ui/account_settings.ui:618 resources/ui/account_settings.ui:728
 msgid "Descriptor should not be too long"
 msgstr ""
 
-#: resources/ui/account_settings.ui:591 resources/ui/account_settings.ui:701
+#: resources/ui/account_settings.ui:629 resources/ui/account_settings.ui:739
 msgid "eg. 1080p"
 msgstr ""
 
-#: resources/ui/account_settings.ui:602 resources/ui/account_settings.ui:712
+#: resources/ui/account_settings.ui:640 resources/ui/account_settings.ui:750
 msgid "eg. 1080p.*WebDL"
 msgstr ""
 
-#: resources/ui/account_settings.ui:622
+#: resources/ui/account_settings.ui:660
 msgid "Edit descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:639
+#: resources/ui/account_settings.ui:677
 #: resources/ui/image_dialog_edit_page.ui:37
 msgid "Save"
 msgstr ""
 
-#: resources/ui/account_settings.ui:732
+#: resources/ui/account_settings.ui:770
 msgid "Change folder"
 msgstr ""
 
-#: resources/ui/account_settings.ui:734
+#: resources/ui/account_settings.ui:772
 msgid "Select new mpv config folder"
 msgstr ""
 

--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -549,11 +549,11 @@ msgid "Auto Select Last Server"
 msgstr ""
 
 #: resources/ui/account_settings.ui:110
-msgid "Always Show Item Titles"
+msgid "Full Display Mode"
 msgstr ""
 
 #: resources/ui/account_settings.ui:111
-msgid "Show titles on all item cards"
+msgid "Show item titles on all cards, turn off for compact mode"
 msgstr ""
 
 #: resources/ui/account_settings.ui:118

--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -105,23 +105,23 @@ msgstr ""
 msgid "Failed to change password"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:288
+#: src/ui/widgets/account_settings.rs:286
 msgid "Cache Cleared"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:309
+#: src/ui/widgets/account_settings.rs:307
 msgid "No file selected"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:562
-#: src/ui/widgets/account_settings.rs:571
-#: src/ui/widgets/account_settings.rs:605
-#: src/ui/widgets/account_settings.rs:614
+#: src/ui/widgets/account_settings.rs:556
+#: src/ui/widgets/account_settings.rs:565
+#: src/ui/widgets/account_settings.rs:599
+#: src/ui/widgets/account_settings.rs:608
 msgid "Descriptor cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:576
-#: src/ui/widgets/account_settings.rs:619
+#: src/ui/widgets/account_settings.rs:570
+#: src/ui/widgets/account_settings.rs:613
 msgid "Invalid regex"
 msgstr ""
 

--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -36,7 +36,7 @@ msgstr ""
 
 #: src/ui/mpv/page.rs:407 src/ui/mpv/page.rs:409 src/ui/widgets/item.rs:707
 #: resources/ui/album_widget.ui:94 resources/ui/item.ui:186
-#: resources/ui/mpv_menu_actions.ui:27 resources/ui/other.ui:76
+#: resources/ui/mpv_menu_actions.ui:27 resources/ui/other.ui:95
 #: resources/ui/player_toolbar.ui:90
 msgid "Play"
 msgstr ""
@@ -63,17 +63,17 @@ msgid ""
 "Tsukimi can't restart MPV."
 msgstr ""
 
-#: src/ui/provider/tu_item.rs:547
+#: src/ui/provider/tu_item.rs:548
 msgid "No next up video found"
 msgstr ""
 
-#: src/ui/provider/tu_item.rs:576 src/ui/widgets/tu_overview_item.rs:254
+#: src/ui/provider/tu_item.rs:577 src/ui/widgets/tu_overview_item.rs:256
 msgid "Present"
 msgstr ""
 
-#: src/ui/provider/tu_item.rs:584 src/ui/provider/tu_item.rs:602
-#: src/ui/provider/tu_item.rs:625 src/ui/provider/tu_item.rs:648
-#: src/ui/provider/tu_item.rs:651
+#: src/ui/provider/tu_item.rs:585 src/ui/provider/tu_item.rs:603
+#: src/ui/provider/tu_item.rs:626 src/ui/provider/tu_item.rs:649
+#: src/ui/provider/tu_item.rs:652
 msgid "Unknown"
 msgstr ""
 
@@ -89,39 +89,39 @@ msgstr ""
 msgid "Server added successfully"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:233
+#: src/ui/widgets/account_settings.rs:235
 msgid "Password cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:237
+#: src/ui/widgets/account_settings.rs:239
 msgid "Passwords do not match!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:244
+#: src/ui/widgets/account_settings.rs:246
 msgid "Password changed successfully! Please login again."
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:248
+#: src/ui/widgets/account_settings.rs:250
 msgid "Failed to change password"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:284
+#: src/ui/widgets/account_settings.rs:286
 msgid "Cache Cleared"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:305
+#: src/ui/widgets/account_settings.rs:307
 msgid "No file selected"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:540
-#: src/ui/widgets/account_settings.rs:549
-#: src/ui/widgets/account_settings.rs:583
-#: src/ui/widgets/account_settings.rs:592
+#: src/ui/widgets/account_settings.rs:553
+#: src/ui/widgets/account_settings.rs:562
+#: src/ui/widgets/account_settings.rs:596
+#: src/ui/widgets/account_settings.rs:605
 msgid "Descriptor cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:554
-#: src/ui/widgets/account_settings.rs:597
+#: src/ui/widgets/account_settings.rs:567
+#: src/ui/widgets/account_settings.rs:610
 msgid "Invalid regex"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgid "Disc"
 msgstr ""
 
 #. if merged, next up will contain resume items, so change title to continue watching
-#: src/ui/widgets/home.rs:230 resources/ui/home.ui:25 resources/ui/item.ui:294
+#: src/ui/widgets/home.rs:230 resources/ui/home.ui:25 resources/ui/item.ui:300
 msgid "Continue Watching"
 msgstr ""
 
@@ -153,21 +153,21 @@ msgid "Identify"
 msgstr ""
 
 #: src/ui/widgets/identify/search_page.rs:126
-#: src/ui/widgets/image_dialog/search_page.rs:148
+#: src/ui/widgets/image_dialog/search_page.rs:145
 #: src/ui/widgets/metadata_dialog.rs:290 src/ui/widgets/tu_item/action.rs:485
 msgid "Are you sure you wish to continue?"
 msgstr ""
 
 #: src/ui/widgets/identify/search_page.rs:129
-#: src/ui/widgets/image_dialog/search_page.rs:151
+#: src/ui/widgets/image_dialog/search_page.rs:148
 #: src/ui/widgets/metadata_dialog.rs:293 src/ui/widgets/tu_item/action.rs:489
-#: src/ui/widgets/tu_item/action.rs:549 resources/ui/account_settings.ui:515
-#: resources/ui/account_settings.ui:625
+#: src/ui/widgets/tu_item/action.rs:549 resources/ui/account_settings.ui:523
+#: resources/ui/account_settings.ui:633
 msgid "Cancel"
 msgstr ""
 
 #: src/ui/widgets/identify/search_page.rs:130
-#: src/ui/widgets/image_dialog/search_page.rs:152
+#: src/ui/widgets/image_dialog/search_page.rs:149
 #: src/ui/widgets/metadata_dialog.rs:294
 msgid "Ok"
 msgstr ""
@@ -180,11 +180,11 @@ msgstr ""
 msgid "View Images"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/image_edit_dialog_page.rs:184
+#: src/ui/widgets/image_dialog/image_edit_dialog_page.rs:183
 msgid "Image saved"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/image_edit_dialog_page.rs:189
+#: src/ui/widgets/image_dialog/image_edit_dialog_page.rs:188
 msgid "Failed to load image"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Error deleting image"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/search_page.rs:146
+#: src/ui/widgets/image_dialog/search_page.rs:143
 msgid "Replace Image"
 msgstr ""
 
@@ -217,68 +217,68 @@ msgstr ""
 msgid "Resume"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1088
+#: src/ui/widgets/item.rs:1092
 msgid "Codec"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1091
+#: src/ui/widgets/item.rs:1095
 msgid "Language"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1094 resources/ui/metadata_dialog.ui:90
+#: src/ui/widgets/item.rs:1098 resources/ui/metadata_dialog.ui:90
 #: resources/ui/single_grid.ui:108
 msgid "Title"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1098 resources/ui/single_grid.ui:109
+#: src/ui/widgets/item.rs:1102 resources/ui/single_grid.ui:109
 msgid "Bitrate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1103
+#: src/ui/widgets/item.rs:1107
 msgid "BitDepth"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1107
+#: src/ui/widgets/item.rs:1111
 msgid "SampleRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1111
+#: src/ui/widgets/item.rs:1115
 msgid "Height"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1114
+#: src/ui/widgets/item.rs:1118
 msgid "Width"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1117
+#: src/ui/widgets/item.rs:1121
 msgid "ColorSpace"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1121
+#: src/ui/widgets/item.rs:1125
 msgid "DisplayTitle"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1125
+#: src/ui/widgets/item.rs:1129
 msgid "Channel"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1129
+#: src/ui/widgets/item.rs:1133
 msgid "ChannelLayout"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1134
+#: src/ui/widgets/item.rs:1138
 msgid "AverageFrameRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1138
+#: src/ui/widgets/item.rs:1142
 msgid "PixelFormat"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1250
+#: src/ui/widgets/item.rs:1254
 msgid "No video source found"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1386
+#: src/ui/widgets/item.rs:1390
 msgid "Season not found. Is this a continue watching list?"
 msgstr ""
 
@@ -299,12 +299,12 @@ msgid "BoxSet"
 msgstr ""
 
 #: src/ui/widgets/list.rs:132 resources/ui/filter.ui:85
-#: resources/ui/item.ui:483 resources/ui/other.ui:150
+#: resources/ui/item.ui:489 resources/ui/other.ui:168
 msgid "Tags"
 msgstr ""
 
 #: src/ui/widgets/list.rs:133 resources/ui/filter.ui:78
-#: resources/ui/item.ui:478 resources/ui/other.ui:155
+#: resources/ui/item.ui:484 resources/ui/other.ui:173
 msgid "Genres"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: src/ui/widgets/missing_episodes_dialog.rs:148
+#: src/ui/widgets/missing_episodes_dialog.rs:147
 msgid "Special"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 msgid "No overview"
 msgstr ""
 
-#: src/ui/widgets/server_action_row.rs:129
+#: src/ui/widgets/server_action_row.rs:128
 msgid "Edit Server"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgid "Enter the server details below."
 msgstr ""
 
 #: resources/ui/account.ui:48 resources/ui/identify_dialog.ui:74
-#: resources/ui/other.ui:54
+#: resources/ui/other.ui:73
 msgid "Name"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: resources/ui/account.ui:108 resources/ui/account_settings.ui:521
+#: resources/ui/account.ui:108 resources/ui/account_settings.ui:529
 msgid "Add"
 msgstr ""
 
@@ -515,240 +515,248 @@ msgstr ""
 msgid "Preferred Audio Language"
 msgstr ""
 
-#: resources/ui/account_settings.ui:30 resources/ui/account_settings.ui:55
-#: resources/ui/account_settings.ui:155
+#: resources/ui/account_settings.ui:30 resources/ui/account_settings.ui:56
+#: resources/ui/account_settings.ui:163
 msgid "Default"
 msgstr ""
 
-#: resources/ui/account_settings.ui:46
+#: resources/ui/account_settings.ui:47
 msgid "Preferred Subtitle Language"
 msgstr ""
 
-#: resources/ui/account_settings.ui:73
+#: resources/ui/account_settings.ui:75
 msgid "Appearence"
 msgstr ""
 
-#: resources/ui/account_settings.ui:76
+#: resources/ui/account_settings.ui:78
 msgid "Use Custom Accent Color"
 msgstr ""
 
-#: resources/ui/account_settings.ui:77
+#: resources/ui/account_settings.ui:79
 msgid "Disable to follow the system accent color"
 msgstr ""
 
-#: resources/ui/account_settings.ui:82
+#: resources/ui/account_settings.ui:84
 msgid "Accent Color"
 msgstr ""
 
-#: resources/ui/account_settings.ui:98
+#: resources/ui/account_settings.ui:100
 msgid "Hide Sidebar"
 msgstr ""
 
-#: resources/ui/account_settings.ui:103
+#: resources/ui/account_settings.ui:105
 msgid "Auto Select Last Server"
 msgstr ""
 
 #: resources/ui/account_settings.ui:110
-msgid "Home Page"
+msgid "Always Show Item Titles"
 msgstr ""
 
-#: resources/ui/account_settings.ui:113
-msgid "Refresh when returning to home page"
+#: resources/ui/account_settings.ui:111
+msgid "Show titles on all item cards"
 msgstr ""
 
 #: resources/ui/account_settings.ui:118
-msgid "Merge Continue Watching and Next Up"
+msgid "Home Page"
 msgstr ""
 
-#: resources/ui/account_settings.ui:119
-msgid "Jellyfin only"
+#: resources/ui/account_settings.ui:121
+msgid "Refresh when returning to home page"
 msgstr ""
 
 #: resources/ui/account_settings.ui:126
+msgid "Merge Continue Watching and Next Up"
+msgstr ""
+
+#: resources/ui/account_settings.ui:127
+msgid "Jellyfin only"
+msgstr ""
+
+#: resources/ui/account_settings.ui:134
 msgid "Network"
 msgstr ""
 
-#: resources/ui/account_settings.ui:129
+#: resources/ui/account_settings.ui:137
 msgid "Threads"
 msgstr ""
 
-#: resources/ui/account_settings.ui:130
+#: resources/ui/account_settings.ui:138
 msgid "Excessive thread counts may exhaust the system's connection pool"
 msgstr ""
 
-#: resources/ui/account_settings.ui:146 resources/ui/mpv_control_sidebar.ui:399
+#: resources/ui/account_settings.ui:154 resources/ui/mpv_control_sidebar.ui:399
 msgid "Background"
 msgstr ""
 
-#: resources/ui/account_settings.ui:178
+#: resources/ui/account_settings.ui:186
 msgid "Opacity"
 msgstr ""
 
-#: resources/ui/account_settings.ui:192
+#: resources/ui/account_settings.ui:200
 msgid "Blur"
 msgstr ""
 
-#: resources/ui/account_settings.ui:197
+#: resources/ui/account_settings.ui:205
 msgid "Blur Radius"
 msgstr ""
 
-#: resources/ui/account_settings.ui:213 resources/ui/mpv_control_sidebar.ui:84
+#: resources/ui/account_settings.ui:221 resources/ui/mpv_control_sidebar.ui:84
 msgid "Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:216
+#: resources/ui/account_settings.ui:224
 msgid "Clear Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:231 resources/ui/account_settings.ui:350
+#: resources/ui/account_settings.ui:239 resources/ui/account_settings.ui:358
 msgid "Others"
 msgstr ""
 
-#: resources/ui/account_settings.ui:234 resources/ui/account_settings.ui:426
+#: resources/ui/account_settings.ui:242 resources/ui/account_settings.ui:434
 msgid "Preferred Video Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:246
+#: resources/ui/account_settings.ui:254
 msgid "Account"
 msgstr ""
 
-#: resources/ui/account_settings.ui:259 resources/ui/account_settings.ui:276
+#: resources/ui/account_settings.ui:267 resources/ui/account_settings.ui:284
 msgid "Change Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:262
+#: resources/ui/account_settings.ui:270
 msgid "New Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:267
+#: resources/ui/account_settings.ui:275
 msgid "Confirm Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:290
+#: resources/ui/account_settings.ui:298
 msgid "Media"
 msgstr ""
 
-#: resources/ui/account_settings.ui:295
+#: resources/ui/account_settings.ui:303
 msgid "Music Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:298 resources/ui/player_toolbar.ui:197
+#: resources/ui/account_settings.ui:306 resources/ui/player_toolbar.ui:197
 msgid "Repeat Mode"
 msgstr ""
 
-#: resources/ui/account_settings.ui:302 resources/ui/player_toolbar.ui:231
+#: resources/ui/account_settings.ui:310 resources/ui/player_toolbar.ui:231
 msgid "Repeat One"
 msgstr ""
 
-#: resources/ui/account_settings.ui:303 resources/ui/player_toolbar.ui:235
+#: resources/ui/account_settings.ui:311 resources/ui/player_toolbar.ui:235
 msgid "Repeat All"
 msgstr ""
 
-#: resources/ui/account_settings.ui:304 resources/ui/account_settings.ui:332
+#: resources/ui/account_settings.ui:312 resources/ui/account_settings.ui:340
 #: resources/ui/player_toolbar.ui:239
 msgid "None"
 msgstr ""
 
-#: resources/ui/account_settings.ui:314
+#: resources/ui/account_settings.ui:322
 msgid "Video Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:315
+#: resources/ui/account_settings.ui:323
 msgid "Requires restart"
 msgstr ""
 
-#: resources/ui/account_settings.ui:318
+#: resources/ui/account_settings.ui:326
 msgid "Enable external config"
 msgstr ""
 
-#: resources/ui/account_settings.ui:323
+#: resources/ui/account_settings.ui:331
 msgid "Config dir"
 msgstr ""
 
-#: resources/ui/account_settings.ui:355
+#: resources/ui/account_settings.ui:363
 msgid "Video Output"
 msgstr ""
 
-#: resources/ui/account_settings.ui:356
+#: resources/ui/account_settings.ui:364
 msgid "Only for debugging"
 msgstr ""
 
-#: resources/ui/account_settings.ui:359
+#: resources/ui/account_settings.ui:367
 msgid "libmpv (default)"
 msgstr ""
 
-#: resources/ui/account_settings.ui:404
+#: resources/ui/account_settings.ui:412
 msgid "Preferred Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:427
+#: resources/ui/account_settings.ui:435
 msgid ""
 "Weight is ordered from high to low, until a specific version is matched, or "
 "the highest matching version is obtained before clearing the match list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:442
+#: resources/ui/account_settings.ui:450
 msgid "Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:464
+#: resources/ui/account_settings.ui:472
 msgid "It is recommended to set no more than 3 lines"
 msgstr ""
 
-#: resources/ui/account_settings.ui:485
+#: resources/ui/account_settings.ui:493
 msgid "No Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:504
+#: resources/ui/account_settings.ui:512
 msgid "Add a descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:546 resources/ui/account_settings.ui:656
+#: resources/ui/account_settings.ui:554 resources/ui/account_settings.ui:664
 msgid "This will use exact matching to obtain a list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:549 resources/ui/account_settings.ui:659
+#: resources/ui/account_settings.ui:557 resources/ui/account_settings.ui:667
 msgid "Descriptor Type"
 msgstr ""
 
-#: resources/ui/account_settings.ui:554 resources/ui/account_settings.ui:664
+#: resources/ui/account_settings.ui:562 resources/ui/account_settings.ui:672
 msgid "String"
 msgstr ""
 
-#: resources/ui/account_settings.ui:555 resources/ui/account_settings.ui:665
+#: resources/ui/account_settings.ui:563 resources/ui/account_settings.ui:673
 msgid "Regular Expression"
 msgstr ""
 
-#: resources/ui/account_settings.ui:567 resources/ui/account_settings.ui:677
+#: resources/ui/account_settings.ui:575 resources/ui/account_settings.ui:685
 msgid "Descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:572 resources/ui/account_settings.ui:682
+#: resources/ui/account_settings.ui:580 resources/ui/account_settings.ui:690
 msgid "Descriptor should not be too long"
 msgstr ""
 
-#: resources/ui/account_settings.ui:583 resources/ui/account_settings.ui:693
+#: resources/ui/account_settings.ui:591 resources/ui/account_settings.ui:701
 msgid "eg. 1080p"
 msgstr ""
 
-#: resources/ui/account_settings.ui:594 resources/ui/account_settings.ui:704
+#: resources/ui/account_settings.ui:602 resources/ui/account_settings.ui:712
 msgid "eg. 1080p.*WebDL"
 msgstr ""
 
-#: resources/ui/account_settings.ui:614
+#: resources/ui/account_settings.ui:622
 msgid "Edit descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:631
+#: resources/ui/account_settings.ui:639
 #: resources/ui/image_dialog_edit_page.ui:37
 msgid "Save"
 msgstr ""
 
-#: resources/ui/account_settings.ui:724
+#: resources/ui/account_settings.ui:732
 msgid "Change folder"
 msgstr ""
 
-#: resources/ui/account_settings.ui:726
+#: resources/ui/account_settings.ui:734
 msgid "Select new mpv config folder"
 msgstr ""
 
@@ -789,8 +797,8 @@ msgstr ""
 msgid "Official Ratings"
 msgstr ""
 
-#: resources/ui/filter.ui:106 resources/ui/item.ui:473
-#: resources/ui/other.ui:145
+#: resources/ui/filter.ui:106 resources/ui/item.ui:479
+#: resources/ui/other.ui:163
 msgid "Studios"
 msgstr ""
 
@@ -929,40 +937,40 @@ msgstr ""
 msgid "Subtitle: "
 msgstr ""
 
-#: resources/ui/item.ui:308
+#: resources/ui/item.ui:314
 msgid "View this season"
 msgstr ""
 
-#: resources/ui/item.ui:416 resources/ui/liked.ui:69
+#: resources/ui/item.ui:422 resources/ui/liked.ui:69
 #: resources/ui/single_grid.ui:167
 msgid "Nothing Here"
 msgstr ""
 
-#: resources/ui/item.ui:443
+#: resources/ui/item.ui:449
 msgid "Included In"
 msgstr ""
 
-#: resources/ui/item.ui:448
+#: resources/ui/item.ui:454
 msgid "Additional Parts"
 msgstr ""
 
-#: resources/ui/item.ui:453
+#: resources/ui/item.ui:459
 msgid "Seasons"
 msgstr ""
 
-#: resources/ui/item.ui:458 resources/ui/other.ui:140
+#: resources/ui/item.ui:464 resources/ui/other.ui:158
 msgid "Actors"
 msgstr ""
 
-#: resources/ui/item.ui:463
+#: resources/ui/item.ui:469
 msgid "Recommend"
 msgstr ""
 
-#: resources/ui/item.ui:468 resources/ui/other.ui:160
+#: resources/ui/item.ui:474 resources/ui/other.ui:178
 msgid "Links"
 msgstr ""
 
-#: resources/ui/item.ui:501
+#: resources/ui/item.ui:507
 msgid "MediaInfo"
 msgstr ""
 
@@ -1233,7 +1241,7 @@ msgstr ""
 msgid "Dual Channel (Invert)"
 msgstr ""
 
-#: resources/ui/mpv_control_sidebar.ui:516 resources/ui/other.ui:134
+#: resources/ui/mpv_control_sidebar.ui:516 resources/ui/other.ui:152
 #: resources/ui/search.ui:84
 msgid "Video"
 msgstr ""
@@ -1564,19 +1572,19 @@ msgstr ""
 msgid "Adjust Volume"
 msgstr ""
 
-#: resources/ui/other.ui:94
+#: resources/ui/other.ui:113
 msgid "No Inscriptions"
 msgstr ""
 
-#: resources/ui/other.ui:116 resources/ui/search.ui:54
+#: resources/ui/other.ui:134 resources/ui/search.ui:54
 msgid "Movie"
 msgstr ""
 
-#: resources/ui/other.ui:122 resources/ui/search.ui:48
+#: resources/ui/other.ui:140 resources/ui/search.ui:48
 msgid "Series"
 msgstr ""
 
-#: resources/ui/other.ui:128 resources/ui/search.ui:90
+#: resources/ui/other.ui:146 resources/ui/search.ui:90
 msgid "Episode"
 msgstr ""
 

--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -57,6 +57,10 @@
       <default>true</default>
       <summary>Whether to override the system accent color</summary>
     </key>
+    <key name="always-show-item-title" type="b">
+      <default>false</default>
+      <summary>Whether to always show item titles on cards</summary>
+    </key>
     <key name="root-pic" type="s">
       <default>""</default>
       <summary>Default Background Path</summary>

--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -57,9 +57,15 @@
       <default>true</default>
       <summary>Whether to override the system accent color</summary>
     </key>
-    <key name="full-item-display-mode" type="b">
-      <default>false</default>
-      <summary>Whether to use full item display mode</summary>
+    <key name="item-text-display" type="s">
+      <default>"compact"</default>
+      <summary>Item text display mode</summary>
+      <description>compact or full</description>
+    </key>
+    <key name="item-card-style" type="s">
+      <default>"integrated"</default>
+      <summary>Item card style</summary>
+      <description>integrated or separated</description>
     </key>
     <key name="root-pic" type="s">
       <default>""</default>

--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -57,9 +57,9 @@
       <default>true</default>
       <summary>Whether to override the system accent color</summary>
     </key>
-    <key name="always-show-item-title" type="b">
+    <key name="full-item-display-mode" type="b">
       <default>false</default>
-      <summary>Whether to always show item titles on cards</summary>
+      <summary>Whether to use full item display mode</summary>
     </key>
     <key name="root-pic" type="s">
       <default>""</default>

--- a/resources/style.css
+++ b/resources/style.css
@@ -379,3 +379,8 @@ progressbar.accent > trough > progress {
 .cover-progress-frame {
     border-radius: 10px;
 }
+
+.tulistitem {
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+    border-radius: 10px;
+}

--- a/resources/style.css
+++ b/resources/style.css
@@ -379,8 +379,3 @@ progressbar.accent > trough > progress {
 .cover-progress-frame {
     border-radius: 10px;
 }
-
-.tulistitem {
-    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
-    border-radius: 10px;
-}

--- a/resources/style.css
+++ b/resources/style.css
@@ -330,7 +330,11 @@ checkbutton.theme-selector radio:checked {
 }
 
 progressbar.accent > trough {
-  min-height: 4px;
+  min-height: 6px;
+}
+
+progressbar.accent > trough > progress {
+  border-radius: 0;
 }
 
 .mpv-seekbar>trough {
@@ -369,6 +373,10 @@ progressbar.accent > trough {
 .picture-loader {
     background-color: transparent;
     box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+    border-radius: 10px;
+}
+
+.cover-progress-frame {
     border-radius: 10px;
 }
 

--- a/resources/ui/account_settings.ui
+++ b/resources/ui/account_settings.ui
@@ -100,13 +100,19 @@
                 <property name="title" translatable="yes">Hide Sidebar</property>
               </object>
             </child>
-            <child>
-              <object class="AdwSwitchRow" id="selectlastcontrol">
-                <property name="title" translatable="yes">Auto Select Last Server</property>
-              </object>
-            </child>
-          </object>
-        </child>
+	            <child>
+	              <object class="AdwSwitchRow" id="selectlastcontrol">
+	                <property name="title" translatable="yes">Auto Select Last Server</property>
+	              </object>
+	            </child>
+	            <child>
+	              <object class="AdwSwitchRow" id="always_show_item_title_control">
+	                <property name="title" translatable="yes">Always Show Item Titles</property>
+	                <property name="subtitle" translatable="yes">Show titles on all item cards</property>
+	              </object>
+	            </child>
+	          </object>
+	        </child>
         <child>
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Home Page</property>

--- a/resources/ui/account_settings.ui
+++ b/resources/ui/account_settings.ui
@@ -106,9 +106,47 @@
 	              </object>
 	            </child>
 	            <child>
-	              <object class="AdwSwitchRow" id="full_item_display_mode_control">
-	                <property name="title" translatable="yes">Full Display Mode</property>
-	                <property name="subtitle" translatable="yes">Show item titles on all cards, turn off for compact mode</property>
+	              <object class="AdwActionRow">
+	                <property name="title" translatable="yes">Text Display</property>
+	                <child type="suffix">
+	                  <object class="AdwToggleGroup" id="text_display_group">
+	                    <property name="valign">center</property>
+	                    <child>
+	                      <object class="AdwToggle">
+	                        <property name="label" translatable="yes">Compact</property>
+	                        <property name="name">compact</property>
+	                      </object>
+	                    </child>
+	                    <child>
+	                      <object class="AdwToggle">
+	                        <property name="label" translatable="yes">Full</property>
+	                        <property name="name">full</property>
+	                      </object>
+	                    </child>
+	                  </object>
+	                </child>
+	              </object>
+	            </child>
+	            <child>
+	              <object class="AdwActionRow">
+	                <property name="title" translatable="yes">Card Style</property>
+	                <child type="suffix">
+	                  <object class="AdwToggleGroup" id="card_style_group">
+	                    <property name="valign">center</property>
+	                    <child>
+	                      <object class="AdwToggle">
+	                        <property name="label" translatable="yes">Integrated</property>
+	                        <property name="name">integrated</property>
+	                      </object>
+	                    </child>
+	                    <child>
+	                      <object class="AdwToggle">
+	                        <property name="label" translatable="yes">Separated</property>
+	                        <property name="name">separated</property>
+	                      </object>
+	                    </child>
+	                  </object>
+	                </child>
 	              </object>
 	            </child>
 	          </object>

--- a/resources/ui/account_settings.ui
+++ b/resources/ui/account_settings.ui
@@ -106,9 +106,9 @@
 	              </object>
 	            </child>
 	            <child>
-	              <object class="AdwSwitchRow" id="always_show_item_title_control">
-	                <property name="title" translatable="yes">Always Show Item Titles</property>
-	                <property name="subtitle" translatable="yes">Show titles on all item cards</property>
+	              <object class="AdwSwitchRow" id="full_item_display_mode_control">
+	                <property name="title" translatable="yes">Full Display Mode</property>
+	                <property name="subtitle" translatable="yes">Show item titles on all cards, turn off for compact mode</property>
 	              </object>
 	            </child>
 	          </object>

--- a/resources/ui/eu_item.ui
+++ b/resources/ui/eu_item.ui
@@ -46,9 +46,6 @@
             </style>
           </object>
         </child>
-        <style>
-        <class name="tulistitem"/>
-      </style>
       </object>
     </child>
   </template>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -13,12 +13,24 @@
             <property name="valign">fill</property>
             <property name="overflow">visible</property>
             <child>
-                <object class="GtkOverlay" id="overlay">
-                    <property name="valign">fill</property>
-                    <property name="width-request">100</property>
-                    <property name="height-request">100</property>
-                    <property name="halign">fill</property>
-                    <property name="overflow">visible</property>
+	                <object class="GtkOverlay" id="overlay">
+	                    <property name="valign">fill</property>
+	                    <property name="width-request">100</property>
+	                    <property name="height-request">100</property>
+	                    <property name="halign">fill</property>
+	                    <property name="overflow">hidden</property>
+	                    <style>
+	                        <class name="cover-progress-frame" />
+	                    </style>
+	                    <child type="overlay">
+	                        <object class="GtkProgressBar" id="progress_bar">
+	                            <property name="visible">false</property>
+	                            <property name="valign">end</property>
+	                            <style>
+	                                <class name="accent" />
+	                            </style>
+                        </object>
+                    </child>
                     <child type="overlay">
                         <object class="GtkButton" id="played_mark">
                             <property name="halign">end</property>
@@ -49,11 +61,11 @@
                     </child>
                     <child type="overlay">
                         <object class="GtkButton" id="direct_play_button">
-                            <property name="halign">start</property>
-                            <property name="valign">end</property>
-                            <property name="margin-start">8</property>
-                            <property name="margin-bottom">8</property>
-                            <property name="icon-name">media-playback-start-symbolic</property>
+	                            <property name="halign">start</property>
+	                            <property name="valign">end</property>
+	                            <property name="margin-start">8</property>
+	                            <property name="margin-bottom">11</property>
+	                            <property name="icon-name">media-playback-start-symbolic</property>
                             <property name="visible">false</property>
                             <signal name="clicked" handler="on_play_clicked" swapped="yes"/>
                             <style>
@@ -78,11 +90,11 @@
                     <attribute name="scale" value="0.9" />
                     <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
                 </attributes>
-                </object>
-            </child>
-            <style>
-                <class name="tulistitem" />
-            </style>
+	                </object>
+	            </child>
+	            <style>
+	                <class name="tulistitem" />
+	            </style>
             </object>
         </child>
       </object>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -6,6 +6,7 @@
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
         <property name="valign">fill</property>
         <property name="overflow">visible</property>
         <child>
@@ -14,6 +15,7 @@
             <child>
               <object class="GtkBox" id="content_box">
                 <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
                 <property name="valign">fill</property>
                 <property name="overflow">visible</property>
                 <child>
@@ -88,7 +90,6 @@
                         <property name="orientation">vertical</property>
                         <property name="spacing">2</property>
                         <property name="visible">false</property>
-                        <property name="margin-top">12</property>
                         <property name="margin-bottom">10</property>
                         <property name="margin-start">10</property>
                         <property name="margin-end">10</property>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -82,6 +82,7 @@
           <object class="GtkLabel" id="title">
             <property name="justify">center</property>
             <property name="wrap">true</property>
+            <property name="wrap-mode">word-char</property>
             <property name="max-width-chars">1</property>
             <property name="visible">false</property>
             <property name="margin-bottom">10</property>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -4,98 +4,95 @@
     <property name="halign">center</property>
     <property name="valign">start</property>
     <child>
-      <object class="HoverScale" id="hover_scale">
-        <property name="valign">start</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <property name="valign">fill</property>
+        <property name="overflow">visible</property>
         <child>
-            <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="spacing">8</property>
-            <property name="valign">fill</property>
-            <property name="overflow">visible</property>
+          <object class="HoverScale" id="hover_scale">
+            <property name="valign">start</property>
             <child>
-	                <object class="GtkOverlay" id="overlay">
-	                    <property name="valign">fill</property>
-	                    <property name="width-request">100</property>
-	                    <property name="height-request">100</property>
-	                    <property name="halign">fill</property>
-	                    <property name="overflow">hidden</property>
-	                    <style>
-	                        <class name="cover-progress-frame" />
-	                    </style>
-	                    <child type="overlay">
-	                        <object class="GtkProgressBar" id="progress_bar">
-	                            <property name="visible">false</property>
-	                            <property name="valign">end</property>
-	                            <style>
-	                                <class name="accent" />
-	                            </style>
-                        </object>
-                    </child>
-                    <child type="overlay">
-                        <object class="GtkButton" id="played_mark">
-                            <property name="halign">end</property>
-                            <property name="valign">start</property>
-                            <property name="margin-end">8</property>
-                            <property name="margin-top">8</property>
-                            <property name="icon-name">checkmark-small-symbolic</property>
-                            <property name="visible">false</property>
-                            <style>
-                                <class name="circular" />
-                                <class name="osd" />
-                            </style>
-                        </object>
-                    </child>
-                    <child type="overlay">
-                        <object class="GtkButton" id="folder_mark">
-                            <property name="halign">end</property>
-                            <property name="valign">start</property>
-                            <property name="margin-end">8</property>
-                            <property name="margin-top">8</property>
-                            <property name="icon-name">folder-visiting-symbolic</property>
-                            <property name="visible">false</property>
-                            <style>
-                                <class name="circular" />
-                                <class name="osd" />
-                            </style>
-                        </object>
-                    </child>
-                    <child type="overlay">
-                        <object class="GtkButton" id="direct_play_button">
-	                            <property name="halign">start</property>
-	                            <property name="valign">end</property>
-	                            <property name="margin-start">8</property>
-	                            <property name="margin-bottom">11</property>
-	                            <property name="icon-name">media-playback-start-symbolic</property>
-                            <property name="visible">false</property>
-                            <signal name="clicked" handler="on_play_clicked" swapped="yes"/>
-                            <style>
-                                <class name="circular" />
-                                <class name="osd" />
-                            </style>
-                        </object>
-                    </child>
-                </object>
+              <object class="GtkOverlay" id="overlay">
+                <property name="valign">fill</property>
+                <property name="width-request">100</property>
+                <property name="height-request">100</property>
+                <property name="halign">fill</property>
+                <property name="overflow">hidden</property>
+                <style>
+                  <class name="cover-progress-frame" />
+                </style>
+                <child type="overlay">
+                  <object class="GtkProgressBar" id="progress_bar">
+                    <property name="visible">false</property>
+                    <property name="valign">end</property>
+                    <style>
+                      <class name="accent" />
+                    </style>
+                  </object>
+                </child>
+                <child type="overlay">
+                  <object class="GtkButton" id="played_mark">
+                    <property name="halign">end</property>
+                    <property name="valign">start</property>
+                    <property name="margin-end">8</property>
+                    <property name="margin-top">8</property>
+                    <property name="icon-name">checkmark-small-symbolic</property>
+                    <property name="visible">false</property>
+                    <style>
+                      <class name="circular" />
+                      <class name="osd" />
+                    </style>
+                  </object>
+                </child>
+                <child type="overlay">
+                  <object class="GtkButton" id="folder_mark">
+                    <property name="halign">end</property>
+                    <property name="valign">start</property>
+                    <property name="margin-end">8</property>
+                    <property name="margin-top">8</property>
+                    <property name="icon-name">folder-visiting-symbolic</property>
+                    <property name="visible">false</property>
+                    <style>
+                      <class name="circular" />
+                      <class name="osd" />
+                    </style>
+                  </object>
+                </child>
+                <child type="overlay">
+                  <object class="GtkButton" id="direct_play_button">
+                    <property name="halign">start</property>
+                    <property name="valign">end</property>
+                    <property name="margin-start">8</property>
+                    <property name="margin-bottom">11</property>
+                    <property name="icon-name">media-playback-start-symbolic</property>
+                    <property name="visible">false</property>
+                    <signal name="clicked" handler="on_play_clicked" swapped="yes"/>
+                    <style>
+                      <class name="circular" />
+                      <class name="osd" />
+                    </style>
+                  </object>
+                </child>
+              </object>
             </child>
-            <child>
-                <object class="GtkLabel" id="title">
-                <property name="justify">center</property>
-                <property name="wrap">true</property>
-                <property name="max-width-chars">1</property>
-                <property name="visible">false</property>
-                <property name="margin-bottom">10</property>
-                <property name="margin-start">10</property>
-                <property name="margin-end">10</property>
-                <property name="opacity">0.9</property>
-                <attributes>
-                    <attribute name="scale" value="0.9" />
-                    <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
-                </attributes>
-	                </object>
-	            </child>
-	            <style>
-	                <class name="tulistitem" />
-	            </style>
-            </object>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="title">
+            <property name="justify">center</property>
+            <property name="wrap">true</property>
+            <property name="max-width-chars">1</property>
+            <property name="visible">false</property>
+            <property name="margin-bottom">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="opacity">0.9</property>
+            <attributes>
+              <attribute name="scale" value="0.9" />
+              <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
+            </attributes>
+          </object>
         </child>
       </object>
     </child>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -79,20 +79,39 @@
           </object>
         </child>
         <child>
-          <object class="GtkLabel" id="title">
-            <property name="justify">center</property>
-            <property name="wrap">true</property>
-            <property name="wrap-mode">word-char</property>
-            <property name="max-width-chars">1</property>
+          <object class="GtkBox" id="title_box">
+            <property name="orientation">vertical</property>
+            <property name="spacing">2</property>
             <property name="visible">false</property>
             <property name="margin-bottom">10</property>
             <property name="margin-start">10</property>
             <property name="margin-end">10</property>
-            <property name="opacity">0.9</property>
-            <attributes>
-              <attribute name="scale" value="0.9" />
-              <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
-            </attributes>
+            <child>
+              <object class="GtkLabel" id="title">
+                <property name="justify">center</property>
+                <property name="wrap">true</property>
+                <property name="wrap-mode">word-char</property>
+                <property name="max-width-chars">1</property>
+                <property name="opacity">0.9</property>
+                <attributes>
+                  <attribute name="scale" value="0.9" />
+                  <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="subtitle">
+                <property name="justify">center</property>
+                <property name="wrap">true</property>
+                <property name="wrap-mode">word-char</property>
+                <property name="max-width-chars">1</property>
+                <property name="visible">false</property>
+                <property name="opacity">0.65</property>
+                <attributes>
+                  <attribute name="scale" value="0.82" />
+                </attributes>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -4,14 +4,14 @@
     <property name="halign">center</property>
     <property name="valign">start</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <property name="spacing">12</property>
-        <property name="valign">fill</property>
-        <property name="overflow">visible</property>
+      <object class="HoverScale" id="hover_scale">
+        <property name="valign">start</property>
         <child>
-          <object class="HoverScale" id="hover_scale">
-            <property name="valign">start</property>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
+            <property name="valign">fill</property>
+            <property name="overflow">visible</property>
             <child>
               <object class="GtkOverlay" id="overlay">
                 <property name="valign">fill</property>
@@ -76,46 +76,49 @@
                 </child>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox" id="title_box">
-            <property name="orientation">vertical</property>
-            <property name="spacing">2</property>
-            <property name="visible">false</property>
-            <property name="margin-bottom">10</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
             <child>
-              <object class="GtkLabel" id="title">
-                <property name="justify">center</property>
-                <property name="wrap">true</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="max-width-chars">1</property>
-                <property name="lines">1</property>
-                <property name="ellipsize">middle</property>
-                <property name="opacity">0.9</property>
-                <attributes>
-                  <attribute name="scale" value="0.9" />
-                  <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
-                </attributes>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="subtitle">
-                <property name="justify">center</property>
-                <property name="wrap">true</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="max-width-chars">1</property>
-                <property name="lines">1</property>
-                <property name="ellipsize">middle</property>
+              <object class="GtkBox" id="title_box">
+                <property name="orientation">vertical</property>
+                <property name="spacing">2</property>
                 <property name="visible">false</property>
-                <property name="opacity">0.65</property>
-                <attributes>
-                  <attribute name="scale" value="0.82" />
-                </attributes>
+                <property name="margin-bottom">10</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">10</property>
+                <child>
+                  <object class="GtkLabel" id="title">
+                    <property name="justify">center</property>
+                    <property name="wrap">true</property>
+                    <property name="wrap-mode">word-char</property>
+                    <property name="max-width-chars">1</property>
+                    <property name="lines">1</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="opacity">0.9</property>
+                    <attributes>
+                      <attribute name="scale" value="0.9" />
+                      <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
+                    </attributes>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="subtitle">
+                    <property name="justify">center</property>
+                    <property name="wrap">true</property>
+                    <property name="wrap-mode">word-char</property>
+                    <property name="max-width-chars">1</property>
+                    <property name="lines">1</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="visible">false</property>
+                    <property name="opacity">0.65</property>
+                    <attributes>
+                      <attribute name="scale" value="0.82" />
+                    </attributes>
+                  </object>
+                </child>
               </object>
             </child>
+            <style>
+              <class name="tulistitem" />
+            </style>
           </object>
         </child>
       </object>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -92,6 +92,8 @@
                 <property name="wrap">true</property>
                 <property name="wrap-mode">word-char</property>
                 <property name="max-width-chars">1</property>
+                <property name="lines">1</property>
+                <property name="ellipsize">middle</property>
                 <property name="opacity">0.9</property>
                 <attributes>
                   <attribute name="scale" value="0.9" />
@@ -105,6 +107,8 @@
                 <property name="wrap">true</property>
                 <property name="wrap-mode">word-char</property>
                 <property name="max-width-chars">1</property>
+                <property name="lines">1</property>
+                <property name="ellipsize">middle</property>
                 <property name="visible">false</property>
                 <property name="opacity">0.65</property>
                 <attributes>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -4,121 +4,136 @@
     <property name="halign">center</property>
     <property name="valign">start</property>
     <child>
-      <object class="HoverScale" id="hover_scale">
-        <property name="valign">start</property>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <property name="valign">fill</property>
+        <property name="overflow">visible</property>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="spacing">12</property>
-            <property name="valign">fill</property>
-            <property name="overflow">visible</property>
+          <object class="HoverScale" id="hover_scale">
+            <property name="valign">start</property>
             <child>
-              <object class="GtkOverlay" id="overlay">
-                <property name="valign">fill</property>
-                <property name="width-request">100</property>
-                <property name="height-request">100</property>
-                <property name="halign">fill</property>
-                <property name="overflow">hidden</property>
-                <style>
-                  <class name="cover-progress-frame" />
-                </style>
-                <child type="overlay">
-                  <object class="GtkProgressBar" id="progress_bar">
-                    <property name="visible">false</property>
-                    <property name="valign">end</property>
-                    <style>
-                      <class name="accent" />
-                    </style>
-                  </object>
-                </child>
-                <child type="overlay">
-                  <object class="GtkButton" id="played_mark">
-                    <property name="halign">end</property>
-                    <property name="valign">start</property>
-                    <property name="margin-end">8</property>
-                    <property name="margin-top">8</property>
-                    <property name="icon-name">checkmark-small-symbolic</property>
-                    <property name="visible">false</property>
-                    <style>
-                      <class name="circular" />
-                      <class name="osd" />
-                    </style>
-                  </object>
-                </child>
-                <child type="overlay">
-                  <object class="GtkButton" id="folder_mark">
-                    <property name="halign">end</property>
-                    <property name="valign">start</property>
-                    <property name="margin-end">8</property>
-                    <property name="margin-top">8</property>
-                    <property name="icon-name">folder-visiting-symbolic</property>
-                    <property name="visible">false</property>
-                    <style>
-                      <class name="circular" />
-                      <class name="osd" />
-                    </style>
-                  </object>
-                </child>
-                <child type="overlay">
-                  <object class="GtkButton" id="direct_play_button">
-                    <property name="halign">start</property>
-                    <property name="valign">end</property>
-                    <property name="margin-start">8</property>
-                    <property name="margin-bottom">11</property>
-                    <property name="icon-name">media-playback-start-symbolic</property>
-                    <property name="visible">false</property>
-                    <signal name="clicked" handler="on_play_clicked" swapped="yes"/>
-                    <style>
-                      <class name="circular" />
-                      <class name="osd" />
-                    </style>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox" id="title_box">
+              <object class="GtkBox" id="content_box">
                 <property name="orientation">vertical</property>
-                <property name="spacing">2</property>
-                <property name="visible">false</property>
-                <property name="margin-bottom">10</property>
-                <property name="margin-start">10</property>
-                <property name="margin-end">10</property>
+                <property name="valign">fill</property>
+                <property name="overflow">visible</property>
                 <child>
-                  <object class="GtkLabel" id="title">
-                    <property name="justify">center</property>
-                    <property name="wrap">true</property>
-                    <property name="wrap-mode">word-char</property>
-                    <property name="max-width-chars">1</property>
-                    <property name="lines">1</property>
-                    <property name="ellipsize">middle</property>
-                    <property name="opacity">0.9</property>
-                    <attributes>
-                      <attribute name="scale" value="0.9" />
-                      <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
-                    </attributes>
+                  <object class="GtkOverlay" id="overlay">
+                    <property name="valign">fill</property>
+                    <property name="width-request">100</property>
+                    <property name="height-request">100</property>
+                    <property name="halign">fill</property>
+                    <property name="overflow">hidden</property>
+                    <style>
+                      <class name="cover-progress-frame" />
+                    </style>
+                    <child type="overlay">
+                      <object class="GtkProgressBar" id="progress_bar">
+                        <property name="visible">false</property>
+                        <property name="valign">end</property>
+                        <style>
+                          <class name="accent" />
+                        </style>
+                      </object>
+                    </child>
+                    <child type="overlay">
+                      <object class="GtkButton" id="played_mark">
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin-end">8</property>
+                        <property name="margin-top">8</property>
+                        <property name="icon-name">checkmark-small-symbolic</property>
+                        <property name="visible">false</property>
+                        <style>
+                          <class name="circular" />
+                          <class name="osd" />
+                        </style>
+                      </object>
+                    </child>
+                    <child type="overlay">
+                      <object class="GtkButton" id="folder_mark">
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin-end">8</property>
+                        <property name="margin-top">8</property>
+                        <property name="icon-name">folder-visiting-symbolic</property>
+                        <property name="visible">false</property>
+                        <style>
+                          <class name="circular" />
+                          <class name="osd" />
+                        </style>
+                      </object>
+                    </child>
+                    <child type="overlay">
+                      <object class="GtkButton" id="direct_play_button">
+                        <property name="halign">start</property>
+                        <property name="valign">end</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-bottom">11</property>
+                        <property name="icon-name">media-playback-start-symbolic</property>
+                        <property name="visible">false</property>
+                        <signal name="clicked" handler="on_play_clicked" swapped="yes"/>
+                        <style>
+                          <class name="circular" />
+                          <class name="osd" />
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="subtitle">
-                    <property name="justify">center</property>
-                    <property name="wrap">true</property>
-                    <property name="wrap-mode">word-char</property>
-                    <property name="max-width-chars">1</property>
-                    <property name="lines">1</property>
-                    <property name="ellipsize">middle</property>
-                    <property name="visible">false</property>
-                    <property name="opacity">0.65</property>
-                    <attributes>
-                      <attribute name="scale" value="0.82" />
-                    </attributes>
+                  <object class="GtkBox" id="scaled_title_slot">
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkBox" id="title_box">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">2</property>
+                        <property name="visible">false</property>
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <child>
+                          <object class="GtkLabel" id="title">
+                            <property name="justify">center</property>
+                            <property name="wrap">true</property>
+                            <property name="wrap-mode">word-char</property>
+                            <property name="max-width-chars">1</property>
+                            <property name="lines">1</property>
+                            <property name="ellipsize">middle</property>
+                            <property name="opacity">0.9</property>
+                            <attributes>
+                              <attribute name="scale" value="0.9" />
+                              <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
+                            </attributes>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="subtitle">
+                            <property name="justify">center</property>
+                            <property name="wrap">true</property>
+                            <property name="wrap-mode">word-char</property>
+                            <property name="max-width-chars">1</property>
+                            <property name="lines">1</property>
+                            <property name="ellipsize">middle</property>
+                            <property name="visible">false</property>
+                            <property name="opacity">0.65</property>
+                            <attributes>
+                              <attribute name="scale" value="0.82" />
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
             </child>
-            <style>
-              <class name="tulistitem" />
-            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="plain_title_slot">
+            <property name="orientation">vertical</property>
+            <property name="visible">false</property>
           </object>
         </child>
       </object>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -89,7 +89,6 @@
                       <object class="GtkBox" id="title_box">
                         <property name="orientation">vertical</property>
                         <property name="spacing">2</property>
-                        <property name="visible">false</property>
                         <property name="margin-bottom">10</property>
                         <property name="margin-start">10</property>
                         <property name="margin-end">10</property>

--- a/resources/ui/tu_overview_item.ui
+++ b/resources/ui/tu_overview_item.ui
@@ -17,13 +17,17 @@
               <object class="HoverScale" id="hover_scale">
                 <property name="valign">fill</property>
                 <child>
-                  <object class="GtkOverlay" id="overlay">
-                    <property name="valign">fill</property>
-                    <property name="width-request">250</property>
-                    <property name="height-request">141</property>
-                    <property name="halign">center</property>
-                    <child type="overlay">
-                      <object class="GtkBox" id="overlay_button_box">
+	                  <object class="GtkOverlay" id="overlay">
+	                    <property name="valign">fill</property>
+	                    <property name="width-request">250</property>
+	                    <property name="height-request">141</property>
+	                    <property name="halign">center</property>
+	                    <property name="overflow">hidden</property>
+	                    <style>
+	                      <class name="cover-progress-frame" />
+	                    </style>
+	                    <child type="overlay">
+	                      <object class="GtkBox" id="overlay_button_box">
                         <property name="orientation">horizontal</property>
                         <property name="spacing">12</property>
                         <property name="halign">end</property>
@@ -34,13 +38,11 @@
                     </child>
                     <child type="overlay">
                       <object class="GtkProgressBar" id="progress_bar">
-                        <property name="visible">false</property>
-                        <property name="valign">end</property>
-                        <property name="margin-start">3</property>
-                        <property name="margin-end">3</property>
-                        <style>
-                          <class name="accent" />
-                        </style>
+	                        <property name="visible">false</property>
+	                        <property name="valign">end</property>
+	                        <style>
+	                          <class name="accent" />
+	                        </style>
                       </object>
                     </child>
                   </object>

--- a/resources/ui/tu_overview_item.ui
+++ b/resources/ui/tu_overview_item.ui
@@ -16,10 +16,9 @@
             <child>
 	              <object class="HoverScale" id="hover_scale">
 	                <property name="valign">fill</property>
-	                <property name="margin-start">20</property>
-					<property name="margin-end">8</property>
-	                <property name="margin-top">12</property>
-					<property name="margin-bottom">8</property>
+	                <property name="max-scale">1.00</property>
+	                <property name="margin-start">8</property>
+	                <property name="margin-top">8</property>
 	                <child>
 		                  <object class="GtkOverlay" id="overlay">
 	                    <property name="valign">fill</property>

--- a/resources/ui/tu_overview_item.ui
+++ b/resources/ui/tu_overview_item.ui
@@ -131,6 +131,7 @@
         </child>
         <child>
           <object class="GtkInscription" id="overview">
+            <property name="margin-start">8</property>
             <property name="min-lines">3</property>
             <property name="tooltip-text" bind-source="overview" bind-property="text" bind-flags="sync-create"/>
             <property name="text-overflow">ellipsize-end</property>

--- a/resources/ui/tu_overview_item.ui
+++ b/resources/ui/tu_overview_item.ui
@@ -14,30 +14,35 @@
             <property name="spacing">8</property>
             <property name="valign">fill</property>
             <child>
-              <object class="GtkOverlay" id="overlay">
+              <object class="HoverScale" id="hover_scale">
                 <property name="valign">fill</property>
-                <property name="width-request">250</property>
-                <property name="height-request">141</property>
-                <property name="halign">center</property>
-                <child type="overlay">
-                  <object class="GtkBox" id="overlay_button_box">
-                    <property name="orientation">horizontal</property>
-                    <property name="spacing">12</property>
-                    <property name="halign">end</property>
-                    <property name="valign">start</property>
-                    <property name="margin-end">8</property>
-                    <property name="margin-top">8</property>
-                  </object>
-                </child>
-                <child type="overlay">
-                  <object class="GtkProgressBar" id="progress_bar">
-                    <property name="visible">false</property>
-                    <property name="valign">end</property>
-                    <property name="margin-start">3</property>
-                    <property name="margin-end">3</property>
-                    <style>
-                      <class name="accent" />
-                    </style>
+                <child>
+                  <object class="GtkOverlay" id="overlay">
+                    <property name="valign">fill</property>
+                    <property name="width-request">250</property>
+                    <property name="height-request">141</property>
+                    <property name="halign">center</property>
+                    <child type="overlay">
+                      <object class="GtkBox" id="overlay_button_box">
+                        <property name="orientation">horizontal</property>
+                        <property name="spacing">12</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin-end">8</property>
+                        <property name="margin-top">8</property>
+                      </object>
+                    </child>
+                    <child type="overlay">
+                      <object class="GtkProgressBar" id="progress_bar">
+                        <property name="visible">false</property>
+                        <property name="valign">end</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
+                        <style>
+                          <class name="accent" />
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/resources/ui/tu_overview_item.ui
+++ b/resources/ui/tu_overview_item.ui
@@ -14,10 +14,14 @@
             <property name="spacing">8</property>
             <property name="valign">fill</property>
             <child>
-              <object class="HoverScale" id="hover_scale">
-                <property name="valign">fill</property>
-                <child>
-	                  <object class="GtkOverlay" id="overlay">
+	              <object class="HoverScale" id="hover_scale">
+	                <property name="valign">fill</property>
+	                <property name="margin-start">20</property>
+					<property name="margin-end">8</property>
+	                <property name="margin-top">12</property>
+					<property name="margin-bottom">8</property>
+	                <child>
+		                  <object class="GtkOverlay" id="overlay">
 	                    <property name="valign">fill</property>
 	                    <property name="width-request">250</property>
 	                    <property name="height-request">141</property>

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -33,7 +33,7 @@ impl Settings {
     const KEY_LIST_SORT_ORDER: &'static str = "list-sort-order";
     const KEY_ACCENT_COLOR_CODE: &'static str = "accent-color-code";
     const KEY_USE_CUSTOM_ACCENT_COLOR: &'static str = "use-custom-accent-color";
-    const KEY_ALWAYS_SHOW_ITEM_TITLE: &'static str = "always-show-item-title";
+    const KEY_FULL_ITEM_DISPLAY_MODE: &'static str = "full-item-display-mode";
     const KEY_MUSIC_REPEAT_MODE: &'static str = "music-repeat-mode";
     const KEY_MPV_SEEK_FORWARD_STEP: &'static str = "mpv-seek-forward-step";
     const KEY_MPV_SEEK_BACKWARD_STEP: &'static str = "mpv-seek-backward-step";
@@ -120,8 +120,8 @@ impl Settings {
         self.boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP)
     }
 
-    pub fn always_show_item_title(&self) -> bool {
-        self.boolean(Self::KEY_ALWAYS_SHOW_ITEM_TITLE)
+    pub fn full_item_display_mode(&self) -> bool {
+        self.boolean(Self::KEY_FULL_ITEM_DISPLAY_MODE)
     }
 
     pub fn mpv_config_dir(&self) -> String {

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -33,7 +33,8 @@ impl Settings {
     const KEY_LIST_SORT_ORDER: &'static str = "list-sort-order";
     const KEY_ACCENT_COLOR_CODE: &'static str = "accent-color-code";
     const KEY_USE_CUSTOM_ACCENT_COLOR: &'static str = "use-custom-accent-color";
-    const KEY_FULL_ITEM_DISPLAY_MODE: &'static str = "full-item-display-mode";
+    const KEY_ITEM_TEXT_DISPLAY: &'static str = "item-text-display";
+    const KEY_ITEM_CARD_STYLE: &'static str = "item-card-style";
     const KEY_MUSIC_REPEAT_MODE: &'static str = "music-repeat-mode";
     const KEY_MPV_SEEK_FORWARD_STEP: &'static str = "mpv-seek-forward-step";
     const KEY_MPV_SEEK_BACKWARD_STEP: &'static str = "mpv-seek-backward-step";
@@ -120,8 +121,32 @@ impl Settings {
         self.boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP)
     }
 
-    pub fn full_item_display_mode(&self) -> bool {
-        self.boolean(Self::KEY_FULL_ITEM_DISPLAY_MODE)
+    pub fn item_text_display(&self) -> String {
+        match self.string(Self::KEY_ITEM_TEXT_DISPLAY).as_str() {
+            "full" => "full",
+            _ => "compact",
+        }
+        .to_string()
+    }
+
+    pub fn set_item_text_display(&self, item_text_display: &str) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_ITEM_TEXT_DISPLAY, item_text_display)
+    }
+
+    pub fn item_card_style(&self) -> String {
+        match self.string(Self::KEY_ITEM_CARD_STYLE).as_str() {
+            "separated" => "separated",
+            _ => "integrated",
+        }
+        .to_string()
+    }
+
+    pub fn set_item_card_style(&self, item_card_style: &str) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_ITEM_CARD_STYLE, item_card_style)
+    }
+
+    pub fn item_card_style_is_integrated(&self) -> bool {
+        self.item_card_style() == "integrated"
     }
 
     pub fn mpv_config_dir(&self) -> String {

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -33,6 +33,7 @@ impl Settings {
     const KEY_LIST_SORT_ORDER: &'static str = "list-sort-order";
     const KEY_ACCENT_COLOR_CODE: &'static str = "accent-color-code";
     const KEY_USE_CUSTOM_ACCENT_COLOR: &'static str = "use-custom-accent-color";
+    const KEY_ALWAYS_SHOW_ITEM_TITLE: &'static str = "always-show-item-title";
     const KEY_MUSIC_REPEAT_MODE: &'static str = "music-repeat-mode";
     const KEY_MPV_SEEK_FORWARD_STEP: &'static str = "mpv-seek-forward-step";
     const KEY_MPV_SEEK_BACKWARD_STEP: &'static str = "mpv-seek-backward-step";
@@ -117,6 +118,10 @@ impl Settings {
 
     pub fn merge_resume_and_next_up(&self) -> bool {
         self.boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP)
+    }
+
+    pub fn always_show_item_title(&self) -> bool {
+        self.boolean(Self::KEY_ALWAYS_SHOW_ITEM_TITLE)
     }
 
     pub fn mpv_config_dir(&self) -> String {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -56,6 +56,7 @@ use crate::{
     },
     ui::{
         GlobalToast,
+        SETTINGS,
         provider::{
             core_song::CoreSong,
             tu_item::item_type::{
@@ -746,20 +747,34 @@ impl TuItem {
             return None;
         }
 
-        let title = match self.item_type().as_str() {
-            TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER => name,
-            EPISODE if self.series_name().is_some() && self.prefer_size() != PreferSize::Post => {
-                self.fmt_subtitle()
-            }
-            MOVIE if self.is_resume() => self.fmt_title(),
-            PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR => {
-                if let Some(role) = self.role() {
+        let title = if SETTINGS.always_show_item_title() {
+            match self.item_type().as_str() {
+                EPISODE => self.fmt_subtitle(),
+                PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR
+                    if let Some(role) = self.role() =>
+                {
                     format!("{name} / {role}")
-                } else {
-                    name
                 }
+                _ => name,
             }
-            _ => return None,
+        } else {
+            match self.item_type().as_str() {
+                TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER => name,
+                EPISODE
+                    if self.series_name().is_some() && self.prefer_size() != PreferSize::Post =>
+                {
+                    self.fmt_subtitle()
+                }
+                MOVIE if self.is_resume() => self.fmt_title(),
+                PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR => {
+                    if let Some(role) = self.role() {
+                        format!("{name} / {role}")
+                    } else {
+                        name
+                    }
+                }
+                _ => return None,
+            }
         };
 
         Some(title)

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -734,7 +734,7 @@ impl TuItem {
         }
     }
 
-    pub fn list_item_text(&self) -> Option<(String, Option<String>)> {
+    pub fn list_item_title(&self) -> Option<String> {
         let name = self.name();
 
         if name.is_empty() {
@@ -742,11 +742,10 @@ impl TuItem {
         }
 
         if SETTINGS.item_text_display() == "full" {
-            let subtitle = self.fmt_subtitle();
-            return Some((self.fmt_title(), (!subtitle.is_empty()).then_some(subtitle)));
+            return Some(self.fmt_title());
         }
 
-        let title = match self.item_type().as_str() {
+        Some(match self.item_type().as_str() {
             TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER => name,
             EPISODE if self.series_name().is_some() && self.is_resume() => self.fmt_subtitle(),
             MOVIE if self.is_resume() => self.fmt_title(),
@@ -758,9 +757,16 @@ impl TuItem {
                 }
             }
             _ => return None,
-        };
+        })
+    }
 
-        Some((title, None))
+    pub fn list_item_subtitle(&self) -> Option<String> {
+        if self.name().is_empty() || SETTINGS.item_text_display() != "full" {
+            return None;
+        }
+
+        let subtitle = self.fmt_subtitle();
+        (!subtitle.is_empty()).then_some(subtitle)
     }
 
     pub fn fmt_rating(&self) -> Option<String> {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -746,16 +746,10 @@ impl TuItem {
         }
 
         Some(match self.item_type().as_str() {
-            TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER => name,
+            TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER | PERSON
+            | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR => name,
             EPISODE if self.series_name().is_some() && self.is_resume() => self.fmt_subtitle(),
             MOVIE if self.is_resume() => self.fmt_title(),
-            PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR => {
-                if let Some(role) = self.role() {
-                    format!("{name} / {role}")
-                } else {
-                    name
-                }
-            }
             _ => return None,
         })
     }

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -663,16 +663,10 @@ impl TuItem {
     }
 
     pub fn fmt_title(&self) -> String {
-        let title = match self.item_type().as_str() {
+        match self.item_type().as_str() {
             TV_CHANNEL => self.fmt_tv_name(),
             EPISODE if let Some(series_name) = self.series_name() => series_name,
             _ => self.name(),
-        };
-
-        if self.has_unplayed_item() && self.unplayed_item_count() > 0 {
-            format!("{} ({})", title, self.unplayed_item_count())
-        } else {
-            title
         }
     }
 

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -760,11 +760,7 @@ impl TuItem {
         } else {
             match self.item_type().as_str() {
                 TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER => name,
-                EPISODE
-                    if self.series_name().is_some() && self.prefer_size() != PreferSize::Post =>
-                {
-                    self.fmt_subtitle()
-                }
+                EPISODE if self.series_name().is_some() && self.is_resume() => self.fmt_subtitle(),
                 MOVIE if self.is_resume() => self.fmt_title(),
                 PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR => {
                     if let Some(role) = self.role() {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -747,7 +747,7 @@ impl TuItem {
             return None;
         }
 
-        let title = if SETTINGS.always_show_item_title() {
+        let title = if SETTINGS.full_item_display_mode() {
             match self.item_type().as_str() {
                 EPISODE => self.fmt_subtitle(),
                 PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -740,40 +740,33 @@ impl TuItem {
         }
     }
 
-    pub fn list_item_title(&self) -> Option<String> {
+    pub fn list_item_text(&self) -> Option<(String, Option<String>)> {
         let name = self.name();
 
         if name.is_empty() {
             return None;
         }
 
-        let title = if SETTINGS.full_item_display_mode() {
-            match self.item_type().as_str() {
-                EPISODE => self.fmt_subtitle(),
-                PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR
-                    if let Some(role) = self.role() =>
-                {
+        if SETTINGS.full_item_display_mode() {
+            let subtitle = self.fmt_subtitle();
+            return Some((self.fmt_title(), (!subtitle.is_empty()).then_some(subtitle)));
+        }
+
+        let title = match self.item_type().as_str() {
+            TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER => name,
+            EPISODE if self.series_name().is_some() && self.is_resume() => self.fmt_subtitle(),
+            MOVIE if self.is_resume() => self.fmt_title(),
+            PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR => {
+                if let Some(role) = self.role() {
                     format!("{name} / {role}")
+                } else {
+                    name
                 }
-                _ => name,
             }
-        } else {
-            match self.item_type().as_str() {
-                TV_CHANNEL | SEASON | BOX_SET | MUSIC_ALBUM | GENRE | TAG | FOLDER => name,
-                EPISODE if self.series_name().is_some() && self.is_resume() => self.fmt_subtitle(),
-                MOVIE if self.is_resume() => self.fmt_title(),
-                PERSON | DIRECTOR | WRITER | PRODUCER | GUEST_STAR | ACTOR => {
-                    if let Some(role) = self.role() {
-                        format!("{name} / {role}")
-                    } else {
-                        name
-                    }
-                }
-                _ => return None,
-            }
+            _ => return None,
         };
 
-        Some(title)
+        Some((title, None))
     }
 
     pub fn fmt_rating(&self) -> Option<String> {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -747,7 +747,7 @@ impl TuItem {
             return None;
         }
 
-        if SETTINGS.full_item_display_mode() {
+        if SETTINGS.item_text_display() == "full" {
             let subtitle = self.fmt_subtitle();
             return Some((self.fmt_title(), (!subtitle.is_empty()).then_some(subtitle)));
         }

--- a/src/ui/provider/tu_object.rs
+++ b/src/ui/provider/tu_object.rs
@@ -11,6 +11,7 @@ use crate::{
     client::structs::SimpleListItem,
     ui::widgets::{
         lazy_diff_view::OnSameKey,
+        tu_item::TuItemProgressbarAnimation,
         tu_list_item::TuListItem,
     },
 };
@@ -51,7 +52,7 @@ impl OnSameKey for TuObject {
             return;
         };
         if let Some(played_percentage) = self.item().fmt_percentage() {
-            list_item.set_progress(played_percentage / 100.);
+            list_item.set_progress(played_percentage);
         }
         list_item
             .item()

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -73,6 +73,8 @@ mod imp {
         #[template_child]
         pub selectlastcontrol: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub always_show_item_title_control: TemplateChild<adw::SwitchRow>,
+        #[template_child]
         pub custom_accent_color_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub backgroundblurspinrow: TemplateChild<adw::SpinRow>,
@@ -388,6 +390,13 @@ impl AccountSettings {
             .bind(
                 "use-custom-accent-color",
                 &imp.custom_accent_color_control.get(),
+                "active",
+            )
+            .build();
+        SETTINGS
+            .bind(
+                "always-show-item-title",
+                &imp.always_show_item_title_control.get(),
                 "active",
             )
             .build();

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -73,7 +73,7 @@ mod imp {
         #[template_child]
         pub selectlastcontrol: TemplateChild<adw::SwitchRow>,
         #[template_child]
-        pub always_show_item_title_control: TemplateChild<adw::SwitchRow>,
+        pub full_item_display_mode_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub custom_accent_color_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
@@ -395,8 +395,8 @@ impl AccountSettings {
             .build();
         SETTINGS
             .bind(
-                "always-show-item-title",
-                &imp.always_show_item_title_control.get(),
+                "full-item-display-mode",
+                &imp.full_item_display_mode_control.get(),
                 "active",
             )
             .build();

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -73,7 +73,9 @@ mod imp {
         #[template_child]
         pub selectlastcontrol: TemplateChild<adw::SwitchRow>,
         #[template_child]
-        pub full_item_display_mode_control: TemplateChild<adw::SwitchRow>,
+        pub text_display_group: TemplateChild<adw::ToggleGroup>,
+        #[template_child]
+        pub card_style_group: TemplateChild<adw::ToggleGroup>,
         #[template_child]
         pub custom_accent_color_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
@@ -393,13 +395,20 @@ impl AccountSettings {
                 "active",
             )
             .build();
-        SETTINGS
-            .bind(
-                "full-item-display-mode",
-                &imp.full_item_display_mode_control.get(),
-                "active",
-            )
-            .build();
+        imp.text_display_group
+            .set_active_name(Some(SETTINGS.item_text_display().as_str()));
+        imp.card_style_group
+            .set_active_name(Some(SETTINGS.item_card_style().as_str()));
+        imp.text_display_group.connect_active_name_notify(|group| {
+            if let Some(active_name) = group.active_name() {
+                SETTINGS.set_item_text_display(&active_name).unwrap();
+            }
+        });
+        imp.card_style_group.connect_active_name_notify(|group| {
+            if let Some(active_name) = group.active_name() {
+                SETTINGS.set_item_card_style(&active_name).unwrap();
+            }
+        });
         SETTINGS
             .bind("use-custom-accent-color", &imp.color.get(), "sensitive")
             .build();

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -263,7 +263,7 @@ impl AccountSettings {
             move |control| {
                 let window = obj.window();
                 window.overlay_sidebar(control.is_active());
-                SETTINGS.set_overlay(control.is_active()).unwrap();
+                let _ = SETTINGS.set_overlay(control.is_active());
             }
         ));
     }
@@ -274,9 +274,7 @@ impl AccountSettings {
         imp.color
             .set_rgba(&RGBA::from_str(&SETTINGS.accent_color_code()).unwrap());
         imp.color.connect_rgba_notify(move |control| {
-            SETTINGS
-                .set_accent_color_code(&control.rgba().to_string())
-                .unwrap();
+            let _ = SETTINGS.set_accent_color_code(&control.rgba().to_string());
         });
     }
 
@@ -303,7 +301,7 @@ impl AccountSettings {
         match filedialog.open_future(Some(&window)).await {
             Ok(file) => {
                 let file_path = file.path().unwrap().display().to_string();
-                SETTINGS.set_root_pic(&file_path).unwrap();
+                let _ = SETTINGS.set_root_pic(&file_path);
                 window.set_rootpic(file);
             }
             Err(_) => self.toast(gettext("No file selected")),
@@ -318,7 +316,7 @@ impl AccountSettings {
             #[weak(rename_to = obj)]
             self,
             move |control| {
-                SETTINGS.set_pic_opacity(control.value() as i32).unwrap();
+                let _ = SETTINGS.set_pic_opacity(control.value() as i32);
                 let window = obj.window();
                 window.set_picopacity(control.value() as i32);
             }
@@ -333,9 +331,7 @@ impl AccountSettings {
             #[weak(rename_to = obj)]
             self,
             move |control| {
-                SETTINGS
-                    .set_background_enabled(control.is_active())
-                    .unwrap();
+                let _ = SETTINGS.set_background_enabled(control.is_active());
                 if !control.is_active() {
                     let window = obj.window();
                     window.clear_pic();
@@ -353,7 +349,7 @@ impl AccountSettings {
                 window.clear_pic();
             }
         ));
-        SETTINGS.set_root_pic("").unwrap();
+        let _ = SETTINGS.set_root_pic("");
     }
 
     pub fn bind_settings(&self) {
@@ -401,12 +397,12 @@ impl AccountSettings {
             .set_active_name(Some(SETTINGS.item_card_style().as_str()));
         imp.text_display_group.connect_active_name_notify(|group| {
             if let Some(active_name) = group.active_name() {
-                SETTINGS.set_item_text_display(&active_name).unwrap();
+                let _ = SETTINGS.set_item_text_display(&active_name);
             }
         });
         imp.card_style_group.connect_active_name_notify(|group| {
             if let Some(active_name) = group.active_name() {
-                SETTINGS.set_item_card_style(&active_name).unwrap();
+                let _ = SETTINGS.set_item_card_style(&active_name);
             }
         });
         SETTINGS
@@ -440,7 +436,7 @@ impl AccountSettings {
                     .get::<i32>()
                     .expect("The variant needs to be of type `i32`.");
 
-                SETTINGS.set_mpv_video_output(parameter).unwrap();
+                let _ = SETTINGS.set_mpv_video_output(parameter);
 
                 action.set_state(&parameter.to_variant());
             })
@@ -499,9 +495,7 @@ impl AccountSettings {
         &self, _param: glib::ParamSpec, button: gtk::FontDialogButton,
     ) {
         let font_desc = button.font_desc().unwrap();
-        SETTINGS
-            .set_mpv_subtitle_font(gtk::pango::FontDescription::to_string(&font_desc))
-            .unwrap();
+        let _ = SETTINGS.set_mpv_subtitle_font(gtk::pango::FontDescription::to_string(&font_desc));
     }
 
     #[template_callback]
@@ -768,9 +762,7 @@ impl AccountSettings {
                         .unwrap();
                     descriptors.remove(lr_index);
                     descriptors.insert(index, lr_descriptor.to_owned());
-                    SETTINGS
-                        .set_preferred_version_descriptors(descriptors)
-                        .expect("Failed to set descriptors");
+                    let _ = SETTINGS.set_preferred_version_descriptors(descriptors);
                     obj.refersh_descriptors();
 
                     true

--- a/src/ui/widgets/hover_scale.rs
+++ b/src/ui/widgets/hover_scale.rs
@@ -31,8 +31,11 @@ mod imp {
 
     type UnderlaySnapshotCallback = Box<dyn Fn(&gtk::Snapshot) + 'static>;
 
-    #[derive(Default)]
+    #[derive(Default, glib::Properties)]
+    #[properties(wrapper_type = super::HoverScale)]
     pub struct HoverScale {
+        #[property(get, set, construct, default = MAX_SCALE)]
+        pub max_scale: Cell<f32>,
         pub animation: OnceCell<adw::TimedAnimation>,
         /// Optional closure rendered inside the scale transform, before the child.
         pub underlay: RefCell<Option<UnderlaySnapshotCallback>>,
@@ -48,6 +51,7 @@ mod imp {
         type ParentType = adw::Bin;
     }
 
+    #[glib::derived_properties]
     impl ObjectImpl for HoverScale {
         fn constructed(&self) {
             self.parent_constructed();
@@ -152,7 +156,7 @@ mod imp {
                 return;
             }
 
-            let scale = 1.0 + (super::MAX_SCALE - 1.0) * progress;
+            let scale = 1.0 + (self.max_scale.get() - 1.0) * progress;
             let nx = self.cursor_nx.get();
             let ny = self.cursor_ny.get();
 

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -1,4 +1,3 @@
-use adw::prelude::BinExt;
 use gtk::prelude::*;
 
 use crate::ui::{
@@ -7,7 +6,6 @@ use crate::ui::{
         TuItem,
     },
     widgets::{
-        hover_scale::HoverScale,
         picture_loader::PictureLoader,
         tu_list_item::imp::PosterType,
     },
@@ -83,8 +81,6 @@ pub trait TuItemOverlayPrelude {
 pub trait TuItemOverlay: TuItemBasic + TuItemOverlayPrelude {
     fn set_picture(&self);
 
-    fn set_picture_with_hover_scale(&self);
-
     fn set_animated_picture(&self);
 }
 
@@ -105,24 +101,6 @@ where
         let picture_loader = PictureLoader::new(&id, image_type, tag);
         picture_loader.add_css_class("inbox");
         overlay.set_child(Some(&picture_loader));
-    }
-
-    fn set_picture_with_hover_scale(&self) {
-        let item = self.item();
-        let (image_type, tag, id) = self.get_image_type_and_tag(&item);
-        let overlay = self.overlay();
-
-        if let Some(hover_scale) = overlay.child().and_downcast::<HoverScale>()
-            && let Some(picture_loader) = hover_scale.child().and_downcast::<PictureLoader>()
-        {
-            picture_loader.reload(&id, image_type, tag, false);
-            return;
-        }
-
-        let picture_loader = PictureLoader::new(&id, image_type, tag);
-        let hover_scale = HoverScale::new();
-        hover_scale.set_child(Some(&picture_loader));
-        overlay.set_child(Some(&hover_scale));
     }
 
     fn set_animated_picture(&self) {

--- a/src/ui/widgets/tu_item/progressbar_animation.rs
+++ b/src/ui/widgets/tu_item/progressbar_animation.rs
@@ -1,4 +1,8 @@
-use crate::utils::spawn;
+use std::{
+    cell::RefCell,
+    rc::Rc,
+};
+
 use adw::prelude::*;
 use gtk::glib;
 
@@ -10,6 +14,7 @@ pub trait TuItemProgressbarAnimationPrelude {
 
 pub trait TuItemProgressbarAnimation {
     fn set_progress(&self, progress: f64);
+    fn clear_progress(&self);
 }
 
 impl<T> TuItemProgressbarAnimation for T
@@ -18,30 +23,58 @@ where
 {
     fn set_progress(&self, percentage: f64) {
         let bar = self.progress_bar();
+        if percentage <= 0.0 {
+            self.clear_progress();
+            return;
+        }
         bar.set_visible(true);
 
-        spawn(glib::clone!(
-            #[weak]
-            bar,
-            async move {
-                let target = adw::CallbackAnimationTarget::new(glib::clone!(
-                    #[weak]
-                    bar,
-                    move |v| bar.set_fraction(v)
-                ));
-
-                let animation = adw::TimedAnimation::builder()
-                    .duration(PROGRESSBAR_ANIMATION_DURATION)
-                    .widget(&bar)
-                    .target(&target)
-                    .easing(adw::Easing::EaseOutQuart)
-                    .value_from(0.)
-                    .value_to(percentage / 100.0)
-                    .build();
-
-                glib::timeout_future_seconds(1).await;
-                animation.play();
-            }
-        ));
+        // If the progress bar is already mapped, we can play the animation immediately. Otherwise, we need to wait until it is mapped.
+        // This is useful when the progress bar is not yet visible, for example when the app is first launched.
+        if bar.is_mapped() {
+            play_progress_animation(&bar, percentage);
+        } else {
+            bar.set_fraction(0.);
+            play_progress_when_mapped(&bar, percentage);
+        }
     }
+
+    fn clear_progress(&self) {
+        let bar = self.progress_bar();
+        bar.set_fraction(0.);
+        bar.set_visible(false);
+    }
+}
+
+fn play_progress_when_mapped(bar: &gtk::ProgressBar, percentage: f64) {
+    let handler_id = Rc::new(RefCell::new(None));
+    let handler_id_clone = handler_id.clone();
+
+    let id = bar.connect_map(move |bar| {
+        if let Some(id) = handler_id_clone.borrow_mut().take() {
+            bar.disconnect(id);
+        }
+        play_progress_animation(bar, percentage);
+    });
+
+    *handler_id.borrow_mut() = Some(id);
+}
+
+fn play_progress_animation(bar: &gtk::ProgressBar, percentage: f64) {
+    let target = adw::CallbackAnimationTarget::new(glib::clone!(
+        #[weak]
+        bar,
+        move |v| bar.set_fraction(v)
+    ));
+
+    let animation = adw::TimedAnimation::builder()
+        .duration(PROGRESSBAR_ANIMATION_DURATION)
+        .widget(bar)
+        .target(&target)
+        .easing(adw::Easing::EaseOutQuart)
+        .value_from(bar.fraction())
+        .value_to(percentage / 100.0)
+        .build();
+
+    animation.play();
 }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -19,7 +19,6 @@ use super::tu_item::{
     TuItemProgressbarAnimationPrelude,
 };
 use crate::ui::{
-    SETTINGS,
     provider::tu_item::TuItem,
     widgets::utils::{
         TU_ITEM_BANNER_SIZE,
@@ -210,18 +209,6 @@ impl TuListItem {
 
     fn update_title(&self) {
         let imp = self.imp();
-        let full_display_mode = SETTINGS.full_item_display_mode();
-        let lines = if full_display_mode { 1 } else { -1 };
-        let ellipsize = if full_display_mode {
-            gtk::pango::EllipsizeMode::End
-        } else {
-            gtk::pango::EllipsizeMode::None
-        };
-        imp.title.set_lines(lines);
-        imp.title.set_ellipsize(ellipsize);
-        imp.subtitle.set_lines(lines);
-        imp.subtitle.set_ellipsize(ellipsize);
-
         if let Some((title, subtitle)) = self.item().list_item_text() {
             imp.title.set_text(&title);
             if let Some(subtitle) = subtitle {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -409,10 +409,11 @@ impl TuListItem {
 
     fn update_title(&self) {
         let imp = self.imp();
-        if let Some((title, subtitle)) = self.item().list_item_text() {
+        let item = self.item();
+        if let Some(title) = item.list_item_title() {
             imp.title.set_text(&title);
             imp.title.set_visible(true);
-            if let Some(subtitle) = subtitle {
+            if let Some(subtitle) = item.list_item_subtitle() {
                 imp.subtitle.set_text(&subtitle);
                 imp.subtitle.set_visible(true);
             } else {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -11,11 +11,12 @@ use gtk::{
 use imp::PosterType;
 
 use super::tu_item::{
-    PROGRESSBAR_ANIMATION_DURATION,
     TuItemBasic,
     TuItemMenuPrelude,
     TuItemOverlay,
     TuItemOverlayPrelude,
+    TuItemProgressbarAnimation,
+    TuItemProgressbarAnimationPrelude,
 };
 use crate::ui::{
     provider::tu_item::TuItem,
@@ -39,14 +40,10 @@ pub mod imp {
     use gtk::{
         CompositeTemplate,
         PopoverMenu,
-        gdk,
         glib,
-        graphene,
-        gsk,
     };
 
     use crate::ui::{
-        SETTINGS,
         provider::tu_item::TuItem,
         widgets::{
             hover_scale::HoverScale,
@@ -66,15 +63,6 @@ pub mod imp {
         NoRequest,
     }
 
-    pub struct BackdropNodeCache {
-        node: gsk::RenderNode,
-        backdrop_y: f32,
-        backdrop_h: f32,
-        widget_w: f32,
-        /// Validity key: (width_px, height_px, is_dark, paintable_ptr)
-        key: (i32, i32, bool, usize),
-    }
-
     // Object holding the state
     #[derive(CompositeTemplate, Default, glib::Properties)]
     #[template(resource = "/moe/tsuna/tsukimi/ui/listitem.ui")]
@@ -89,8 +77,8 @@ pub mod imp {
         pub title: TemplateChild<gtk::Label>,
         #[template_child]
         pub overlay: TemplateChild<gtk::Overlay>,
-        #[property(get, set = Self::set_progress)]
-        pub progress: Cell<f64>,
+        #[template_child]
+        pub progress_bar: TemplateChild<gtk::ProgressBar>,
         #[template_child]
         pub played_mark: TemplateChild<gtk::Button>,
         #[template_child]
@@ -100,10 +88,6 @@ pub mod imp {
 
         #[template_child]
         pub hover_scale: TemplateChild<HoverScale>,
-
-        pub progress_inside: Cell<f64>,
-        pub backdrop_cache: RefCell<Option<BackdropNodeCache>>,
-        pub is_dark: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -128,58 +112,8 @@ pub mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
-            let style_manager = adw::StyleManager::default();
-            self.is_dark.set(style_manager.is_dark());
             let obj = self.obj();
 
-            style_manager.connect_dark_notify(glib::clone!(
-                #[weak]
-                obj,
-                move |sm| {
-                    obj.imp().is_dark.set(sm.is_dark());
-                    obj.queue_draw();
-                }
-            ));
-
-            style_manager.connect_accent_color_rgba_notify(glib::clone!(
-                #[weak]
-                obj,
-                move |_| {
-                    obj.queue_draw();
-                }
-            ));
-
-            SETTINGS.connect_changed(
-                Some("use-custom-accent-color"),
-                glib::clone!(
-                    #[weak]
-                    obj,
-                    move |_, _| {
-                        obj.queue_draw();
-                    }
-                ),
-            );
-
-            SETTINGS.connect_changed(
-                Some("accent-color-code"),
-                glib::clone!(
-                    #[weak]
-                    obj,
-                    move |_, _| {
-                        obj.queue_draw();
-                    }
-                ),
-            );
-
-            self.hover_scale.set_underlay(glib::clone!(
-                #[weak]
-                obj,
-                move |snapshot| {
-                    obj.imp().draw_backdrop_and_progress(snapshot);
-                }
-            ));
-
-            let obj = self.obj();
             obj.add_controller(obj.gesture_click());
             obj.set_has_tooltip(true);
             obj.connect_query_tooltip(|obj, _, _, _, tooltip| {
@@ -201,171 +135,6 @@ pub mod imp {
 
     impl WidgetImpl for TuListItem {}
 
-    impl TuListItem {
-        fn draw_backdrop_and_progress(&self, snapshot: &gtk::Snapshot) {
-            if !self.title.is_visible() {
-                return;
-            }
-
-            let Some((paintable, pic_bounds)) = self.compute_blur_info() else {
-                return;
-            };
-
-            let obj = self.obj();
-            // Use picture width for the cache key so it can be reused across
-            // minor widget resizes that don't change the picture dimensions.
-            let w = pic_bounds.width() as i32;
-            let h = obj.height();
-
-            let key = (w, h, self.is_dark.get(), paintable.as_ptr() as usize);
-            let stale = self
-                .backdrop_cache
-                .borrow()
-                .as_ref()
-                .is_none_or(|c| c.key != key);
-            if stale {
-                *self.backdrop_cache.borrow_mut() =
-                    self.build_backdrop_node(&paintable, &pic_bounds, w as f32, h as f32);
-            }
-
-            let cache_ref = self.backdrop_cache.borrow();
-            if let Some(cache) = cache_ref.as_ref() {
-                let progress = self.progress_inside.get() as f32;
-                let alpha = if self.is_dark.get() { 0.2 } else { 0.4 };
-                snapshot.append_node(&cache.node);
-                if let Some(base) = self.progress_fill_color() {
-                    Self::draw_progress_fill(snapshot, cache, progress, alpha, base);
-                }
-            }
-        }
-
-        fn progress_fill_color(&self) -> Option<gdk::RGBA> {
-            if SETTINGS.use_custom_accent_color() {
-                gdk::RGBA::parse(SETTINGS.accent_color_code()).ok()
-            } else {
-                Some(adw::StyleManager::default().accent_color_rgba())
-            }
-        }
-
-        fn compute_blur_info(&self) -> Option<(gdk::Paintable, graphene::Rect)> {
-            let obj = self.obj();
-
-            let picture_loader = self.overlay.child()?.downcast::<PictureLoader>().ok()?;
-
-            let paintable = picture_loader.imp().picture.paintable()?;
-
-            let pic_bounds = picture_loader.compute_bounds(&*obj)?;
-
-            Some((paintable, pic_bounds))
-        }
-
-        fn build_backdrop_node(
-            &self, paintable: &gdk::Paintable, pic_bounds: &graphene::Rect, widget_w: f32,
-            widget_h: f32,
-        ) -> Option<BackdropNodeCache> {
-            const CORNER_RADIUS: f32 = 10.0;
-            const BLUR_RADIUS: f64 = 20.0;
-
-            let pic_bottom = pic_bounds.y() + pic_bounds.height();
-            let backdrop_y = pic_bottom - CORNER_RADIUS;
-            let backdrop_h = widget_h - backdrop_y;
-
-            if backdrop_h <= 0.0 {
-                return None;
-            }
-
-            let backdrop_rect = graphene::Rect::new(0.0, backdrop_y, widget_w, backdrop_h);
-            let rounded = gsk::RoundedRect::new(
-                backdrop_rect,
-                graphene::Size::new(0.0, 0.0),
-                graphene::Size::new(0.0, 0.0),
-                graphene::Size::new(CORNER_RADIUS, CORNER_RADIUS),
-                graphene::Size::new(CORNER_RADIUS, CORNER_RADIUS),
-            );
-
-            let sub = gtk::Snapshot::new();
-            sub.push_rounded_clip(&rounded);
-            sub.push_blur(BLUR_RADIUS);
-
-            let pic_w = pic_bounds.width();
-            let pic_h = pic_bounds.height();
-            let scale = if pic_w > 0.0 { widget_w / pic_w } else { 1.0 };
-            let draw_y = widget_h - pic_h * scale;
-
-            sub.save();
-            sub.translate(&graphene::Point::new(0.0, draw_y));
-            sub.scale(scale, scale);
-            paintable.snapshot(
-                sub.upcast_ref::<gdk::Snapshot>(),
-                pic_w as f64,
-                pic_h as f64,
-            );
-            sub.restore();
-            sub.pop(); // blur
-
-            let stops = if self.is_dark.get() {
-                [
-                    gsk::ColorStop::new(0.0, gdk::RGBA::new(0.0, 0.0, 0.0, 0.35)),
-                    gsk::ColorStop::new(1.0, gdk::RGBA::new(0.0, 0.0, 0.0, 0.45)),
-                ]
-            } else {
-                [
-                    gsk::ColorStop::new(0.0, gdk::RGBA::new(1.0, 1.0, 1.0, 0.15)),
-                    gsk::ColorStop::new(1.0, gdk::RGBA::new(1.0, 1.0, 1.0, 0.25)),
-                ]
-            };
-            sub.append_linear_gradient(
-                &backdrop_rect,
-                &graphene::Point::new(0.0, backdrop_y),
-                &graphene::Point::new(0.0, backdrop_y + backdrop_h),
-                &stops,
-            );
-            sub.pop(); // rounded clip
-
-            let node = sub.to_node()?;
-            let key = (
-                widget_w as i32,
-                widget_h as i32,
-                self.is_dark.get(),
-                paintable.as_ptr() as usize,
-            );
-            Some(BackdropNodeCache {
-                node,
-                backdrop_y,
-                backdrop_h,
-                widget_w,
-                key,
-            })
-        }
-
-        fn draw_progress_fill(
-            snapshot: &gtk::Snapshot, cache: &BackdropNodeCache, progress: f32, alpha: f32,
-            base: gdk::RGBA,
-        ) {
-            if progress <= 0.0 {
-                return;
-            }
-
-            const CR: f32 = 10.0;
-            let fill_w = (cache.widget_w * progress).min(cache.widget_w);
-            let fill_rect = graphene::Rect::new(0.0, cache.backdrop_y, fill_w, cache.backdrop_h);
-            let fill_clip = gsk::RoundedRect::new(
-                graphene::Rect::new(0.0, cache.backdrop_y, cache.widget_w, cache.backdrop_h),
-                graphene::Size::new(0.0, 0.0),
-                graphene::Size::new(0.0, 0.0),
-                graphene::Size::new(CR, CR),
-                graphene::Size::new(CR, CR),
-            );
-
-            snapshot.push_rounded_clip(&fill_clip);
-            snapshot.append_color(
-                &gdk::RGBA::new(base.red(), base.green(), base.blue(), alpha),
-                &fill_rect,
-            );
-            snapshot.pop();
-        }
-    }
-
     impl BinImpl for TuListItem {}
 
     impl TuListItem {
@@ -373,11 +142,6 @@ pub mod imp {
             let obj = self.obj();
             self.item.replace(item);
             obj.refresh_item();
-        }
-
-        pub fn set_progress(&self, progress: f64) {
-            self.progress.set(progress);
-            self.obj().set_progress_anim(progress);
         }
     }
 }
@@ -411,6 +175,12 @@ impl TuItemMenuPrelude for TuListItem {
     }
 }
 
+impl TuItemProgressbarAnimationPrelude for TuListItem {
+    fn progress_bar(&self) -> gtk::ProgressBar {
+        self.imp().progress_bar.get()
+    }
+}
+
 impl Default for TuListItem {
     fn default() -> Self {
         Self::new(TuItem::default())
@@ -421,30 +191,6 @@ impl Default for TuListItem {
 impl TuListItem {
     pub fn new(item: TuItem) -> Self {
         Object::builder().property("item", item).build()
-    }
-
-    fn set_progress_anim(&self, percentage: f64) {
-        let start_value = self.imp().progress_inside.get();
-
-        let target = adw::CallbackAnimationTarget::new(glib::clone!(
-            #[weak(rename_to = this)]
-            self,
-            move |p| {
-                this.imp().progress_inside.set(p);
-                this.queue_draw();
-            }
-        ));
-
-        let animation = adw::TimedAnimation::builder()
-            .duration(PROGRESSBAR_ANIMATION_DURATION)
-            .widget(self)
-            .target(&target)
-            .easing(adw::Easing::EaseOutQuart)
-            .value_from(start_value)
-            .value_to(percentage)
-            .build();
-
-        animation.play();
     }
 
     pub fn refresh_item(&self) {
@@ -462,9 +208,9 @@ impl TuListItem {
         imp.overlay.set_size_request(w, h);
 
         if let Some(p) = item.fmt_percentage() {
-            self.set_progress(p / 100.);
+            self.set_progress(p);
         } else {
-            self.set_progress(0.);
+            self.clear_progress();
         }
 
         imp.played_mark.set_visible(item.has_played_mark());

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -44,6 +44,7 @@ pub mod imp {
     };
 
     use crate::ui::{
+        SETTINGS,
         provider::tu_item::TuItem,
         widgets::{
             hover_scale::HoverScale,
@@ -124,6 +125,15 @@ pub mod imp {
                 tooltip.set_text(Some(&name));
                 true
             });
+
+            SETTINGS.connect_changed(
+                Some("always-show-item-title"),
+                glib::clone!(
+                    #[weak]
+                    obj,
+                    move |_, _| obj.update_title()
+                ),
+            );
         }
 
         fn dispose(&self) {
@@ -193,6 +203,16 @@ impl TuListItem {
         Object::builder().property("item", item).build()
     }
 
+    fn update_title(&self) {
+        let imp = self.imp();
+        if let Some(title) = self.item().list_item_title() {
+            imp.title.set_text(&title);
+            imp.title.set_visible(true);
+        } else {
+            imp.title.set_visible(false);
+        }
+    }
+
     pub fn refresh_item(&self) {
         let imp = self.imp();
         let item = self.item();
@@ -220,12 +240,7 @@ impl TuListItem {
         imp.direct_play_button
             .set_visible(item.has_direct_play_mark());
 
-        if let Some(title) = item.list_item_title() {
-            imp.title.set_text(&title);
-            imp.title.set_visible(true);
-        } else {
-            imp.title.set_visible(false);
-        }
+        self.update_title();
     }
 
     pub fn unbind_item(&self) {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -40,7 +40,10 @@ pub mod imp {
     use gtk::{
         CompositeTemplate,
         PopoverMenu,
+        gdk,
         glib,
+        graphene,
+        gsk,
     };
 
     use crate::ui::{
@@ -62,6 +65,12 @@ pub mod imp {
         #[default]
         Poster,
         NoRequest,
+    }
+
+    pub struct BackdropNodeCache {
+        node: gsk::RenderNode,
+        /// Validity key: (width_px, height_px, is_dark, paintable_ptr)
+        key: (i32, i32, bool, usize),
     }
 
     // Object holding the state
@@ -93,6 +102,9 @@ pub mod imp {
 
         #[template_child]
         pub hover_scale: TemplateChild<HoverScale>,
+
+        pub backdrop_cache: RefCell<Option<BackdropNodeCache>>,
+        pub is_dark: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -117,7 +129,26 @@ pub mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
+            let style_manager = adw::StyleManager::default();
+            self.is_dark.set(style_manager.is_dark());
             let obj = self.obj();
+
+            style_manager.connect_dark_notify(glib::clone!(
+                #[weak]
+                obj,
+                move |sm| {
+                    obj.imp().is_dark.set(sm.is_dark());
+                    obj.queue_draw();
+                }
+            ));
+
+            self.hover_scale.set_underlay(glib::clone!(
+                #[weak]
+                obj,
+                move |snapshot| {
+                    obj.imp().draw_backdrop(snapshot);
+                }
+            ));
 
             obj.add_controller(obj.gesture_click());
             obj.set_has_tooltip(true);
@@ -148,6 +179,119 @@ pub mod imp {
     }
 
     impl WidgetImpl for TuListItem {}
+
+    impl TuListItem {
+        fn draw_backdrop(&self, snapshot: &gtk::Snapshot) {
+            if !self.title_box.is_visible() {
+                return;
+            }
+
+            let Some((paintable, pic_bounds)) = self.compute_blur_info() else {
+                return;
+            };
+
+            let hover_scale = self.hover_scale.get();
+            let w = pic_bounds.width() as i32;
+            let h = hover_scale.height();
+            let key = (w, h, self.is_dark.get(), paintable.as_ptr() as usize);
+
+            let stale = self
+                .backdrop_cache
+                .borrow()
+                .as_ref()
+                .is_none_or(|c| c.key != key);
+            if stale {
+                *self.backdrop_cache.borrow_mut() =
+                    self.build_backdrop_node(&paintable, &pic_bounds, w as f32, h as f32);
+            }
+
+            if let Some(cache) = self.backdrop_cache.borrow().as_ref() {
+                snapshot.append_node(&cache.node);
+            }
+        }
+
+        fn compute_blur_info(&self) -> Option<(gdk::Paintable, graphene::Rect)> {
+            let hover_scale = self.hover_scale.get();
+            let picture_loader = self.overlay.child()?.downcast::<PictureLoader>().ok()?;
+            let paintable = picture_loader.imp().picture.paintable()?;
+            let pic_bounds = picture_loader.compute_bounds(&hover_scale)?;
+
+            Some((paintable, pic_bounds))
+        }
+
+        fn build_backdrop_node(
+            &self, paintable: &gdk::Paintable, pic_bounds: &graphene::Rect, widget_w: f32,
+            widget_h: f32,
+        ) -> Option<BackdropNodeCache> {
+            const CORNER_RADIUS: f32 = 10.0;
+            const BLUR_RADIUS: f64 = 20.0;
+
+            let pic_bottom = pic_bounds.y() + pic_bounds.height();
+            let backdrop_y = pic_bottom - CORNER_RADIUS;
+            let backdrop_h = widget_h - backdrop_y;
+
+            if backdrop_h <= 0.0 {
+                return None;
+            }
+
+            let backdrop_rect = graphene::Rect::new(0.0, backdrop_y, widget_w, backdrop_h);
+            let rounded = gsk::RoundedRect::new(
+                backdrop_rect,
+                graphene::Size::new(0.0, 0.0),
+                graphene::Size::new(0.0, 0.0),
+                graphene::Size::new(CORNER_RADIUS, CORNER_RADIUS),
+                graphene::Size::new(CORNER_RADIUS, CORNER_RADIUS),
+            );
+
+            let sub = gtk::Snapshot::new();
+            sub.push_rounded_clip(&rounded);
+            sub.push_blur(BLUR_RADIUS);
+
+            let pic_w = pic_bounds.width();
+            let pic_h = pic_bounds.height();
+            let scale = if pic_w > 0.0 { widget_w / pic_w } else { 1.0 };
+            let draw_y = widget_h - pic_h * scale;
+
+            sub.save();
+            sub.translate(&graphene::Point::new(0.0, draw_y));
+            sub.scale(scale, scale);
+            paintable.snapshot(
+                sub.upcast_ref::<gdk::Snapshot>(),
+                pic_w as f64,
+                pic_h as f64,
+            );
+            sub.restore();
+            sub.pop();
+
+            let stops = if self.is_dark.get() {
+                [
+                    gsk::ColorStop::new(0.0, gdk::RGBA::new(0.0, 0.0, 0.0, 0.35)),
+                    gsk::ColorStop::new(1.0, gdk::RGBA::new(0.0, 0.0, 0.0, 0.45)),
+                ]
+            } else {
+                [
+                    gsk::ColorStop::new(0.0, gdk::RGBA::new(1.0, 1.0, 1.0, 0.15)),
+                    gsk::ColorStop::new(1.0, gdk::RGBA::new(1.0, 1.0, 1.0, 0.25)),
+                ]
+            };
+            sub.append_linear_gradient(
+                &backdrop_rect,
+                &graphene::Point::new(0.0, backdrop_y),
+                &graphene::Point::new(0.0, backdrop_y + backdrop_h),
+                &stops,
+            );
+            sub.pop();
+
+            let node = sub.to_node()?;
+            let key = (
+                widget_w as i32,
+                widget_h as i32,
+                self.is_dark.get(),
+                paintable.as_ptr() as usize,
+            );
+            Some(BackdropNodeCache { node, key })
+        }
+    }
 
     impl BinImpl for TuListItem {}
 

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -19,6 +19,7 @@ use super::tu_item::{
     TuItemProgressbarAnimationPrelude,
 };
 use crate::ui::{
+    SETTINGS,
     provider::tu_item::TuItem,
     widgets::utils::{
         TU_ITEM_BANNER_SIZE,
@@ -75,7 +76,11 @@ pub mod imp {
         pub poster_type: Cell<PosterType>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
+        pub title_box: TemplateChild<gtk::Box>,
+        #[template_child]
         pub title: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub subtitle: TemplateChild<gtk::Label>,
         #[template_child]
         pub overlay: TemplateChild<gtk::Overlay>,
         #[template_child]
@@ -205,11 +210,30 @@ impl TuListItem {
 
     fn update_title(&self) {
         let imp = self.imp();
-        if let Some(title) = self.item().list_item_title() {
-            imp.title.set_text(&title);
-            imp.title.set_visible(true);
+        let full_display_mode = SETTINGS.full_item_display_mode();
+        let lines = if full_display_mode { 1 } else { -1 };
+        let ellipsize = if full_display_mode {
+            gtk::pango::EllipsizeMode::End
         } else {
-            imp.title.set_visible(false);
+            gtk::pango::EllipsizeMode::None
+        };
+        imp.title.set_lines(lines);
+        imp.title.set_ellipsize(ellipsize);
+        imp.subtitle.set_lines(lines);
+        imp.subtitle.set_ellipsize(ellipsize);
+
+        if let Some((title, subtitle)) = self.item().list_item_text() {
+            imp.title.set_text(&title);
+            if let Some(subtitle) = subtitle {
+                imp.subtitle.set_text(&subtitle);
+                imp.subtitle.set_visible(true);
+            } else {
+                imp.subtitle.set_visible(false);
+            }
+            imp.title_box.set_visible(true);
+        } else {
+            imp.title_box.set_visible(false);
+            imp.subtitle.set_visible(false);
         }
     }
 

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -84,6 +84,12 @@ pub mod imp {
         pub poster_type: Cell<PosterType>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
+        pub content_box: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub scaled_title_slot: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub plain_title_slot: TemplateChild<gtk::Box>,
+        #[template_child]
         pub title_box: TemplateChild<gtk::Box>,
         #[template_child]
         pub title: TemplateChild<gtk::Label>,
@@ -133,6 +139,8 @@ pub mod imp {
             self.is_dark.set(style_manager.is_dark());
             let obj = self.obj();
 
+            self.update_item_card_style();
+
             style_manager.connect_dark_notify(glib::clone!(
                 #[weak]
                 obj,
@@ -162,11 +170,23 @@ pub mod imp {
             });
 
             SETTINGS.connect_changed(
-                Some("full-item-display-mode"),
+                Some("item-text-display"),
                 glib::clone!(
                     #[weak]
                     obj,
                     move |_, _| obj.update_title()
+                ),
+            );
+
+            SETTINGS.connect_changed(
+                Some("item-card-style"),
+                glib::clone!(
+                    #[weak]
+                    obj,
+                    move |_, _| {
+                        obj.imp().update_item_card_style();
+                        obj.queue_draw();
+                    }
                 ),
             );
         }
@@ -181,8 +201,36 @@ pub mod imp {
     impl WidgetImpl for TuListItem {}
 
     impl TuListItem {
+        fn update_item_card_style(&self) {
+            let integrated = SETTINGS.item_card_style_is_integrated();
+            let title_box = self.title_box.get();
+            let target = if integrated {
+                self.scaled_title_slot.get()
+            } else {
+                self.plain_title_slot.get()
+            };
+
+            if title_box.parent().as_ref() != Some(target.upcast_ref()) {
+                if let Some(parent) = title_box.parent()
+                    && let Ok(parent) = parent.downcast::<gtk::Box>()
+                {
+                    parent.remove(&title_box);
+                }
+                target.append(&title_box);
+            }
+
+            if integrated {
+                self.content_box.add_css_class("tulistitem");
+            } else {
+                self.content_box.remove_css_class("tulistitem");
+            }
+
+            self.scaled_title_slot.set_visible(integrated);
+            self.plain_title_slot.set_visible(!integrated);
+        }
+
         fn draw_backdrop(&self, snapshot: &gtk::Snapshot) {
-            if !self.title_box.is_visible() {
+            if !SETTINGS.item_card_style_is_integrated() || !self.title_box.is_visible() {
                 return;
             }
 
@@ -354,16 +402,18 @@ impl TuListItem {
     fn update_title(&self) {
         let imp = self.imp();
         if let Some((title, subtitle)) = self.item().list_item_text() {
+            imp.title_box.set_visible(true);
             imp.title.set_text(&title);
+            imp.title.set_visible(true);
             if let Some(subtitle) = subtitle {
                 imp.subtitle.set_text(&subtitle);
                 imp.subtitle.set_visible(true);
             } else {
                 imp.subtitle.set_visible(false);
             }
-            imp.title_box.set_visible(true);
         } else {
             imp.title_box.set_visible(false);
+            imp.title.set_visible(false);
             imp.subtitle.set_visible(false);
         }
     }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -127,7 +127,7 @@ pub mod imp {
             });
 
             SETTINGS.connect_changed(
-                Some("always-show-item-title"),
+                Some("full-item-display-mode"),
                 glib::clone!(
                     #[weak]
                     obj,

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -19,6 +19,7 @@ use super::tu_item::{
     TuItemProgressbarAnimationPrelude,
 };
 use crate::ui::{
+    SETTINGS,
     provider::tu_item::TuItem,
     widgets::utils::{
         TU_ITEM_BANNER_SIZE,
@@ -224,15 +225,10 @@ pub mod imp {
             } else {
                 self.content_box.remove_css_class("tulistitem");
             }
-
-            self.update_item_card_style_title_visibility();
+            self.update_title_slot_visibility(integrated, self.title.get_visible());
         }
 
-        pub(super) fn update_item_card_style_title_visibility(&self) {
-            let integrated = SETTINGS.item_card_style_is_integrated();
-            let has_title = !self.title.text().is_empty();
-
-            self.title_box.set_visible(has_title);
+        pub(super) fn update_title_slot_visibility(&self, integrated: bool, has_title: bool) {
             self.scaled_title_slot.set_visible(integrated && has_title);
             self.plain_title_slot.set_visible(!integrated && has_title);
         }
@@ -410,7 +406,7 @@ impl TuListItem {
     fn update_title(&self) {
         let imp = self.imp();
         let item = self.item();
-        if let Some(title) = item.list_item_title() {
+        let has_title = if let Some(title) = item.list_item_title() {
             imp.title.set_text(&title);
             imp.title.set_visible(true);
             if let Some(subtitle) = item.list_item_subtitle() {
@@ -419,16 +415,14 @@ impl TuListItem {
             } else {
                 imp.subtitle.set_visible(false);
             }
+            true
         } else {
-            imp.title.set_text("");
             imp.title.set_visible(false);
-            imp.subtitle.set_text("");
             imp.subtitle.set_visible(false);
-            imp.title_box.set_visible(false);
-            imp.scaled_title_slot.set_visible(false);
-            imp.plain_title_slot.set_visible(false);
-        }
-        imp.update_item_card_style_title_visibility();
+            false
+        };
+
+        imp.update_title_slot_visibility(SETTINGS.item_card_style_is_integrated(), has_title);
     }
 
     pub fn refresh_item(&self) {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -317,7 +317,7 @@ pub mod imp {
                 pic_h as f64,
             );
             sub.restore();
-            sub.pop();
+            sub.pop(); // blur
 
             let stops = if self.is_dark.get() {
                 [
@@ -336,7 +336,7 @@ pub mod imp {
                 &graphene::Point::new(0.0, backdrop_y + backdrop_h),
                 &stops,
             );
-            sub.pop();
+            sub.pop(); // rounded clip
 
             let node = sub.to_node()?;
             let key = (

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -225,8 +225,16 @@ pub mod imp {
                 self.content_box.remove_css_class("tulistitem");
             }
 
-            self.scaled_title_slot.set_visible(integrated);
-            self.plain_title_slot.set_visible(!integrated);
+            self.update_item_card_style_title_visibility();
+        }
+
+        pub(super) fn update_item_card_style_title_visibility(&self) {
+            let integrated = SETTINGS.item_card_style_is_integrated();
+            let has_title = !self.title.text().is_empty();
+
+            self.title_box.set_visible(has_title);
+            self.scaled_title_slot.set_visible(integrated && has_title);
+            self.plain_title_slot.set_visible(!integrated && has_title);
         }
 
         fn draw_backdrop(&self, snapshot: &gtk::Snapshot) {
@@ -402,7 +410,6 @@ impl TuListItem {
     fn update_title(&self) {
         let imp = self.imp();
         if let Some((title, subtitle)) = self.item().list_item_text() {
-            imp.title_box.set_visible(true);
             imp.title.set_text(&title);
             imp.title.set_visible(true);
             if let Some(subtitle) = subtitle {
@@ -412,10 +419,15 @@ impl TuListItem {
                 imp.subtitle.set_visible(false);
             }
         } else {
-            imp.title_box.set_visible(false);
+            imp.title.set_text("");
             imp.title.set_visible(false);
+            imp.subtitle.set_text("");
             imp.subtitle.set_visible(false);
+            imp.title_box.set_visible(false);
+            imp.scaled_title_slot.set_visible(false);
+            imp.plain_title_slot.set_visible(false);
         }
+        imp.update_item_card_style_title_visibility();
     }
 
     pub fn refresh_item(&self) {

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -56,6 +56,7 @@ pub mod imp {
     use crate::ui::{
         provider::tu_item::TuItem,
         widgets::{
+            hover_scale::HoverScale,
             picture_loader::PictureLoader,
             tu_item::TuItemAction,
         },
@@ -98,6 +99,7 @@ pub mod imp {
         type ParentType = adw::Bin;
 
         fn class_init(klass: &mut Self::Class) {
+            HoverScale::ensure_type();
             PictureLoader::ensure_type();
             klass.bind_template();
             klass.bind_template_instance_callbacks();
@@ -273,7 +275,7 @@ impl TuOverviewItem {
                 }
             }
         }
-        self.set_picture_with_hover_scale();
+        self.set_picture();
         self.set_tooltip_text(Some(&item.name()));
     }
 }


### PR DESCRIPTION
close #644.

1. Adjusted the progress bar style. It now uses `gtk::ProgressBar` instead of a custom-drawn progress bar, which also avoids some update issues with the custom implementation.
2. For the episode overview, the progress bar now scales together with the cover on hover. In addition, margins have been added around the cover to prevent overflow when it scales on hover.
3. Added toggles for text display and card style. When text display is set to full, all items will include a title.

|Page/Component|Before|After|
|--|--|--|
|Homepage|<img width="2816" height="1676" alt="图片" src="https://github.com/user-attachments/assets/8b20d34f-7d5a-4bdc-bdf0-920630f75071" />|<img width="2856" height="1685" alt="图片" src="https://github.com/user-attachments/assets/39479c77-4dd8-4848-ae2a-1f72971b2921" />|
|Overview|<img width="753" height="369" alt="图片" src="https://github.com/user-attachments/assets/14691969-234a-4e23-a1c0-da7facced73b" />|<img width="770" height="402" alt="图片" src="https://github.com/user-attachments/assets/b445ce2b-65dd-4e7b-bc19-20d85fe6cec1" />|

