### PR TITLE
feat: improve episode selection and refresh behavior

### DIFF
--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Failed to get GLContext"
 msgstr ""
 
-#: src/ui/mpv/page.rs:407 src/ui/mpv/page.rs:409 src/ui/widgets/item.rs:707
+#: src/ui/mpv/page.rs:407 src/ui/mpv/page.rs:409 src/ui/widgets/item.rs:688
 #: resources/ui/album_widget.ui:94 resources/ui/item.ui:186
 #: resources/ui/mpv_menu_actions.ui:27 resources/ui/other.ui:95
 #: resources/ui/player_toolbar.ui:90
@@ -213,73 +213,85 @@ msgstr ""
 msgid "Replace Image"
 msgstr ""
 
-#: src/ui/widgets/item.rs:703 src/ui/widgets/list.rs:130
+#: src/ui/widgets/item.rs:345
+msgid "No episode selected"
+msgstr ""
+
+#: src/ui/widgets/item.rs:346
+msgid "Select an episode"
+msgstr ""
+
+#: src/ui/widgets/item.rs:684 src/ui/widgets/list.rs:130
 msgid "Resume"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1092
+#: src/ui/widgets/item.rs:1073
 msgid "Codec"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1095
+#: src/ui/widgets/item.rs:1076
 msgid "Language"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1098 resources/ui/metadata_dialog.ui:90
+#: src/ui/widgets/item.rs:1079 resources/ui/metadata_dialog.ui:90
 #: resources/ui/single_grid.ui:108
 msgid "Title"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1102 resources/ui/single_grid.ui:109
+#: src/ui/widgets/item.rs:1083 resources/ui/single_grid.ui:109
 msgid "Bitrate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1107
+#: src/ui/widgets/item.rs:1088
 msgid "BitDepth"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1111
+#: src/ui/widgets/item.rs:1092
 msgid "SampleRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1115
+#: src/ui/widgets/item.rs:1096
 msgid "Height"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1118
+#: src/ui/widgets/item.rs:1099
 msgid "Width"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1121
+#: src/ui/widgets/item.rs:1102
 msgid "ColorSpace"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1125
+#: src/ui/widgets/item.rs:1106
 msgid "DisplayTitle"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1129
+#: src/ui/widgets/item.rs:1110
 msgid "Channel"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1133
+#: src/ui/widgets/item.rs:1114
 msgid "ChannelLayout"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1138
+#: src/ui/widgets/item.rs:1119
 msgid "AverageFrameRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1142
+#: src/ui/widgets/item.rs:1123
 msgid "PixelFormat"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1254
+#: src/ui/widgets/item.rs:1235
 msgid "No video source found"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1390
+#: src/ui/widgets/item.rs:1371
 msgid "Season not found. Is this a continue watching list?"
+msgstr ""
+
+#: src/ui/widgets/item_actionbox.rs:117 src/ui/widgets/tu_item/action.rs:98
+msgid "Success"
 msgstr ""
 
 #: src/ui/widgets/liked.rs:158
@@ -406,10 +418,6 @@ msgstr ""
 msgid "Add to favorites"
 msgstr ""
 
-#: src/ui/widgets/tu_item/action.rs:98
-msgid "Success"
-msgstr ""
-
 #: src/ui/widgets/tu_item/action.rs:479
 msgid "Delete Item"
 msgstr ""
@@ -449,16 +457,16 @@ msgstr ""
 msgid "Server Panel"
 msgstr ""
 
-#: src/ui/widgets/window.rs:990
+#: src/ui/widgets/window.rs:989
 msgid "Fatal Error"
 msgstr ""
 
-#: src/ui/widgets/window.rs:993
+#: src/ui/widgets/window.rs:992
 msgid "Copy Error & Close"
 msgstr ""
 
 #. TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-#: src/ui/widgets/window.rs:1022
+#: src/ui/widgets/window.rs:1021
 msgid "translator-credits"
 msgstr ""
 

--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Failed to get GLContext"
 msgstr ""
 
-#: src/ui/mpv/page.rs:407 src/ui/mpv/page.rs:409 src/ui/widgets/item.rs:688
+#: src/ui/mpv/page.rs:407 src/ui/mpv/page.rs:409 src/ui/widgets/item.rs:689
 #: resources/ui/album_widget.ui:94 resources/ui/item.ui:186
 #: resources/ui/mpv_menu_actions.ui:27 resources/ui/other.ui:95
 #: resources/ui/player_toolbar.ui:90
@@ -221,72 +221,72 @@ msgstr ""
 msgid "Select an episode"
 msgstr ""
 
-#: src/ui/widgets/item.rs:684 src/ui/widgets/list.rs:130
+#: src/ui/widgets/item.rs:685 src/ui/widgets/list.rs:130
 msgid "Resume"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1073
+#: src/ui/widgets/item.rs:1074
 msgid "Codec"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1076
+#: src/ui/widgets/item.rs:1077
 msgid "Language"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1079 resources/ui/metadata_dialog.ui:90
+#: src/ui/widgets/item.rs:1080 resources/ui/metadata_dialog.ui:90
 #: resources/ui/single_grid.ui:108
 msgid "Title"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1083 resources/ui/single_grid.ui:109
+#: src/ui/widgets/item.rs:1084 resources/ui/single_grid.ui:109
 msgid "Bitrate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1088
+#: src/ui/widgets/item.rs:1089
 msgid "BitDepth"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1092
+#: src/ui/widgets/item.rs:1093
 msgid "SampleRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1096
+#: src/ui/widgets/item.rs:1097
 msgid "Height"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1099
+#: src/ui/widgets/item.rs:1100
 msgid "Width"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1102
+#: src/ui/widgets/item.rs:1103
 msgid "ColorSpace"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1106
+#: src/ui/widgets/item.rs:1107
 msgid "DisplayTitle"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1110
+#: src/ui/widgets/item.rs:1111
 msgid "Channel"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1114
+#: src/ui/widgets/item.rs:1115
 msgid "ChannelLayout"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1119
+#: src/ui/widgets/item.rs:1120
 msgid "AverageFrameRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1123
+#: src/ui/widgets/item.rs:1124
 msgid "PixelFormat"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1235
+#: src/ui/widgets/item.rs:1236
 msgid "No video source found"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1371
+#: src/ui/widgets/item.rs:1372
 msgid "Season not found. Is this a continue watching list?"
 msgstr ""
 

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -1363,9 +1363,9 @@ impl MPVPage {
 
     #[template_callback]
     pub fn on_stop_clicked(&self) {
-        self.handle_callback(BackType::Stop);
         self.remove_timeout();
         self.reset_skippable_segments();
+        let current_video = self.current_video();
 
         let mpv = self.mpv();
         mpv.pause(true);
@@ -1390,7 +1390,11 @@ impl MPVPage {
                     glib::source::SourceId::remove(timeout);
                 }
                 obj.set_reveal_overlay(true);
-                window.update_item_page().await;
+                // Wait for stop progress to land before refreshing item state
+                obj.handle_callback_sync(BackType::Stop).await;
+                if let Some(current_video) = current_video {
+                    window.update_item_page(current_video).await;
+                }
             }
         ));
         self.notify_stopped();
@@ -1401,17 +1405,26 @@ impl MPVPage {
         glib::ControlFlow::Continue
     }
 
-    fn handle_callback(&self, backtype: BackType) {
+    fn position_back(&self) -> Option<Back> {
         let position = self.imp().last_playback_position.get();
-        let back = self.imp().back.borrow();
+        let mut back = self.imp().back.borrow().as_ref()?.to_owned();
+        back.tick = position as u64 * 10000000;
+        Some(back)
+    }
 
-        if let Some(back) = back.as_ref() {
-            let duration = position as u64 * 10000000;
-            let mut back = back.to_owned();
-            back.tick = duration;
+    fn handle_callback(&self, backtype: BackType) {
+        if let Some(back) = self.position_back() {
             crate::utils::spawn_tokio_without_await(async move {
                 let _ = JELLYFIN_CLIENT.position_back(&back, backtype).await;
             });
+        }
+    }
+
+    async fn handle_callback_sync(&self, backtype: BackType) {
+        if let Some(back) = self.position_back() {
+            let _ =
+                spawn_tokio(async move { JELLYFIN_CLIENT.position_back(&back, backtype).await })
+                    .await;
         }
     }
 

--- a/src/ui/provider/actions.rs
+++ b/src/ui/provider/actions.rs
@@ -1,9 +1,3 @@
-use gtk::{
-    glib,
-    prelude::*,
-    subclass::prelude::ObjectSubclassIsExt,
-};
-
 use crate::{
     client::{
         error::UserFacingError,
@@ -20,6 +14,12 @@ use crate::{
         spawn,
         spawn_tokio,
     },
+};
+use gettextrs::gettext;
+use gtk::{
+    glib,
+    prelude::*,
+    subclass::prelude::ObjectSubclassIsExt,
 };
 
 pub trait HasLikeAction {
@@ -53,7 +53,7 @@ macro_rules! impl_has_likeaction {
 
                                     match result {
                                         Ok(_) => {
-                                            obj.toast("Success");
+                                            obj.toast(gettext("Success"));
                                         }
                                         Err(e) => {
                                             obj.toast(e.to_user_facing());

--- a/src/ui/widgets/episode_switcher/switcher.rs
+++ b/src/ui/widgets/episode_switcher/switcher.rs
@@ -55,7 +55,7 @@ glib::wrapper! {
 
 #[gtk::template_callbacks]
 impl EpisodeSwitcher {
-    const EPISODES_PER_GROUP: usize = 50;
+    pub const EPISODES_PER_GROUP: usize = 50;
 
     pub fn new() -> Self {
         glib::Object::new()
@@ -78,15 +78,15 @@ impl EpisodeSwitcher {
         self.add_button(&button);
     }
 
-    pub fn load_from_n_items<F>(&self, n_items: usize, callback: F)
+    pub fn load_from_range<F>(&self, max_index: usize, callback: F)
     where
         F: Fn(&EpisodeButton) + 'static + Clone,
     {
         self.clear();
 
-        for i in (0..n_items).step_by(Self::EPISODES_PER_GROUP) {
+        for i in (0..max_index).step_by(Self::EPISODES_PER_GROUP) {
             let start = i;
-            let end = (i + Self::EPISODES_PER_GROUP).min(n_items);
+            let end = (i + Self::EPISODES_PER_GROUP).min(max_index);
 
             let callback = callback.to_owned();
             let cb = move |btn: &EpisodeButton| {

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -528,7 +528,8 @@ impl ItemPage {
         {
             Self::search_episode_index(&items, &current_item)
                 .map(|_| {
-                    current_item.index_number() as usize / EpisodeSwitcher::EPISODES_PER_GROUP
+                    current_item.index_number().saturating_sub(1) as usize
+                        / EpisodeSwitcher::EPISODES_PER_GROUP
                         * EpisodeSwitcher::EPISODES_PER_GROUP
                 })
                 .unwrap_or_default()

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -659,7 +659,6 @@ impl ItemPage {
         let tu_item = TuItem::from_simple(next_up_item);
 
         self.set_now_item::<false>(&tu_item);
-        self.set_current_item(Some(&tu_item));
 
         Some(tu_item)
     }
@@ -848,7 +847,7 @@ impl ItemPage {
 
         let mut events = fetch_with_cache(
             &format!("season_{}", id),
-            CachePolicy::IgnoreCache,
+            CachePolicy::ReadCacheAndRefresh,
             async move { JELLYFIN_CLIENT.get_season_list(&id).await },
         )
         .await;

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -1,5 +1,8 @@
 use super::{
-    episode_switcher::EpisodeButton,
+    episode_switcher::{
+        EpisodeButton,
+        EpisodeSwitcher,
+    },
     fix::ScrolledWindowFixExt,
     hortu_scrolled::{
         SHOW_BUTTON_ANIMATION_DURATION,
@@ -39,7 +42,6 @@ use crate::{
         fetch_with_cache,
         get_image_with_cache,
         spawn,
-        spawn_g_timeout,
         spawn_tokio,
     },
 };
@@ -209,8 +211,6 @@ pub(crate) mod imp {
         pub show_button_animation: OnceCell<adw::TimedAnimation>,
         pub hide_button_animation: OnceCell<adw::TimedAnimation>,
 
-        pub season_id: RefCell<Option<String>>,
-
         #[property(get, set, nullable)]
         pub current_item: RefCell<Option<TuItem>>,
 
@@ -328,28 +328,30 @@ impl ItemPage {
         if type_ == "Series" {
             let series_id = item.id();
 
-            spawn(glib::clone!(
-                #[weak(rename_to = obj)]
-                self,
-                #[strong]
-                series_id,
-                async move {
-                    let Some(intro) = obj.set_shows_next_up(&series_id).await else {
-                        obj.imp()
-                            .buttoncontent
-                            .set_label(&gettext("Select an episode"));
-                        return;
-                    };
-                    obj.set_intro::<false>(&intro).await;
-                }
-            ));
+            if let Some(item) = self.set_shows_next_up(&series_id).await {
+                // ensure current_item available before season episodes load
+                self.set_current_item(Some(&item));
+                spawn(glib::clone!(
+                    #[weak(rename_to = obj)]
+                    self,
+                    #[strong]
+                    item,
+                    async move {
+                        obj.set_intro::<false>(&item).await;
+                    }
+                ));
+            } else {
+                let imp = self.imp();
+                imp.episode_line.set_text(&gettext("No episode selected"));
+                imp.buttoncontent.set_label(&gettext("Select an episode"));
+            }
 
             self.imp().actionbox.set_id(Some(series_id.to_owned()));
             self.setup_item(&series_id).await;
             self.setup_seasons(&series_id).await;
         } else if type_ == "Episode" && item.series_name().is_some() {
             let series_id = item.series_id().unwrap_or(item.id());
-
+            self.set_current_item(Some(&item));
             spawn(glib::clone!(
                 #[weak(rename_to = obj)]
                 self,
@@ -379,45 +381,27 @@ impl ItemPage {
         }
     }
 
-    pub async fn update_intro(&self) {
+    pub async fn update_intro(&self, current_item: TuItem) {
         let item = self.item();
 
-        if item.item_type() == "Series" || item.item_type() == "Episode" {
-            let series_id = item.series_id().unwrap_or(item.id());
-
-            spawn(glib::clone!(
-                #[weak(rename_to = obj)]
-                self,
-                #[strong]
-                series_id,
-                async move {
-                    let Some(intro) = obj.set_shows_next_up(&series_id).await else {
-                        return;
-                    };
-                    obj.set_intro::<false>(&intro).await;
+        let id = current_item.id();
+        let current_item =
+            match spawn_tokio(async move { JELLYFIN_CLIENT.get_item_info(&id).await }).await {
+                Ok(item) => TuItem::from_simple(item),
+                Err(e) => {
+                    self.toast(e.to_user_facing());
+                    current_item
                 }
-            ));
+            };
+
+        if item.item_type() == "Series" || item.item_type() == "Episode" {
+            self.set_intro::<false>(&current_item).await;
+            self.on_season_selected(None, self.imp().seasonlist.get())
+                .await;
         }
 
         if item.item_type() == "Video" || item.item_type() == "Movie" {
-            spawn(glib::clone!(
-                #[weak(rename_to = obj)]
-                self,
-                #[weak]
-                item,
-                async move {
-                    let id = item.id();
-                    match spawn_tokio(async move { JELLYFIN_CLIENT.get_item_info(&id).await }).await
-                    {
-                        Ok(item) => {
-                            obj.set_intro::<true>(&TuItem::from_simple(item)).await;
-                        }
-                        Err(e) => {
-                            obj.toast(e.to_user_facing());
-                        }
-                    }
-                }
-            ));
+            self.set_intro::<true>(&current_item).await;
         }
     }
 
@@ -482,55 +466,35 @@ impl ItemPage {
     #[template_callback]
     async fn on_season_selected(&self, _param: Option<glib::ParamSpec>, dropdown: gtk::DropDown) {
         let item = self.item();
-
         let item_type = item.item_type();
-
         if item_type != "Series" && item_type != "Episode" {
             return;
         }
-
-        let object = dropdown.selected_item();
-        let Some(season_name) = object.and_downcast_ref::<gtk::StringObject>() else {
-            return;
-        };
-
-        let season_name = season_name.string().to_string();
 
         let imp = self.imp();
         imp.episode_stack.set_visible_child_name("loading");
 
         let series_id = item.series_id().unwrap_or(item.id());
-
         let position = dropdown.selected();
-        let season_id = item.season_id();
 
-        let list = match (position, season_id.to_owned()) {
+        let current_item = self.current_item();
+        let current_season_id = current_item.as_ref().and_then(|item| item.season_id());
+
+        let items = match (position, current_season_id) {
+            (0, None) => vec![],
             (0, Some(season_id)) => {
                 let season_id_clone = season_id.to_owned();
                 match spawn_tokio(async move {
                     JELLYFIN_CLIENT
-                        .get_episodes(&series_id, &season_id.to_string(), 0)
+                        .get_episodes_all(&series_id, &season_id)
                         .await
                 })
                 .await
                 {
-                    Ok(item) => {
+                    Ok(res) => {
                         self.set_current_season(Some(season_id_clone));
-                        item
+                        res.items
                     }
-                    Err(e) => {
-                        self.toast(e.to_user_facing());
-                        return;
-                    }
-                }
-            }
-            (0, None) => {
-                match spawn_tokio(async move {
-                    JELLYFIN_CLIENT.get_continue_play_list(&series_id).await
-                })
-                .await
-                {
-                    Ok(item) => item,
                     Err(e) => {
                         self.toast(e.to_user_facing());
                         return;
@@ -540,21 +504,20 @@ impl ItemPage {
             _ => {
                 let season_id = {
                     let season_list = imp.season_list_vec.borrow();
-                    let Some(season) = season_list.iter().find(|s| s.name == season_name) else {
+                    let Some(season) = season_list.get(position.saturating_sub(1) as usize) else {
                         return;
                     };
-                    self.imp().season_id.replace(Some(season.id.to_owned()));
+                    self.set_current_season(Some(season.id.to_owned()));
                     season.id.to_owned()
                 };
-
                 match spawn_tokio(async move {
                     JELLYFIN_CLIENT
-                        .get_episodes(&series_id, &season_id, 0)
+                        .get_episodes_all(&series_id, &season_id)
                         .await
                 })
                 .await
                 {
-                    Ok(list) => list,
+                    Ok(res) => res.items,
                     Err(e) => {
                         self.toast(e.to_user_facing());
                         return;
@@ -563,103 +526,123 @@ impl ItemPage {
             }
         };
 
-        let index = list
-            .items
-            .iter()
-            .position(|item| item.index_number == Some(self.item().index_number()))
-            .unwrap_or(0);
-
-        self.set_episode_list(list.items);
-
-        if position == 0 {
-            // itemlist need wait for property binding to scroll
-            spawn_g_timeout(glib::clone!(
-                #[weak]
-                imp,
-                async move {
-                    imp.itemlist
-                        .scroll_to(index as u32, ListScrollFlags::all(), None);
-                },
-            ));
+        let start_idx = if let Some(current_item) = current_item
+            && self.current_season() == current_item.season_id()
+        {
+            Self::search_episode_index(&items, &current_item)
+                .map(|_| {
+                    current_item.index_number() as usize / EpisodeSwitcher::EPISODES_PER_GROUP
+                        * EpisodeSwitcher::EPISODES_PER_GROUP
+                })
+                .unwrap_or_default()
         } else {
-            self.imp().episode_switcher.load_from_n_items(
-                list.total_record_count as usize,
-                glib::clone!(
-                    #[weak(rename_to = obj)]
-                    self,
-                    move |btn| {
-                        spawn(glib::clone!(
-                            #[weak]
-                            obj,
-                            #[weak]
-                            btn,
-                            async move {
-                                obj.on_episode_switcher_clicked(&btn).await;
-                            }
-                        ))
-                    }
-                ),
-            );
-        }
+            0
+        };
+
+        let max_episode_number = items
+            .last()
+            .and_then(|item| item.index_number)
+            .unwrap_or_default() as usize;
+
+        self.set_episode_list(items, start_idx);
+        self.imp().episode_switcher.load_from_range(
+            max_episode_number,
+            glib::clone!(
+                #[weak(rename_to = obj)]
+                self,
+                move |btn| {
+                    spawn(glib::clone!(
+                        #[weak]
+                        obj,
+                        #[weak]
+                        btn,
+                        async move {
+                            obj.on_episode_switcher_clicked(&btn).await;
+                        }
+                    ))
+                }
+            ),
+        );
     }
 
-    fn set_episode_list(&self, list: Vec<SimpleListItem>) {
+    fn set_episode_list(&self, list: Vec<SimpleListItem>, start_index: usize) {
+        let imp = self.imp();
+        imp.episode_list_vec.replace(list);
+        self.set_episode_list_range(start_index);
+    }
+
+    fn set_episode_list_range(&self, start_index: usize) {
         let imp = self.imp();
         let store_model = imp.selection.model();
         let Some(store) = store_model.and_downcast_ref::<gio::ListStore>() else {
             return;
         };
-
-        store.remove_all();
-
+        let list = imp.episode_list_vec.borrow();
         if list.is_empty() {
             imp.episode_stack.set_visible_child_name("fallback");
             return;
         }
+        let (start_episode, end_episode) = (
+            start_index as u32 + 1,
+            start_index as u32 + EpisodeSwitcher::EPISODES_PER_GROUP as u32,
+        );
+        let (left, right) = (
+            list.partition_point(|item| {
+                item.index_number
+                    .expect("index_number should be present in SimpleListItem")
+                    < start_episode
+            }),
+            list.partition_point(|item| {
+                item.index_number
+                    .expect("index_number should be present in SimpleListItem")
+                    <= end_episode
+            }),
+        );
+        let slice = &list[left..right];
+        let scroll_to = match self.current_item() {
+            None => None,
+            Some(item) => {
+                let (season_id, index_number) = (item.season_id(), item.index_number());
+                if self.current_season() != season_id
+                    || index_number < start_episode
+                    || index_number > end_episode
+                {
+                    None
+                } else {
+                    Self::search_episode_index(slice, &item)
+                }
+            }
+        };
 
-        let items = list
+        let items = slice
             .iter()
             .map(|item| TuObject::from_simple(item.to_owned()))
             .collect::<Vec<_>>();
 
+        store.remove_all();
         store.extend_from_slice(&items);
 
-        imp.episode_list_vec.replace(list);
         imp.episode_stack.set_visible_child_name("view");
+        if let Some(scroll_index) = scroll_to {
+            let itemlist = imp.itemlist.get();
+            glib::idle_add_local_once(move || {
+                itemlist.scroll_to(scroll_index as u32, ListScrollFlags::all(), None);
+            });
+        }
+    }
+
+    fn search_episode_index(list: &[SimpleListItem], current_item: &TuItem) -> Option<usize> {
+        let index_number = current_item.index_number();
+        list.binary_search_by_key(&index_number, |item| {
+            item.index_number
+                .expect("index_number should be present in SimpleListItem")
+        })
+        .ok()
     }
 
     async fn on_episode_switcher_clicked(&self, btn: &EpisodeButton) {
-        let imp = self.imp();
-
         let start_index = btn.start_index();
-        let item = self.item();
-        let series_id = item.series_id().unwrap_or(item.id());
-
-        let Some(season_id) =
-            self.current_season().or(item
-                .season_id()
-                .or(self.imp().season_id.borrow().to_owned()))
-        else {
-            return;
-        };
-
-        imp.episode_stack.set_visible_child_name("loading");
-
-        let list = match spawn_tokio(async move {
-            JELLYFIN_CLIENT
-                .get_episodes(&series_id, &season_id, start_index)
-                .await
-        })
-        .await
-        {
-            Ok(list) => list,
-            Err(e) => {
-                self.toast(e.to_user_facing());
-                return;
-            }
-        };
-
-        self.set_episode_list(list.items);
+        self.set_episode_list_range(start_index as usize);
     }
 
     async fn set_shows_next_up(&self, id: &str) -> Option<TuItem> {
@@ -678,6 +661,7 @@ impl ItemPage {
         let tu_item = TuItem::from_simple(next_up_item);
 
         self.set_now_item::<false>(&tu_item);
+        self.set_current_item(Some(&tu_item));
 
         Some(tu_item)
     }
@@ -866,7 +850,7 @@ impl ItemPage {
 
         let mut events = fetch_with_cache(
             &format!("season_{}", id),
-            CachePolicy::ReadCacheAndRefresh,
+            CachePolicy::IgnoreCache,
             async move { JELLYFIN_CLIENT.get_season_list(&id).await },
         )
         .await;

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -483,7 +483,7 @@ impl ItemPage {
         let items = match (position, current_season_id) {
             (0, None) => vec![],
             (0, Some(season_id)) => {
-                let season_id_clone = season_id.to_owned();
+                self.set_current_season(Some(season_id.to_owned()));
                 match spawn_tokio(async move {
                     JELLYFIN_CLIENT
                         .get_episodes_all(&series_id, &season_id)
@@ -491,10 +491,7 @@ impl ItemPage {
                 })
                 .await
                 {
-                    Ok(res) => {
-                        self.set_current_season(Some(season_id_clone));
-                        res.items
-                    }
+                    Ok(res) => res.items,
                     Err(e) => {
                         self.toast(e.to_user_facing());
                         return;

--- a/src/ui/widgets/item_actionbox.rs
+++ b/src/ui/widgets/item_actionbox.rs
@@ -1,4 +1,5 @@
 use adw::subclass::prelude::*;
+use gettextrs::gettext;
 use gtk::{
     CompositeTemplate,
     gio,
@@ -113,7 +114,7 @@ impl ItemActionsBox {
 
             match result {
                 Ok(_) => {
-                    self.toast("Success");
+                    self.toast(gettext("Success"));
                 }
                 Err(e) => {
                     self.toast(e.to_user_facing());
@@ -179,7 +180,7 @@ impl ItemActionsBox {
                                         {
                                             Ok(_) => {
                                                 obj.set_played(false);
-                                                obj.toast("Success");
+                                                obj.toast(gettext("Success"));
                                                 obj.bind_edit();
                                             }
                                             Err(e) => {
@@ -212,7 +213,7 @@ impl ItemActionsBox {
                                         {
                                             Ok(_) => {
                                                 obj.set_played(true);
-                                                obj.toast("Success");
+                                                obj.toast(gettext("Success"));
                                                 obj.bind_edit();
                                             }
                                             Err(e) => {

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -976,13 +976,12 @@ impl Window {
         }
     }
 
-    pub async fn update_item_page(&self) {
+    pub async fn update_item_page(&self, current_item: TuItem) {
         let nav = self.imp().mainview.visible_page();
         let Some(now_page) = nav.and_downcast_ref::<ItemPage>() else {
             return;
         };
-
-        now_page.update_intro().await;
+        now_page.update_intro(current_item).await;
     }
 
     pub fn close_on_error(&self, description: String) {


### PR DESCRIPTION
close #655, close #364.

Before this PR, the episode handling logic on the episode details page had several issues:

1. When entering from an episode, episodes with an episode number greater than 50 could not be located automatically, because the episode list was loaded with fixed 50-item pagination.
2. When exiting the player, the current episode was refreshed to the next up episode instead of the last played episode. This caused problems when replaying watched episodes: for example, after watching episodes 1–4, the next up episode is episode 5; if the user goes back to episode 2 and exits midway, the current episode would jump to episode 5 instead of staying on episode 2.
3. The episode list was not refreshed after exiting the player, so users could notice stale data after autoplaying multiple videos. Also, switching episodes replaces the selected episode with data from the episode list, so once the user switched away, the current episode’s progress could be lost and switching back would still show the old progress.
4. When entering directly from a series, the “Continue Watching” section only loaded the next episode. Since autoplay depends on the playlist returned from this section, loading only one episode meant autoplay could not continue. Combined with issue 3, after playback finished, “Continue Watching” would still show the completed episode, and users had to go back and re-enter to continue with the next episode.

This PR improves the experience with the following changes:

1. Both “Continue Watching” and each season now load the full episode list for the current season. The season loaded by “Continue Watching” depends on the entry point: when entering from an episode, it loads that episode’s season; when entering from a series, it first fetches the next up episode, then loads the season containing it. This resolves issues 1 and 4, and allows autoplay across the full season instead of being limited to 50 episodes.
2. Episode range buttons no longer control paginated loading. They now act as helpers to avoid rendering an overly long list by slicing the already loaded episode list into the selected range. If the selected episode is within that range, it is located automatically.
3. Previously, episode range generation and pagination were based on list indexes instead of actual episode numbers, which was a limitation of the pagination-based implementation. This usually worked, but could be wrong when episodes were missing on the media server. For example, if the server had episodes 1–49 and 51–53, the old range selector would show 1–50 and 51–52, with episode 51 appearing under 1–50. Since the full episode list is now available, ranges can be generated from the actual `index_number`.
4. When exiting the player back to the details page, the player’s last played video is refreshed through the API and used to replace the current episode. This resolves issue 2. An API refresh is used instead of optimistically applying the last playback progress because the media server may mark videos as not started or played when playback is near the beginning or end, which raw progress alone cannot reflect correctly.
5. Exiting the player now also triggers episode list reloading and automatic locating logic, resolving issue 3.
