### PR TITLE
perf: several small improvements

### DIFF
--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -307,7 +307,7 @@ impl JellyfinClient {
         let request = self
             .prepare_request(Method::GET, path, params)?
             .header("If-None-Match", etag.unwrap_or_default());
-        let res = request.send().await?;
+        let res = self.send_request(request).await?;
         Ok(res)
     }
 

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -289,14 +289,14 @@ impl JellyfinClient {
             }
         };
 
-        let res_text = res.text().await?;
-        match serde_json::from_str(&res_text) {
+        let res_bytes = res.bytes().await?;
+        match serde_json::from_slice(&res_bytes) {
             Ok(json) => Ok(json),
             Err(e) => Err(anyhow!(
                 "Request Path: {}\nFailed parsing response to json {}: {}",
                 path,
                 e,
-                res_text
+                String::from_utf8_lossy(&res_bytes)
             )),
         }
     }

--- a/src/ui/widgets/identify/search_page.rs
+++ b/src/ui/widgets/identify/search_page.rs
@@ -10,6 +10,7 @@ use gtk::{
 };
 
 use gtk::template_callbacks;
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
@@ -174,7 +175,7 @@ impl IdentifyDialogSearchPage {
     }
 
     pub fn extend_item(&self, items: Value, item_type: String) {
-        let Value::Array(ref items) = items else {
+        let Value::Array(items) = items else {
             return;
         };
 
@@ -186,22 +187,24 @@ impl IdentifyDialogSearchPage {
         else {
             return;
         };
-        for item_value in items {
-            let Ok(item) = serde_json::from_value::<RemoteSearchResult>(item_value.to_owned())
-            else {
-                continue;
-            };
-            let eu_item = EuItem::new(
-                item.image_url,
-                None,
-                Some(item.name),
-                item.production_year.map(|p| p.to_string()),
-                None,
-                Some(item_type.to_owned()),
-                Some(item_value.to_string()),
-            );
-            let eu_object = EuObject::new(&eu_item);
-            store.append(&eu_object);
-        }
+
+        let items = items
+            .into_iter()
+            .filter_map(|item_value| {
+                let item = RemoteSearchResult::deserialize(&item_value).ok()?;
+                let eu_item = EuItem::new(
+                    item.image_url,
+                    None,
+                    Some(item.name),
+                    item.production_year.map(|p| p.to_string()),
+                    None,
+                    Some(item_type.to_owned()),
+                    Some(item_value.to_string()),
+                );
+                Some(EuObject::new(&eu_item))
+            })
+            .collect::<Vec<_>>();
+
+        store.extend_from_slice(&items);
     }
 }

--- a/src/ui/widgets/image_dialog/search_page.rs
+++ b/src/ui/widgets/image_dialog/search_page.rs
@@ -193,13 +193,9 @@ impl ImageDialogSearchPage {
     pub async fn init<const FIRST_INIT: bool>(&self) {
         let id = self.id();
         let type_ = self.image_type();
+        let imp = self.imp();
 
-        let Some(store) = self
-            .imp()
-            .selection
-            .model()
-            .and_downcast::<gio::ListStore>()
-        else {
+        let Some(store) = imp.selection.model().and_downcast::<gio::ListStore>() else {
             return;
         };
 
@@ -211,7 +207,7 @@ impl ImageDialogSearchPage {
 
         dialog.loading_page();
 
-        let if_all_language = self.imp().all_languages_check.is_active();
+        let if_all_language = imp.all_languages_check.is_active();
         let providers = self.providers();
 
         let remote_image_list = match spawn_tokio(async move {
@@ -230,35 +226,45 @@ impl ImageDialogSearchPage {
 
         dialog.view_page();
 
-        self.imp()
-            .items_count_label
+        imp.items_count_label
             .set_text(&format!("{} Items", remote_image_list.total_record_count));
 
         if FIRST_INIT {
-            for provider in remote_image_list.providers {
-                self.imp().dropdown_string_list.append(&provider);
-            }
+            imp.dropdown_string_list.splice(
+                0,
+                imp.dropdown_string_list.n_items(),
+                &remote_image_list
+                    .providers
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>(),
+            );
         }
 
-        for item in remote_image_list.images {
-            let line2 = format!(
-                "{}x{} - {}",
-                item.width.unwrap_or(0),
-                item.height.unwrap_or(0),
-                item.language.unwrap_or_default()
-            );
-            let eu_item = eu_item::EuItem::new(
-                item.thumbnail_url,
-                Some(item.url),
-                Some(item.provider_name),
-                Some(line2),
-                item.community_rating.map(|x| x.to_string()),
-                Some(self.image_type().to_string()),
-                None,
-            );
-            let eu_object = eu_item::EuObject::new(&eu_item);
-            store.append(&eu_object);
-        }
+        let items = remote_image_list
+            .images
+            .iter()
+            .map(|item| {
+                let line2 = format!(
+                    "{}x{} - {}",
+                    item.width.unwrap_or(0),
+                    item.height.unwrap_or(0),
+                    item.language.clone().unwrap_or_default()
+                );
+                let eu_item = eu_item::EuItem::new(
+                    item.thumbnail_url.clone(),
+                    Some(item.url.clone()),
+                    Some(item.provider_name.clone()),
+                    Some(line2),
+                    item.community_rating.map(|x| x.to_string()),
+                    Some(self.image_type().to_string()),
+                    None,
+                );
+                eu_item::EuObject::new(&eu_item)
+            })
+            .collect::<Vec<_>>();
+
+        store.extend_from_slice(&items);
     }
 
     fn providers(&self) -> String {

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -733,9 +733,9 @@ impl ItemPage {
 
                 let dl: std::cell::Ref<DropdownList> = entry.borrow();
                 let selected = &dl.id;
-                for _i in 0..sstore.n_items() {
-                    sstore.remove(0);
-                }
+
+                let mut objects = Vec::new();
+                let mut subtitle_choice = None;
                 for media in &media_sources {
                     if selected.as_deref().is_some_and(|s| s == media.id) {
                         let mut lang_list = Vec::new();
@@ -755,22 +755,24 @@ impl ItemPage {
 
                                 lang_list
                                     .push((stream.index, dl.line1.to_owned().unwrap_or_default()));
-                                let object = glib::BoxedAnyObject::new(dl);
-                                sstore.append(&object);
+                                objects.push(glib::BoxedAnyObject::new(dl));
                             }
                         }
 
-                        if let Some(u) = make_subtitle_version_choice(lang_list) {
-                            subdropdown.set_selected(u.1 as u32);
-                        }
+                        subtitle_choice = make_subtitle_version_choice(lang_list);
                         break;
                     }
+                }
+                sstore.splice(0, sstore.n_items(), &objects);
+                if let Some(u) = subtitle_choice {
+                    subdropdown.set_selected(u.1 as u32);
                 }
 
                 imp.video_version_matcher.replace(dl.line1.to_owned());
             }
         ));
 
+        let mut objects = Vec::new();
         for media in &playbackinfo.media_sources {
             let line2 = media
                 .bit_rate
@@ -788,9 +790,10 @@ impl ItemPage {
             };
 
             v_dl.push(dl.line1.to_owned().unwrap_or_default());
-            let object = glib::BoxedAnyObject::new(dl);
-            vstore.append(&object);
+            objects.push(glib::BoxedAnyObject::new(dl));
         }
+
+        vstore.extend_from_slice(&objects);
 
         if let Some(matcher) = matcher {
             if let Some(p) = make_video_version_choice_from_matcher(v_dl, &matcher) {

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -343,14 +343,18 @@ impl OtherPage {
                         .unwrap()
                         .downcast::<gio::ListStore>()
                         .unwrap();
-                    store.remove_all();
 
-                    for item in data.items {
-                        let tu_item = TuItem::from_simple(item);
-                        tu_item.set_is_resume(true);
-                        let tu_item = TuObject::new(tu_item);
-                        store.append(&tu_item);
-                    }
+                    let items = data
+                        .items
+                        .into_iter()
+                        .map(|item| {
+                            let tu_item = TuItem::from_simple(item);
+                            tu_item.set_is_resume(true);
+                            TuObject::new(tu_item)
+                        })
+                        .collect::<Vec<_>>();
+
+                    store.splice(0, store.n_items(), &items);
 
                     let episode_page = self
                         .imp()

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -154,23 +154,32 @@ impl TuViewScrolled {
             return;
         };
 
-        if C {
-            store.remove_all();
+        let prefer_size = if C {
             let size = resolve_prefer_size(self.unify_size(), &items);
             self.imp().prefer_size_cache.replace(size);
-        }
+            size
+        } else {
+            *self.imp().prefer_size_cache.borrow()
+        };
 
-        let prefer_size = *self.imp().prefer_size_cache.borrow();
         let prefer_poster = self.prefer_poster();
         let is_resume = self.is_resume();
 
-        for item in items {
-            let tu_item = TuItem::from_simple(item);
-            tu_item.set_is_resume(is_resume);
-            tu_item.set_prefer_poster(prefer_poster);
-            tu_item.set_prefer_size(prefer_size);
-            let tu_item = TuObject::new(tu_item);
-            store.append(&tu_item);
+        let items = items
+            .into_iter()
+            .map(|item| {
+                let tu_item = TuItem::from_simple(item);
+                tu_item.set_is_resume(is_resume);
+                tu_item.set_prefer_poster(prefer_poster);
+                tu_item.set_prefer_size(prefer_size);
+                TuObject::new(tu_item)
+            })
+            .collect::<Vec<_>>();
+
+        if C {
+            store.splice(0, store.n_items(), &items);
+        } else {
+            store.extend_from_slice(&items);
         }
     }
 

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -918,18 +918,17 @@ impl Window {
         self.add_action_entries([shortcuts_action]);
     }
 
-    pub fn set_mpv_playlist(&self, episode_list: &Vec<TuItem>) {
+    pub fn set_mpv_playlist(&self, episode_list: &[TuItem]) {
         let model = self.imp().mpv_playlist_selection.model();
         let Some(store) = model.and_downcast_ref::<gio::ListStore>() else {
             return;
         };
+        let items = episode_list
+            .iter()
+            .map(|item| TuObject::new(item.to_owned()))
+            .collect::<Vec<_>>();
 
-        store.remove_all();
-
-        for item in episode_list {
-            let object = TuObject::new(item.to_owned());
-            store.append(&object);
-        }
+        store.splice(0, store.n_items(), &items);
     }
 
     pub fn view_playlist(&self) {


### PR DESCRIPTION
1. (fix) Apply the semaphore limit to image requests as well.
2. Avoid extra `String` allocations in successful Jellyfin client requests.
3. Use `splice` and `remove_all` instead of appending items one by one where possible, as described in the `GListStore::splice` documentation: “This function is more efficient than g_list_store_insert() and g_list_store_remove(), because it only emits GListModel::items-changed once for the change.”
