### PR TITLE
refactor: switch image loading to glycin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,6 +2110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,10 +3437,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "chrono",
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,30 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,44 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-
-[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -314,59 +258,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey 0.1.1",
- "rayon",
- "thiserror",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3efb2ca85bc610acfa917b5aaa36f3fcbebed5b3182d7f877b02531c4b80c8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -379,15 +274,6 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "bitstream-io"
-version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
-dependencies = [
- "core2",
-]
 
 [[package]]
 name = "block"
@@ -409,12 +295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
-
-[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,12 +314,6 @@ name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -575,12 +449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,15 +478,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -714,6 +573,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +721,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "epoxy"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,26 +751,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "shared_library",
-]
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -894,56 +791,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
 ]
 
 [[package]]
@@ -989,6 +842,33 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1252,16 +1132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f954a9e9159ec994f73a30a12b96a702dde78f5547bcb561174597924f7d4162"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gio"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1228,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "glycin"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923674c1f2b1a28f69ebdc0f572672e63874e17ce0e60c96b8bfaff47a8ef4e9"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "gdk4",
+ "gio",
+ "glib",
+ "glycin-common",
+ "glycin-utils",
+ "gufo-common",
+ "gufo-exif",
+ "lcms2",
+ "lcms2-sys",
+ "libc",
+ "libseccomp",
+ "memfd",
+ "memmap2",
+ "nix",
+ "static_assertions",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "yeslogic-fontconfig-sys",
+ "zbus",
+]
+
+[[package]]
+name = "glycin-common"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db28cec888051ccbf68f9f352d57ba2a292179863524a0769e54dbb72d152a03"
+dependencies = [
+ "bitflags 2.11.1",
+ "gufo-common",
+ "half",
+ "memmap2",
+ "nix",
+ "paste",
+ "rmp-serde",
+ "serde",
+ "thiserror",
+ "zerocopy",
+ "zvariant",
+]
+
+[[package]]
+name = "glycin-utils"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49cd2451bced7416341a5e89d74f547e92b85b67e8f66c8723a7505930a50ab"
+dependencies = [
+ "async-lock",
+ "bitflags 2.11.1",
+ "blocking",
+ "env_logger",
+ "futures-util",
+ "glycin-common",
+ "gufo-common",
+ "half",
+ "libc",
+ "libseccomp",
+ "log",
+ "memmap2",
+ "nix",
+ "paste",
+ "rayon",
+ "serde",
+ "thiserror",
+ "tokio",
+ "zbus",
+ "zerocopy",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,7 +1389,7 @@ dependencies = [
  "num-integer",
  "num-rational",
  "option-operations",
- "pastey 0.2.2",
+ "pastey",
  "pin-project-lite",
  "smallvec",
  "thiserror",
@@ -1513,6 +1461,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "gufo-common"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f23bc0d0e791259ce4fe703c4d988c64317e33477bc4d1d7526ab8eb9fcaab6"
+dependencies = [
+ "paste",
+ "serde",
+ "thiserror",
+ "zvariant",
+]
+
+[[package]]
+name = "gufo-exif"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad61fccc591119491879e7bee63ebbfbd27811b35367b4728a857119fde78843"
+dependencies = [
+ "gufo-common",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1510,7 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1824,46 +1796,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
- "moxcms",
- "num-traits",
- "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
- "zune-core 0.5.0",
- "zune-jpeg 0.5.5",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imgref"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
-
-[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,17 +1804,6 @@ dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
-]
-
-[[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1932,6 +1853,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,16 +1919,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lcms2"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75877b724685dd49310bdbadbf973fc69b1d01992a6d4a861b928fc3943f87b"
+dependencies = [
+ "bytemuck",
+ "foreign-types",
+ "lcms2-sys",
+]
+
+[[package]]
+name = "lcms2-sys"
+version = "4.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "264db0b78119c5a37d78bb41fb355daab29b3b29430b53cd92e3da51f0ab06cc"
+dependencies = [
+ "cc",
+ "dunce",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libadwaita"
@@ -2020,16 +1983,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
-dependencies = [
- "arbitrary",
- "cc",
-]
 
 [[package]]
 name = "libloading"
@@ -2077,6 +2030,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libseccomp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5310a2c5b6ffbc094b5f70a2ca7b79ed36ad90e6f90994b166489a1bce3fcc"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libseccomp-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libseccomp-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60276e2d41bbb68b323e566047a1bfbf952050b157d8b5cdc74c07c1bf4ca3b6"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,18 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2148,20 +2110,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2173,19 +2143,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2220,16 +2183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "mpris-server"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,26 +2202,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
+name = "nix"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "memchr",
- "minimal-lexical",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2277,27 +2220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2315,7 +2237,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2388,7 +2309,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aca39cf52b03268400c16eeb9b56382ea3c3353409309b63f5c8f0b1faf42754"
 dependencies = [
- "pastey 0.2.2",
+ "pastey",
 ]
 
 [[package]]
@@ -2462,12 +2383,6 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
@@ -2502,19 +2417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "png"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
-dependencies = [
- "bitflags 2.11.1",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "polling"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2436,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2580,49 +2491,6 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "profiling"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pxfm"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55f4fedc84ed39cb7a489322318976425e42a147e2be79d8f878e2884f94e84"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2756,56 +2624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec 0.6.4",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.14.0",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.4",
- "rand_chacha",
- "simd_helpers",
- "thiserror",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
-]
-
-[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,12 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rgb"
-version = "0.8.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,6 +2744,25 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -3194,21 +3025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3391,20 +3207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg 0.4.21",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,6 +3245,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.1",
 ]
 
@@ -3464,6 +3267,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3661,10 +3475,10 @@ dependencies = [
  "gdk4-x11",
  "gettext-rs",
  "glow",
+ "glycin",
  "gstreamer",
  "gtk4",
  "hostname",
- "image",
  "itertools 0.15.0",
  "libadwaita",
  "libc",
@@ -3674,7 +3488,6 @@ dependencies = [
  "mpris-server",
  "once_cell",
  "rand 0.10.1",
- "rayon",
  "regex",
  "reqwest",
  "serde",
@@ -3751,17 +3564,6 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "v_frame"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
-dependencies = [
- "aligned-vec 0.5.0",
- "num-traits",
  "wasm-bindgen",
 ]
 
@@ -4018,12 +3820,6 @@ checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "winapi"
@@ -4498,10 +4294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
-name = "y4m"
-version = "0.8.0"
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "yoke"
@@ -4552,6 +4353,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -4673,45 +4475,6 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fb7703e32e9a07fb3f757360338b3a567a5054f21b5f52a666752e333d58e"
-dependencies = [
- "zune-core 0.5.0",
-]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ atomic-wait = "1.1.0"
 flume = "0.12.0"
 derive_builder = "0.20.2"
 anyhow = "1.0"
-tracing-subscriber = { version = "0.3", features = ["chrono"] }
+tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter"] }
 regex = "1.12.3"
 strsim = "0.11.1"
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 gst = { version = "0.25", package = "gstreamer" }
 url = "2.5.8"
-image = "0.25"
-rayon = "1.12.0"
 gettext-rs = { version = "~0.7", features = ["gettext-system"] }
 hostname = "0.4.2"
 epoxy = "0.1.0"
@@ -57,6 +55,7 @@ xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 futures-util = "0.3.31"
 itertools = "0.15.0"
 moka = { version = "0.12.15", features = ["future"] }
+glycin = { version = "3.1.0", default-features = false, features = ["gdk4", "tokio"] }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -9,9 +9,11 @@ use clap::Parser;
 use tracing::{
     error,
     info,
-    level_filters::LevelFilter,
 };
-use tracing_subscriber::fmt::time::ChronoLocal;
+use tracing_subscriber::{
+    EnvFilter,
+    fmt::time::ChronoLocal,
+};
 
 use crate::dyn_event;
 
@@ -48,16 +50,14 @@ impl Args {
     ///
     /// Panics if the log file cannot be opened.
     fn init_tracing_subscriber(&self) {
-        let builder = tracing_subscriber::fmt().with_timer(ChronoLocal::rfc_3339());
-
-        let builder = match self.log_level.as_deref() {
-            Some("error") => builder.with_max_level(LevelFilter::ERROR),
-            Some("warn") => builder.with_max_level(LevelFilter::WARN),
-            Some("info") => builder.with_max_level(LevelFilter::INFO),
-            Some("debug") => builder.with_max_level(LevelFilter::DEBUG),
-            Some("trace") => builder.with_max_level(LevelFilter::TRACE),
-            _ => builder.with_max_level(LevelFilter::INFO),
+        let level = match self.log_level.as_deref() {
+            Some(level) if ["error", "warn", "info", "debug", "trace"].contains(&level) => level,
+            _ => "info",
         };
+        let filter = EnvFilter::builder().parse_lossy(format!("{level},glycin=error"));
+        let builder = tracing_subscriber::fmt()
+            .with_timer(ChronoLocal::rfc_3339())
+            .with_env_filter(filter);
 
         match &self.log_file {
             None => builder.with_writer(io::stderr).init(),

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -675,8 +675,10 @@ impl JellyfinClient {
 
         match self.image_request(id, image_type, tag, etag).await {
             Ok(response) => {
-                if response.status().is_redirection() {
+                if response.status() == reqwest::StatusCode::NOT_MODIFIED {
                     return Ok(path.to_string_lossy().to_string());
+                } else if response.status() == reqwest::StatusCode::NOT_FOUND {
+                    return Ok(String::new());
                 } else if !response.status().is_success() {
                     return Err(anyhow!("Failed to get image: {}", response.status()));
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,10 @@ pub use ui::Window;
 
 pub use app::TsukimiApplication as Application;
 
-use crate::ui::widgets;
+use crate::{
+    client::runtime::runtime,
+    ui::widgets,
+};
 
 pub static USER_AGENT: LazyLock<String> =
     LazyLock::new(|| format!("{}/{} - {}", CLIENT_ID, version(), env::consts::OS));
@@ -65,6 +68,7 @@ pub fn run() -> gtk::glib::ExitCode {
     // Initialize the GTK application
     gtk::glib::set_application_name(CLIENT_ID);
 
+    let _tokio_guard = runtime().enter();
     Application::new().run_with_args::<&str>(&[])
 }
 

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -767,10 +767,6 @@ impl TuItem {
         self.rating()
     }
 
-    pub fn need_animated_picture(&self) -> bool {
-        matches!(self.item_type().as_str(), COLLECTION_FOLDER)
-    }
-
     pub fn can_direct_play(&self) -> bool {
         matches!(self.item_type().as_str(), MOVIE | EPISODE) && self.is_resume()
     }

--- a/src/ui/widgets/content_viewer.rs
+++ b/src/ui/widgets/content_viewer.rs
@@ -10,7 +10,7 @@ use gtk::{
 };
 use tracing::warn;
 
-use super::image_paintable::ImagePaintable;
+use super::image_paintable::paintable_from_file;
 use crate::utils::spawn;
 
 mod imp {
@@ -150,17 +150,13 @@ impl MediaContentViewer {
     }
 
     async fn view_file_inner(&self, file: gio::File) {
-        match ImagePaintable::from_file(&file) {
-            Ok(texture) => {
-                self.view_image(&texture);
-                return;
-            }
+        match paintable_from_file(file, None).await {
+            Ok(paintable) => self.view_image(&paintable),
             Err(error) => {
-                warn!("Could not load GdkTexture from file: {error}");
+                warn!("Could not load image with glycin: {error}");
+                self.show_fallback();
             }
         }
-
-        self.show_fallback();
     }
 
     /// Get the texture displayed by this widget, if any.

--- a/src/ui/widgets/image_dialog/image_infocard.rs
+++ b/src/ui/widgets/image_dialog/image_infocard.rs
@@ -12,7 +12,10 @@ use crate::{
     client::jellyfin_client::JELLYFIN_CLIENT,
     ui::{
         GlobalToast,
-        widgets::window::Window,
+        widgets::{
+            image_paintable::paintable_from_file,
+            window::Window,
+        },
     },
     utils::spawn_tokio,
 };
@@ -235,40 +238,13 @@ impl ImageInfoCard {
 
         let picture = self.imp().picture.get();
 
-        gio::File::for_uri(&path).read_async(
-            glib::Priority::LOW,
-            None::<&gio::Cancellable>,
-            glib::clone!(
-                #[weak(rename_to = obj)]
-                self,
-                move |res| {
-                    if let Ok(stream) = res {
-                        gtk::gdk_pixbuf::Pixbuf::from_stream_async(
-                            &stream,
-                            None::<&gio::Cancellable>,
-                            move |r| match r {
-                                Ok(pixbuf) => {
-                                    #[allow(deprecated)]
-                                    // FIXME: `Texture::for_pixbuf` is deprecated since GTK 4.20.
-                                    // GTK recommends libglycin for loading images into `GdkTexture`, but
-                                    // glycin currently only works on Linux, so keep this fallback for now.
-                                    // https://docs.gtk.org/gdk4/ctor.Texture.new_for_pixbuf.html
-                                    // https://docs.rs/crate/glycin/latest
-                                    picture.set_paintable(Some(&gtk::gdk::Texture::for_pixbuf(
-                                        &pixbuf,
-                                    )));
-                                    obj.set_picture_visible();
-                                }
-                                Err(_) => {
-                                    obj.toast(gettext("Error loading image"));
-                                    obj.set_fallback_visible();
-                                }
-                            },
-                        );
-                    }
-                }
-            ),
-        );
+        if let Ok(paintable) = paintable_from_file(gio::File::for_uri(&path), None).await {
+            picture.set_paintable(Some(&paintable));
+            self.set_picture_visible();
+        } else {
+            self.toast(gettext("Error loading image"));
+            self.set_fallback_visible();
+        }
     }
 
     pub fn set_picture_visible(&self) {

--- a/src/ui/widgets/image_paintable.rs
+++ b/src/ui/widgets/image_paintable.rs
@@ -3,7 +3,10 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Result;
+use anyhow::{
+    Result,
+    bail,
+};
 use gtk::{
     gdk,
     gio,
@@ -113,7 +116,7 @@ pub async fn paintable_from_file(
     file: gio::File, cancellable: Option<gio::Cancellable>,
 ) -> Result<gdk::Paintable> {
     if cancellable.as_ref().is_some_and(|c| c.is_cancelled()) {
-        anyhow::bail!("image load cancelled");
+        bail!("image load cancelled");
     }
 
     let mut loader = glycin::Loader::new(file);

--- a/src/ui/widgets/image_paintable.rs
+++ b/src/ui/widgets/image_paintable.rs
@@ -1,15 +1,9 @@
 use std::{
-    io::{
-        BufRead,
-        BufReader,
-        Cursor,
-        Error as IoError,
-        ErrorKind,
-        Seek,
-    },
+    rc::Rc,
     time::Duration,
 };
 
+use anyhow::Result;
 use gtk::{
     gdk,
     gio,
@@ -18,62 +12,25 @@ use gtk::{
     prelude::*,
     subclass::prelude::*,
 };
-use image::{
-    AnimationDecoder,
-    DynamicImage,
-    ImageFormat,
-    ImageReader,
-    codecs::{
-        gif::GifDecoder,
-        png::PngDecoder,
-        webp::WebPDecoder,
-    },
-    flat::SampleLayout,
-};
-use tracing::error;
+use tracing::warn;
 
-/// A single frame of an animation.
-pub struct Frame {
-    texture: gdk::Texture,
-    duration: Duration,
-}
+use crate::utils::spawn;
 
-pub struct DecodedPaintable {
-    frames: Vec<Frame>,
-}
+const DEFAULT_ANIMATION_FRAME_DELAY: Duration = Duration::from_millis(100);
 
 mod imp {
-    use std::{
-        cell::{
-            Cell,
-            RefCell,
-        },
-        marker::PhantomData,
-    };
+    use std::cell::RefCell;
 
     use super::*;
 
-    #[derive(Default, glib::Properties)]
-    #[properties(wrapper_type = super::ImagePaintable)]
+    #[derive(Default)]
     pub struct ImagePaintable {
-        /// The frames of the animation, if any.
-        pub frames: RefCell<Option<Vec<Frame>>>,
-        /// The image if this is not an animation, otherwise this is the next
-        /// frame to display.
+        /// Glycin image handle used to asynchronously request subsequent animation frames.
+        pub image: RefCell<Option<Rc<glycin::Image>>>,
+        /// The currently displayed frame.
         pub frame: RefCell<Option<gdk::Texture>>,
-        /// The current index in the animation.
-        pub current_idx: Cell<usize>,
         /// The source ID of the timeout to load the next frame, if any.
         pub timeout_source_id: RefCell<Option<glib::SourceId>>,
-        /// Whether this image is an animation.
-        #[property(get = Self::is_animation)]
-        pub is_animation: PhantomData<bool>,
-        /// The width of this image.
-        #[property(get = Self::intrinsic_width, default = -1)]
-        pub width: PhantomData<i32>,
-        /// The height of this image.
-        #[property(get = Self::intrinsic_height, default = -1)]
-        pub height: PhantomData<i32>,
     }
 
     #[glib::object_subclass]
@@ -83,12 +40,13 @@ mod imp {
         type Interfaces = (gdk::Paintable,);
     }
 
-    #[glib::derived_properties]
     impl ObjectImpl for ImagePaintable {
         fn dispose(&self) {
             if let Some(source_id) = self.timeout_source_id.borrow_mut().take() {
                 source_id.remove();
             }
+            self.image.borrow_mut().take();
+            self.frame.borrow_mut().take();
         }
     }
 
@@ -122,11 +80,7 @@ mod imp {
         }
 
         fn flags(&self) -> gdk::PaintableFlags {
-            if self.obj().is_animation() {
-                gdk::PaintableFlags::STATIC_SIZE
-            } else {
-                gdk::PaintableFlags::STATIC_SIZE | gdk::PaintableFlags::STATIC_CONTENTS
-            }
+            gdk::PaintableFlags::STATIC_SIZE
         }
 
         fn current_image(&self) -> gdk::Paintable {
@@ -143,322 +97,92 @@ mod imp {
                 .expect("there should be a fallback paintable")
         }
     }
-
-    impl ImagePaintable {
-        /// Whether this image is an animation.
-        fn is_animation(&self) -> bool {
-            self.frames.borrow().is_some()
-        }
-    }
 }
 
 glib::wrapper! {
-    /// A paintable that loads images with the `image` crate.
+    /// A paintable that displays an animated image decoded by glycin.
     ///
-    /// It handles more image types than GDK-Pixbuf and can also handle
-    /// animations from GIF and APNG files.
+    /// `gtk::Picture` displays paintables but does not drive animation itself;
+    /// this object owns the animation timer, requests the next glycin frame, and
+    /// invalidates its contents when the current frame changes.
     pub struct ImagePaintable(ObjectSubclass<imp::ImagePaintable>)
         @implements gdk::Paintable;
 }
 
-impl ImagePaintable {
-    pub fn decode_bytes(
-        bytes: glib::Bytes,
-    ) -> Result<DecodedPaintable, Box<dyn std::error::Error + Send + Sync>> {
-        let reader = Cursor::new(bytes);
-        let reader = ImageReader::new(reader).with_guessed_format()?;
-        Self::decode_reader(reader)
+pub async fn paintable_from_file(
+    file: gio::File, cancellable: Option<gio::Cancellable>,
+) -> Result<gdk::Paintable> {
+    if cancellable.as_ref().is_some_and(|c| c.is_cancelled()) {
+        anyhow::bail!("image load cancelled");
     }
 
-    pub fn from_decoded(decoded: DecodedPaintable) -> Self {
+    let mut loader = glycin::Loader::new(file);
+    if let Some(cancellable) = cancellable {
+        loader.cancellable(cancellable);
+    }
+
+    let image = loader.load().await?;
+    let frame = image.next_frame().await?;
+
+    if frame.delay().is_some() {
+        Ok(ImagePaintable::new(image, frame).upcast())
+    } else {
+        Ok(frame.texture().upcast())
+    }
+}
+
+impl ImagePaintable {
+    fn new(image: glycin::Image, frame: glycin::Frame) -> Self {
         let obj = glib::Object::new::<Self>();
-        obj.load_decoded(decoded);
+        obj.imp().image.replace(Some(Rc::new(image)));
+        obj.set_frame(frame);
         obj
     }
 
-    fn decode_reader<R: BufRead + Seek>(
-        reader: ImageReader<R>,
-    ) -> Result<DecodedPaintable, Box<dyn std::error::Error + Send + Sync>> {
-        let format = reader
-            .format()
-            .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "Could not detect image format"))?;
-
-        let read = reader.into_inner();
-        let frames = match format {
-            image::ImageFormat::Gif => {
-                let decoder = GifDecoder::new(read)?;
-                decoder
-                    .into_frames()
-                    .collect_frames()?
-                    .into_iter()
-                    .map(Frame::from)
-                    .collect()
-            }
-            image::ImageFormat::Png => {
-                let decoder = PngDecoder::new(read)?;
-                if decoder.is_apng().unwrap_or_default() {
-                    decoder
-                        .apng()?
-                        .into_frames()
-                        .collect_frames()?
-                        .into_iter()
-                        .map(Frame::from)
-                        .collect()
-                } else {
-                    vec![Frame::from(DynamicImage::from_decoder(decoder)?)]
-                }
-            }
-            image::ImageFormat::WebP => {
-                let decoder = WebPDecoder::new(read)?;
-                if decoder.has_animation() {
-                    decoder
-                        .into_frames()
-                        .collect_frames()?
-                        .into_iter()
-                        .map(Frame::from)
-                        .collect()
-                } else {
-                    vec![Frame::from(DynamicImage::from_decoder(decoder)?)]
-                }
-            }
-            _ => vec![Frame::from(image::load(read, format)?)],
-        };
-
-        Ok(DecodedPaintable { frames })
-    }
-
-    /// Load an image from the given reader in the optional format.
-    ///
-    /// The actual format will try to be guessed from the content.
-    pub fn new<R: BufRead + Seek>(
-        reader: R, format: Option<ImageFormat>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let obj = glib::Object::new::<Self>();
-
-        let mut reader = image::ImageReader::new(reader);
-
-        if let Some(format) = format {
-            reader.set_format(format);
-        }
-
-        let reader = reader.with_guessed_format()?;
-
-        let decoded =
-            Self::decode_reader(reader).map_err(|error| -> Box<dyn std::error::Error> { error })?;
-        obj.load_decoded(decoded);
-
-        Ok(obj)
-    }
-
-    fn load_decoded(&self, decoded: DecodedPaintable) {
-        let imp = self.imp();
-        let frames = decoded.frames;
-
-        if frames.len() == 1 {
-            if let Some(frame) = frames.into_iter().next() {
-                imp.frame.replace(Some(frame.texture));
-            }
-        } else {
-            imp.frames.replace(Some(frames));
-            self.update_frame();
-        }
-    }
-
-    /// Creates a new paintable by loading an image from the given file.
-    pub fn from_file(file: &gio::File) -> Result<Self, Box<dyn std::error::Error>> {
-        let stream = file.read(gio::Cancellable::NONE)?;
-        let reader = BufReader::new(stream.into_read());
-        let format = file
-            .path()
-            .and_then(|path| ImageFormat::from_path(path).ok());
-
-        Self::new(reader, format)
-    }
-
-    /// Creates a new paintable by loading an image from memory.
-    pub fn from_bytes(
-        bytes: &[u8], content_type: Option<&str>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let reader = Cursor::new(bytes);
-        let format = content_type.and_then(ImageFormat::from_mime_type);
-
-        Self::new(reader, format)
-    }
-
-    /// Update the current frame of the animation.
-    fn update_frame(&self) {
-        let imp = self.imp();
-        let frames_ref = imp.frames.borrow();
-
-        // If it's not an animation, we return early.
-        let frames = match &*frames_ref {
-            Some(frames) => frames,
-            None => return,
-        };
-
-        let idx = imp.current_idx.get();
-        let next_frame = frames.get(idx).unwrap();
-        imp.frame.replace(Some(next_frame.texture.to_owned()));
-
-        // Invalidate the contents so that the new frame will be rendered.
+    fn set_frame(&self, frame: glycin::Frame) {
+        let delay = frame
+            .delay()
+            .filter(|d| !d.is_zero())
+            .unwrap_or(DEFAULT_ANIMATION_FRAME_DELAY);
+        self.imp().frame.replace(Some(frame.texture()));
         self.invalidate_contents();
+        self.schedule_next_frame(delay);
+    }
 
-        // Update the frame when the duration is elapsed.
-        let update_frame_callback = glib::clone!(
+    fn schedule_next_frame(&self, delay: Duration) {
+        let imp = self.imp();
+        if let Some(source_id) = imp.timeout_source_id.borrow_mut().take() {
+            source_id.remove();
+        }
+
+        let source_id = glib::timeout_add_local_once(
+            delay,
+            glib::clone!(
+                #[weak(rename_to = obj)]
+                self,
+                move || {
+                    obj.imp().timeout_source_id.borrow_mut().take();
+                    obj.load_next_frame();
+                }
+            ),
+        );
+        imp.timeout_source_id.replace(Some(source_id));
+    }
+
+    fn load_next_frame(&self) {
+        let Some(image) = self.imp().image.borrow().as_ref().cloned() else {
+            return;
+        };
+
+        spawn(glib::clone!(
             #[weak(rename_to = obj)]
             self,
-            move || {
-                obj.imp().timeout_source_id.take();
-                obj.update_frame();
+            async move {
+                match image.next_frame().await {
+                    Ok(frame) => obj.set_frame(frame),
+                    Err(error) => warn!("Failed to load animated image frame with glycin: {error}"),
+                }
             }
-        );
-        let source_id = glib::timeout_add_local_once(next_frame.duration, update_frame_callback);
-        imp.timeout_source_id.replace(Some(source_id));
-
-        // Update the index for the next call.
-        let mut new_idx = idx + 1;
-        if new_idx >= frames.len() {
-            new_idx = 0;
-        }
-        imp.current_idx.set(new_idx);
+        ));
     }
-
-    /// Get the current frame of this `ImagePaintable`, if any.
-    pub fn current_frame(&self) -> Option<gdk::Texture> {
-        self.imp().frame.borrow().to_owned()
-    }
-}
-
-impl From<image::Frame> for Frame {
-    fn from(frame: image::Frame) -> Self {
-        let mut duration = Duration::from(frame.delay());
-
-        if duration.is_zero() {
-            duration = Duration::from_millis(100);
-        }
-
-        let sample = frame.into_buffer().into_flat_samples();
-        Self {
-            texture: texture_from_data(
-                &sample.samples,
-                sample.layout,
-                gdk::MemoryFormat::R8g8b8a8,
-                image::ColorType::Rgba8.bytes_per_pixel(),
-            )
-            .upcast(),
-            duration,
-        }
-    }
-}
-
-impl From<DynamicImage> for Frame {
-    fn from(image: DynamicImage) -> Self {
-        let texture = match image.color() {
-            image::ColorType::L8 | image::ColorType::Rgb8 => {
-                let sample = image.into_rgb8().into_flat_samples();
-                texture_from_data(
-                    &sample.samples,
-                    sample.layout,
-                    gdk::MemoryFormat::R8g8b8,
-                    image::ColorType::Rgb8.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::La8 | image::ColorType::Rgba8 => {
-                let sample = image.into_rgba8().into_flat_samples();
-                texture_from_data(
-                    &sample.samples,
-                    sample.layout,
-                    gdk::MemoryFormat::R8g8b8a8,
-                    image::ColorType::Rgba8.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::L16 | image::ColorType::Rgb16 => {
-                let sample = image.into_rgb16().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R16g16b16,
-                    image::ColorType::Rgb16.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::La16 | image::ColorType::Rgba16 => {
-                let sample = image.into_rgba16().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R16g16b16a16,
-                    image::ColorType::Rgba16.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::Rgb32F => {
-                let sample = image.into_rgb32f().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R32g32b32Float,
-                    image::ColorType::Rgb32F.bytes_per_pixel(),
-                )
-            }
-            image::ColorType::Rgba32F => {
-                let sample = image.into_rgba32f().into_flat_samples();
-                let bytes = sample
-                    .samples
-                    .into_iter()
-                    .flat_map(|b| b.to_ne_bytes())
-                    .collect::<Vec<_>>();
-                texture_from_data(
-                    &bytes,
-                    sample.layout,
-                    gdk::MemoryFormat::R32g32b32a32Float,
-                    image::ColorType::Rgba32F.bytes_per_pixel(),
-                )
-            }
-            color => {
-                error!("Received image of unsupported color format: {color:?}");
-                let sample = image.into_rgba8().into_flat_samples();
-                texture_from_data(
-                    &sample.samples,
-                    sample.layout,
-                    gdk::MemoryFormat::R8g8b8a8,
-                    image::ColorType::Rgba8.bytes_per_pixel(),
-                )
-            }
-        };
-
-        Self {
-            texture: texture.upcast(),
-            duration: Duration::ZERO,
-        }
-    }
-}
-
-fn texture_from_data(
-    bytes: &[u8], layout: SampleLayout, format: gdk::MemoryFormat, bpp: u8,
-) -> gdk::MemoryTexture {
-    let bytes = glib::Bytes::from(bytes);
-
-    let stride = layout.width * bpp as u32;
-
-    gdk::MemoryTexture::new(
-        layout.width as i32,
-        layout.height as i32,
-        format,
-        &bytes,
-        stride as usize,
-    )
 }

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -116,8 +116,14 @@ pub(crate) mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
-            let obj = self.obj();
-            obj.load_source(obj.image_source());
+            // Wait until builder properties are applied before reading the image source
+            glib::idle_add_local_once(glib::clone!(
+                #[weak(rename_to = obj)]
+                self.obj(),
+                move || {
+                    obj.load_source(obj.image_source());
+                }
+            ));
         }
 
         fn dispose(&self) {

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::LazyLock,
+};
 
 use super::{
     image_paintable::paintable_from_file,
@@ -32,6 +35,13 @@ use gtk::{
 use tracing::warn;
 
 const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
+static IMAGE_LOAD_SEMAPHORE: LazyLock<tokio::sync::Semaphore> = LazyLock::new(|| {
+    tokio::sync::Semaphore::new(
+        std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(4),
+    )
+});
 
 #[derive(Clone)]
 struct LoadToken {
@@ -274,6 +284,7 @@ impl PictureLoader {
     }
 
     async fn load_file(file: gio::File, load_token: &LoadToken) -> Result<gdk::Paintable> {
+        let _permit = IMAGE_LOAD_SEMAPHORE.acquire().await?;
         paintable_from_file(file, Some(load_token.cancellable.clone())).await
     }
 

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -1,36 +1,7 @@
-use std::{
-    path::PathBuf,
-    sync::{
-        LazyLock,
-        atomic::{
-            AtomicUsize,
-            Ordering,
-        },
-    },
-};
-
-use adw::{
-    prelude::*,
-    subclass::prelude::*,
-};
-use gtk::{
-    CompositeTemplate,
-    gio,
-    glib::{
-        self,
-        clone,
-    },
-};
-use tracing::{
-    debug,
-    warn,
-};
+use std::path::PathBuf;
 
 use super::{
-    image_paintable::{
-        DecodedPaintable,
-        ImagePaintable,
-    },
+    image_paintable::paintable_from_file,
     utils::{
         TU_ITEM_POST_SIZE,
         TU_ITEM_VIDEO_SIZE,
@@ -44,42 +15,51 @@ use crate::{
         spawn_tokio,
     },
 };
+use adw::{
+    prelude::*,
+    subclass::prelude::*,
+};
+use anyhow::{
+    Result,
+    bail,
+};
+use gtk::{
+    CompositeTemplate,
+    gdk,
+    gio,
+    glib,
+};
+use tracing::warn;
 
 const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
-const IMAGE_DECODE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(120);
-static MAX_IMAGE_DECODE_TASKS: LazyLock<usize> = LazyLock::new(rayon::current_num_threads);
-static IMAGE_DECODE_TASKS: AtomicUsize = AtomicUsize::new(0);
 
-enum LoadedImage {
-    Texture(gtk::gdk::Texture),
-    Decoded(DecodedPaintable),
+#[derive(Clone)]
+struct LoadToken {
+    cancellable: gio::Cancellable,
+    generation: u64,
 }
 
-struct DecodePermit;
+impl LoadToken {
+    fn is_cancelled(&self) -> bool {
+        self.cancellable.is_cancelled()
+    }
 
-impl Drop for DecodePermit {
-    fn drop(&mut self) {
-        IMAGE_DECODE_TASKS.fetch_sub(1, Ordering::Release);
+    fn is_current_for(&self, loader: &PictureLoader) -> bool {
+        !self.is_cancelled() && loader.imp().generation.get() == self.generation
     }
 }
 
-fn try_acquire_decode_permit() -> Option<DecodePermit> {
-    let mut current = IMAGE_DECODE_TASKS.load(Ordering::Relaxed);
-    loop {
-        if current >= *MAX_IMAGE_DECODE_TASKS {
-            return None;
-        }
-
-        match IMAGE_DECODE_TASKS.compare_exchange_weak(
-            current,
-            current + 1,
-            Ordering::Acquire,
-            Ordering::Relaxed,
-        ) {
-            Ok(_) => return Some(DecodePermit),
-            Err(next) => current = next,
-        }
-    }
+#[derive(Clone)]
+enum ImageSource {
+    Item {
+        id: String,
+        image_type: String,
+        tag: Option<String>,
+    },
+    Url {
+        image_type: String,
+        url: String,
+    },
 }
 
 pub(crate) mod imp {
@@ -112,8 +92,6 @@ pub(crate) mod imp {
         pub spinner: TemplateChild<adw::Spinner>,
         #[template_child]
         pub broken: TemplateChild<gtk::Box>,
-        #[property(get, set, default = false)]
-        pub animated: Cell<bool>,
         pub cancellable: RefCell<Option<gio::Cancellable>>,
         pub generation: Cell<u64>,
     }
@@ -139,16 +117,11 @@ pub(crate) mod imp {
             self.parent_constructed();
 
             let obj = self.obj();
-
-            if let Some(url) = obj.url() {
-                obj.start_url_loading(url);
-            } else {
-                obj.start_loading();
-            }
+            obj.load_source(obj.image_source());
         }
 
         fn dispose(&self) {
-            self.obj().cancel_loading();
+            self.obj().cancel_current_request();
         }
     }
 
@@ -170,15 +143,6 @@ impl PictureLoader {
             .build()
     }
 
-    pub fn new_animated(id: &str, image_type: &str, tag: Option<String>) -> Self {
-        glib::Object::builder()
-            .property("id", id)
-            .property("imagetype", image_type)
-            .property("tag", tag)
-            .property("animated", true)
-            .build()
-    }
-
     pub fn new_for_url(image_type: &str, url: &str) -> Self {
         glib::Object::builder()
             .property("id", "")
@@ -187,23 +151,26 @@ impl PictureLoader {
             .build()
     }
 
-    pub fn reload(&self, id: &str, image_type: &str, tag: Option<String>, animated: bool) {
-        self.reset();
+    pub fn reload(&self, id: &str, image_type: &str, tag: Option<String>) {
+        self.reset_view();
         self.set_id(id);
         self.set_imagetype(image_type);
         self.set_tag(tag);
         self.set_url(None::<String>);
-        self.set_animated(animated);
-        self.start_loading();
+        self.load_source(self.image_source());
     }
 
     pub fn reset(&self) {
-        self.cancel_loading();
+        self.cancel_current_request();
+        self.reset_view();
+    }
+
+    fn reset_view(&self) {
         let imp = self.imp();
         imp.revealer.set_reveal_child(false);
         imp.broken.set_visible(false);
         imp.spinner.set_visible(true);
-        imp.picture.set_paintable(None::<&gtk::gdk::Paintable>);
+        imp.picture.set_paintable(None::<&gdk::Paintable>);
     }
 
     pub fn reset_in(widget: &gtk::Widget) {
@@ -219,312 +186,148 @@ impl PictureLoader {
         }
     }
 
-    fn start_loading(&self) {
-        let (cancellable, generation) = self.new_request();
-        spawn(clone!(
-            #[weak(rename_to = obj)]
-            self,
-            #[strong]
-            cancellable,
-            async move {
-                glib::timeout_future(IMAGE_LOAD_DELAY).await;
-                if !obj.is_current(&cancellable, generation) {
-                    return;
-                }
-                obj.load_pic(cancellable, generation).await;
-            }
-        ));
-    }
-
-    fn start_url_loading(&self, url: String) {
-        let (cancellable, generation) = self.new_request();
-        self.load_pic_for_url(url, cancellable, generation);
-    }
-
-    fn new_request(&self) -> (gio::Cancellable, u64) {
-        if let Some(cancellable) = self.imp().cancellable.borrow_mut().take() {
-            cancellable.cancel();
+    fn load_source(&self, source: ImageSource) {
+        let load_token = self.new_request();
+        if let ImageSource::Url { image_type, .. } = &source {
+            self.configure_picture_size(image_type);
         }
-
-        let generation = self.imp().generation.get().wrapping_add(1);
-        self.imp().generation.set(generation);
-
-        let cancellable = gio::Cancellable::new();
-        self.imp().cancellable.replace(Some(cancellable.clone()));
-        (cancellable, generation)
-    }
-
-    pub fn cancel_loading(&self) {
-        if let Some(cancellable) = self.imp().cancellable.borrow_mut().take() {
-            cancellable.cancel();
-        }
-
-        let generation = self.imp().generation.get().wrapping_add(1);
-        self.imp().generation.set(generation);
-    }
-
-    fn is_current(&self, cancellable: &gio::Cancellable, generation: u64) -> bool {
-        !cancellable.is_cancelled() && self.imp().generation.get() == generation
-    }
-
-    // for EuListItem
-    pub fn load_pic_for_url(&self, url: String, cancellable: gio::Cancellable, generation: u64) {
-        let size = match self.imagetype().as_str() {
-            "Primary" => &TU_ITEM_POST_SIZE,
-            _ => &TU_ITEM_VIDEO_SIZE,
-        };
-
-        self.imp().picture.set_width_request(size.0);
-        self.imp().picture.set_height_request(size.1);
-        self.imp().picture.set_content_fit(gtk::ContentFit::Contain);
-
-        let file = gio::File::for_uri(&url);
-        self.load_file_bytes(file, None, cancellable, generation, false);
-    }
-
-    pub async fn load_pic(&self, cancellable: gio::Cancellable, generation: u64) {
-        if !self.is_current(&cancellable, generation) {
-            return;
-        }
-
-        let cache_file_path = self.cache_file().await;
-        self.reveal_picture(cache_file_path, cancellable, generation, true);
-    }
-
-    pub fn reveal_picture(
-        &self, cache_file_path: PathBuf, cancellable: gio::Cancellable, generation: u64,
-        fetch_on_error: bool,
-    ) {
-        let file = gio::File::for_path(&cache_file_path);
-        self.load_file_bytes(
-            file,
-            Some(cache_file_path),
-            cancellable,
-            generation,
-            fetch_on_error,
-        );
-    }
-
-    fn set_picture_visible(&self, cancellable: gio::Cancellable, generation: u64) {
-        if !self.is_current(&cancellable, generation) {
-            return;
-        }
-
-        let imp = self.imp();
-        imp.spinner.set_visible(false);
-        spawn(clone!(
-            #[weak]
-            imp,
-            #[strong]
-            cancellable,
-            async move {
-                if cancellable.is_cancelled() {
-                    return;
-                }
-                imp.revealer.set_reveal_child(true);
-            }
-        ));
-    }
-
-    fn set_broken(&self, cancellable: gio::Cancellable, generation: u64) {
-        if !self.is_current(&cancellable, generation) {
-            return;
-        }
-
-        let imp = self.imp();
-        imp.broken.set_visible(true);
-        imp.spinner.set_visible(false);
-        spawn(clone!(
-            #[weak]
-            imp,
-            #[strong]
-            cancellable,
-            async move {
-                if cancellable.is_cancelled() {
-                    return;
-                }
-                imp.revealer.set_reveal_child(true);
-            }
-        ));
-    }
-
-    fn load_file_bytes(
-        &self, file: gio::File, cache_file_path: Option<PathBuf>, cancellable: gio::Cancellable,
-        generation: u64, fetch_on_error: bool,
-    ) {
-        if !self.is_current(&cancellable, generation) {
-            return;
-        }
-
-        let weak_self: glib::SendWeakRef<Self> = self.downgrade().into();
-        let read_cancellable = cancellable.clone();
-        file.load_bytes_async(Some(&cancellable), move |res| {
-            let cancellable = read_cancellable;
-
-            if cancellable.is_cancelled() {
-                return;
-            }
-
-            let Ok((bytes, _etag)) = res else {
-                let weak_self = weak_self.into_weak_ref();
-                let Some(obj) = weak_self.upgrade() else {
-                    return;
-                };
-
-                if !obj.is_current(&cancellable, generation) {
-                    return;
-                }
-
-                if fetch_on_error {
-                    if let Some(path) = cache_file_path {
-                        obj.get_file(path, cancellable, generation);
-                    }
-                } else {
-                    obj.set_broken(cancellable, generation);
-                }
-                return;
-            };
-
-            let animated = {
-                let weak_self = weak_self.clone().into_weak_ref();
-                let Some(obj) = weak_self.upgrade() else {
-                    return;
-                };
-
-                if !obj.is_current(&cancellable, generation) {
-                    return;
-                }
-
-                obj.animated()
-            };
-
-            Self::try_spawn_decode(
-                weak_self,
-                bytes,
-                animated,
-                cache_file_path,
-                cancellable,
-                generation,
-                fetch_on_error,
-            );
-        });
-    }
-
-    fn try_spawn_decode(
-        weak_self: glib::SendWeakRef<Self>, bytes: glib::Bytes, animated: bool,
-        cache_file_path: Option<PathBuf>, cancellable: gio::Cancellable, generation: u64,
-        fetch_on_error: bool,
-    ) {
-        let Some(decode_permit) = try_acquire_decode_permit() else {
-            glib::timeout_add_local_once(IMAGE_DECODE_RETRY_DELAY, move || {
-                let weak_ref = weak_self.clone().into_weak_ref();
-                let Some(obj) = weak_ref.upgrade() else {
-                    return;
-                };
-                if obj.is_current(&cancellable, generation) {
-                    Self::try_spawn_decode(
-                        weak_self,
-                        bytes,
-                        animated,
-                        cache_file_path,
-                        cancellable,
-                        generation,
-                        fetch_on_error,
-                    );
-                }
-            });
-            return;
-        };
-
-        rayon::spawn(move || {
-            let decoded = Self::decode_bytes(bytes, animated);
-            drop(decode_permit);
-            glib::idle_add_once(move || {
-                let weak_self = weak_self.into_weak_ref();
-                let Some(obj) = weak_self.upgrade() else {
-                    return;
-                };
-
-                if !obj.is_current(&cancellable, generation) {
-                    return;
-                }
-
-                match decoded {
-                    Ok(LoadedImage::Texture(texture)) => {
-                        obj.imp().picture.set_paintable(Some(&texture));
-                        obj.set_picture_visible(cancellable, generation);
-                    }
-                    Ok(LoadedImage::Decoded(decoded)) => {
-                        let paintable = ImagePaintable::from_decoded(decoded);
-                        obj.imp().picture.set_paintable(Some(&paintable));
-                        obj.set_picture_visible(cancellable, generation);
-                    }
-                    Err(_) if fetch_on_error => {
-                        if let Some(path) = cache_file_path {
-                            obj.get_file(path, cancellable, generation);
-                        } else {
-                            obj.set_broken(cancellable, generation);
-                        }
-                    }
-                    Err(_) => obj.set_broken(cancellable, generation),
-                }
-            });
-        });
-    }
-
-    fn decode_bytes(
-        bytes: glib::Bytes, animated: bool,
-    ) -> Result<LoadedImage, Box<dyn std::error::Error + Send + Sync>> {
-        if animated {
-            return ImagePaintable::decode_bytes(bytes).map(LoadedImage::Decoded);
-        }
-
-        match gtk::gdk::Texture::from_bytes(&bytes) {
-            Ok(texture) => Ok(LoadedImage::Texture(texture)),
-            Err(_) => ImagePaintable::decode_bytes(bytes).map(LoadedImage::Decoded),
-        }
-    }
-
-    pub async fn cache_file(&self) -> PathBuf {
-        let cache_path = jellyfin_cache_path().await;
-        let path = format!(
-            "{}-{}-{}",
-            self.id(),
-            self.imagetype(),
-            self.tag().as_deref().unwrap_or("0")
-        );
-        cache_path.join(path)
-    }
-
-    pub fn get_file(&self, pathbuf: PathBuf, cancellable: gio::Cancellable, generation: u64) {
-        let id = self.id();
-        let image_type = self.imagetype();
-        let tag = self.tag();
         let weak_self = self.downgrade();
         spawn(async move {
-            if cancellable.is_cancelled() {
-                return;
-            }
-
-            spawn_tokio(async move {
-                let tag = tag.to_owned();
-                if let Err(e) = JELLYFIN_CLIENT
-                    .get_image(&id, &image_type, tag.and_then(|s| s.parse::<u8>().ok()))
-                    .await
-                {
-                    warn!("{}: {}-{}", e, id, image_type);
-                }
-            })
-            .await;
-
+            let paintable = Self::load_paintable(load_token.clone(), source).await;
             let Some(obj) = weak_self.upgrade() else {
                 return;
             };
-
-            if obj.is_current(&cancellable, generation) {
-                debug!("Setting image: {}", &pathbuf.display());
-                obj.reveal_picture(pathbuf, cancellable, generation, false);
+            if !load_token.is_current_for(&obj) {
+                return;
+            }
+            if let Ok(paintable) = paintable {
+                obj.show_paintable(&paintable, &load_token);
+            } else {
+                obj.show_broken(&load_token);
             }
         });
+    }
+
+    fn new_request(&self) -> LoadToken {
+        let generation = self.cancel_current_request();
+        let cancellable = gio::Cancellable::new();
+        self.imp().cancellable.replace(Some(cancellable.clone()));
+        LoadToken {
+            cancellable,
+            generation,
+        }
+    }
+
+    fn cancel_current_request(&self) -> u64 {
+        if let Some(cancellable) = self.imp().cancellable.borrow_mut().take() {
+            cancellable.cancel();
+        }
+        let generation = self.imp().generation.get().wrapping_add(1);
+        self.imp().generation.set(generation);
+        generation
+    }
+
+    fn configure_picture_size(&self, image_type: &str) {
+        let size = match image_type {
+            "Primary" => &TU_ITEM_POST_SIZE,
+            _ => &TU_ITEM_VIDEO_SIZE,
+        };
+        self.imp().picture.set_width_request(size.0);
+        self.imp().picture.set_height_request(size.1);
+        self.imp().picture.set_content_fit(gtk::ContentFit::Contain);
+    }
+
+    async fn load_paintable(load_token: LoadToken, source: ImageSource) -> Result<gdk::Paintable> {
+        match source {
+            ImageSource::Url { url, .. } => {
+                Self::load_file(gio::File::for_uri(&url), &load_token).await
+            }
+            ImageSource::Item {
+                id,
+                image_type,
+                tag,
+            } => {
+                glib::timeout_future(IMAGE_LOAD_DELAY).await;
+                if load_token.is_cancelled() {
+                    bail!("image load cancelled");
+                }
+                let cache_path = Self::cache_file(&id, &image_type, tag.as_deref()).await;
+                let file = gio::File::for_path(&cache_path);
+
+                if let Ok(paintable) = Self::load_file(file.clone(), &load_token).await {
+                    Ok(paintable)
+                } else {
+                    Self::download_image(&id, &image_type, tag.as_deref()).await;
+                    if load_token.is_cancelled() {
+                        bail!("image load cancelled");
+                    }
+                    Self::load_file(file, &load_token).await
+                }
+            }
+        }
+    }
+
+    async fn load_file(file: gio::File, load_token: &LoadToken) -> Result<gdk::Paintable> {
+        paintable_from_file(file, Some(load_token.cancellable.clone())).await
+    }
+
+    async fn cache_file(id: &str, image_type: &str, tag: Option<&str>) -> PathBuf {
+        let cache_path = jellyfin_cache_path().await;
+        let path = format!("{}-{}-{}", id, image_type, tag.unwrap_or("0"));
+        cache_path.join(path)
+    }
+
+    async fn download_image(id: &str, image_type: &str, tag: Option<&str>) {
+        let id = id.to_string();
+        let image_type = image_type.to_string();
+        let tag = tag.map(str::to_string);
+        let warn_id = id.clone();
+        let warn_image_type = image_type.clone();
+
+        let result = spawn_tokio(async move {
+            JELLYFIN_CLIENT
+                .get_image(&id, &image_type, tag.and_then(|s| s.parse::<u8>().ok()))
+                .await
+        })
+        .await;
+
+        if let Err(error) = result {
+            warn!("{}: {}-{}", error, warn_id, warn_image_type);
+        }
+    }
+
+    fn image_source(&self) -> ImageSource {
+        if let Some(url) = self.url() {
+            ImageSource::Url {
+                image_type: self.imagetype(),
+                url,
+            }
+        } else {
+            ImageSource::Item {
+                id: self.id(),
+                image_type: self.imagetype(),
+                tag: self.tag(),
+            }
+        }
+    }
+
+    fn show_paintable(&self, paintable: &gdk::Paintable, load_token: &LoadToken) {
+        if !load_token.is_current_for(self) {
+            return;
+        }
+        let imp = self.imp();
+        imp.picture.set_paintable(Some(paintable));
+        imp.spinner.set_visible(false);
+        imp.revealer.set_reveal_child(true);
+    }
+
+    fn show_broken(&self, load_token: &LoadToken) {
+        if !load_token.is_current_for(self) {
+            return;
+        }
+        let imp = self.imp();
+        imp.broken.set_visible(true);
+        imp.spinner.set_visible(false);
+        imp.revealer.set_reveal_child(true);
     }
 }

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -80,8 +80,6 @@ pub trait TuItemOverlayPrelude {
 
 pub trait TuItemOverlay: TuItemBasic + TuItemOverlayPrelude {
     fn set_picture(&self);
-
-    fn set_animated_picture(&self);
 }
 
 impl<T> TuItemOverlay for T
@@ -94,26 +92,11 @@ where
         let overlay = self.overlay();
 
         if let Some(picture_loader) = overlay.child().and_downcast::<PictureLoader>() {
-            picture_loader.reload(&id, image_type, tag, false);
+            picture_loader.reload(&id, image_type, tag);
             return;
         }
 
         let picture_loader = PictureLoader::new(&id, image_type, tag);
-        picture_loader.add_css_class("inbox");
-        overlay.set_child(Some(&picture_loader));
-    }
-
-    fn set_animated_picture(&self) {
-        let item = self.item();
-        let (image_type, tag, id) = self.get_image_type_and_tag(&item);
-        let overlay = self.overlay();
-
-        if let Some(picture_loader) = overlay.child().and_downcast::<PictureLoader>() {
-            picture_loader.reload(&id, image_type, tag, true);
-            return;
-        }
-
-        let picture_loader = PictureLoader::new_animated(&id, image_type, tag);
         picture_loader.add_css_class("inbox");
         overlay.set_child(Some(&picture_loader));
     }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -429,11 +429,7 @@ impl TuListItem {
         let imp = self.imp();
         let item = self.item();
 
-        if item.need_animated_picture() {
-            self.set_animated_picture()
-        } else {
-            self.set_picture()
-        };
+        self.set_picture();
 
         let (w, h) = self.size_hint();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,4 @@
-use std::{
-    future::Future,
-    path::PathBuf,
-};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use serde::{


### PR DESCRIPTION
This PR replaces Tsukimi’s image loading and decoding pipeline with a glycin-based implementation.

`glycin` is already used by [many GNOME-related applications](https://github.com/GNOME/glycin#software-using-glycin), and GTK’s documentation suggests libglycin for loading image formats into `GdkTexture`.

Because glycin supports animated images and provides an ergonomic async API, this refactor removes Tsukimi’s custom rayon-based multithreaded image decoding code, along with much of the custom animated-image handling. This significantly simplifies the related code paths.

The PR also refactors some of the more tangled surrounding code, which should make the image-loading logic easier to read and maintain.

One thing to note is that glycin may require additional runtime dependencies to work correctly. See [External Dependencies](https://docs.rs/glycin/latest/glycin/#external-dependencies) and [Usage and Packaging](https://github.com/GNOME/glycin#usage-and-packaging). Downstream packagers may need to coordinate the required packaging changes.