### PR TITLE
feat(mpv): Increase upper limit for cache size and time adjustments

### DIFF
--- a/resources/ui/mpv_control_sidebar.ui
+++ b/resources/ui/mpv_control_sidebar.ui
@@ -101,7 +101,7 @@
                     <property name="adjustment">
                       <object class="GtkAdjustment" id="cache_size_adj">
                         <property name="lower">50</property>
-                        <property name="upper">1000</property>
+                        <property name="upper">3000</property>
                         <property name="value">100</property>
                         <property name="page-increment">50</property>
                         <property name="step-increment">50</property>
@@ -117,7 +117,7 @@
                     <property name="adjustment">
                       <object class="GtkAdjustment" id="cache_time_adj">
                         <property name="lower">30</property>
-                        <property name="upper">1000</property>
+                        <property name="upper">3000</property>
                         <property name="value">300</property>
                         <property name="page-increment">30</property>
                         <property name="step-increment">30</property>


### PR DESCRIPTION
There is no obvious reason to limit the cache size and cache time to 1000. So slightly increase it.

MPV, according to the [code](https://github.com/mpv-player/mpv/blob/33111f3212ee272ac4a79fe284a7b55c9b5be997/demux/demux.c#L107), can handle a much bigger `demuxer-max-bytes` and `demuxer-readahead-secs`. 
Even though manual of MPV [suggested](https://mpv.io/manual/stable/#options-play-direction)that 
```
The demuxer cache ... If it's too large, implementation tradeoffs may cause general performance issues.
```
I couldn't find exactaly what 'implementation tradeoffs' it implies, so just set it to a slightly larger value but no too large to the point we drains user's memory or need `cache-on-disk`  (don't want to add new options to ui for this yet)


----
BTW, very sorry to hear tsukimi terminates support for windows