### PR TITLE
feat: persist mpv subtitle settings

### DIFF
--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -135,10 +135,6 @@
       <default>false</default>
       <summary>Auto Select Last Server</summary>
     </key>
-    <key name="mpv-subtitle-size" type="i">
-      <default>55</default>
-      <summary>MPV Subtitle Size</summary>
-    </key>
     <key name="mpv-audio-preferred-lang" type="i">
       <default>0</default>
       <summary>Preferred audio language</summary>
@@ -192,9 +188,63 @@
       <summary>Whether to show buffer speed label on left-top</summary>
       <default>true</default>
     </key>
+    <key name="mpv-subtitle-bold" type="b">
+      <summary>MPV subtitle bold</summary>
+      <default>false</default>
+    </key>
+    <key name="mpv-subtitle-italic" type="b">
+      <summary>MPV subtitle italic</summary>
+      <default>false</default>
+    </key>
+    <key name="mpv-subtitle-justify" type="i">
+      <summary>MPV subtitle text justification</summary>
+      <description>0: left, 1: center, 2: right</description>
+      <default>1</default>
+    </key>
+    <key name="mpv-subtitle-position" type="i">
+      <summary>MPV subtitle position</summary>
+      <default>100</default>
+    </key>
+    <key name="mpv-subtitle-size" type="i">
+      <default>55</default>
+      <summary>MPV Subtitle Size</summary>
+    </key>
+    <key type="d" name="mpv-subtitle-scale">
+      <summary>MPV subtitle scale</summary>
+      <default>1.0</default>
+    </key>
     <key name="mpv-subtitle-font" type="s">
       <summary>MPV subtitle font</summary>
       <default>""</default>
+    </key>
+    <key name="mpv-subtitle-border-style" type="i">
+      <summary>MPV subtitle border style</summary>
+      <description>0: outline and shadow, 1: opaque box, 2: background box</description>
+      <default>0</default>
+    </key>
+    <key name="mpv-subtitle-border-size" type="i">
+      <summary>MPV subtitle border size</summary>
+      <default>3</default>
+    </key>
+    <key name="mpv-subtitle-shadow-offset" type="i">
+      <summary>MPV subtitle shadow offset</summary>
+      <default>0</default>
+    </key>
+    <key name="mpv-subtitle-stretch-image-subs-to-screen" type="b">
+      <summary>Whether to stretch image subtitles to screen</summary>
+      <default>false</default>
+    </key>
+    <key name="mpv-subtitle-text-color" type="s">
+      <summary>MPV subtitle text color</summary>
+      <default>"rgb(255,255,255)"</default>
+    </key>
+    <key name="mpv-subtitle-border-color" type="s">
+      <summary>MPV subtitle border color</summary>
+      <default>"rgb(0,0,0)"</default>
+    </key>
+    <key name="mpv-subtitle-background-color" type="s">
+      <summary>MPV subtitle background color</summary>
+      <default>"rgba(0,0,0,0)"</default>
     </key>
     <key name="device-uuid" type="s">
       <summary>Device UUID</summary>
@@ -212,10 +262,6 @@
     <key type="s" name="accounts">
       <summary>List of the accounts</summary>
       <default>'[]'</default>
-    </key>
-    <key type="d" name="mpv-subtitle-scale">
-      <summary>MPV subtitle scale</summary>
-      <default>1.0</default>
     </key>
     <key type="d" name="danmaku-opacity">
       <summary>Danmaku opacity</summary>

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -41,8 +41,21 @@ impl Settings {
     const KEY_MPV_CONFIG: &'static str = "mpv-config";
     const KEY_MPV_CACHE_SIZE: &'static str = "mpv-cache-size";
     const KEY_MPV_CACHE_TIME: &'static str = "mpv-cache-time";
+    const KEY_MPV_SUBTITLE_BOLD: &'static str = "mpv-subtitle-bold"; // bool
+    const KEY_MPV_SUBTITLE_ITALIC: &'static str = "mpv-subtitle-italic"; // bool
+    const KEY_MPV_SUBTITLE_JUSTIFY: &'static str = "mpv-subtitle-justify"; // i32
+    const KEY_MPV_SUBTITLE_POSITION: &'static str = "mpv-subtitle-position"; // i32
     const KEY_MPV_SUBTITLE_SIZE: &'static str = "mpv-subtitle-size"; // i32
+    const KEY_MPV_SUBTITLE_SCALE: &'static str = "mpv-subtitle-scale"; // f64
     const KEY_MPV_SUBTITLE_FONT: &'static str = "mpv-subtitle-font"; // String
+    const KEY_MPV_SUBTITLE_BORDER_STYLE: &'static str = "mpv-subtitle-border-style"; // i32
+    const KEY_MPV_SUBTITLE_BORDER_SIZE: &'static str = "mpv-subtitle-border-size"; // i32
+    const KEY_MPV_SUBTITLE_SHADOW_OFFSET: &'static str = "mpv-subtitle-shadow-offset"; // i32
+    const KEY_MPV_SUBTITLE_STRETCH_IMAGE_SUBS_TO_SCREEN: &'static str =
+        "mpv-subtitle-stretch-image-subs-to-screen"; // bool
+    const KEY_MPV_SUBTITLE_TEXT_COLOR: &'static str = "mpv-subtitle-text-color"; // String
+    const KEY_MPV_SUBTITLE_BORDER_COLOR: &'static str = "mpv-subtitle-border-color"; // String
+    const KEY_MPV_SUBTITLE_BACKGROUND_COLOR: &'static str = "mpv-subtitle-background-color"; // String
     const KEY_MPV_AUDIO_PREFERRED_LANG: &'static str = "mpv-audio-preferred-lang"; // i32
     const KEY_MPV_SUBTITLE_PREFERRED_LANG: &'static str = "mpv-subtitle-preferred-lang"; // i32
     const KEY_MPV_DEFAULT_VOLUME: &'static str = "mpv-default-volume"; // i32
@@ -53,7 +66,6 @@ impl Settings {
     const PREFERRED_VERSION_DESCRIPTORS: &'static str = "video-version-descriptors"; // String
     const ACCOUNTS: &'static str = "accounts"; // String
     const KEY_MPV_AUDIO_CHANNEL: &'static str = "mpv-audio-channel"; // i32
-    const KEY_MPV_SUBTITLE_SCALE: &'static str = "mpv-subtitle-scale"; // f64
     const KEY_MPV_VIDEO_SCALE: &'static str = "mpv-video-scale"; // i32
     const KEY_MPV_CONFIG_DIR: &'static str = "mpv-config-path"; // String
     const KEY_IS_REFRESH: &'static str = "is-refresh"; // bool
@@ -153,8 +165,77 @@ impl Settings {
         self.string(Self::KEY_MPV_CONFIG_DIR).to_string()
     }
 
+    pub fn mpv_subtitle_bold(&self) -> bool {
+        self.boolean(Self::KEY_MPV_SUBTITLE_BOLD)
+    }
+
+    pub fn mpv_subtitle_italic(&self) -> bool {
+        self.boolean(Self::KEY_MPV_SUBTITLE_ITALIC)
+    }
+
+    pub fn mpv_subtitle_justify(&self) -> i32 {
+        self.int(Self::KEY_MPV_SUBTITLE_JUSTIFY)
+    }
+
+    pub fn mpv_subtitle_position(&self) -> i32 {
+        self.int(Self::KEY_MPV_SUBTITLE_POSITION)
+    }
+
+    pub fn mpv_subtitle_size(&self) -> i32 {
+        self.int(Self::KEY_MPV_SUBTITLE_SIZE)
+    }
+
     pub fn mpv_subtitle_scale(&self) -> f64 {
         self.double(Self::KEY_MPV_SUBTITLE_SCALE)
+    }
+
+    pub fn set_mpv_subtitle_font(&self, mpv_subtitle_font: String) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_MPV_SUBTITLE_FONT, &mpv_subtitle_font)
+    }
+
+    pub fn mpv_subtitle_font(&self) -> String {
+        self.string(Self::KEY_MPV_SUBTITLE_FONT).to_string()
+    }
+
+    pub fn mpv_subtitle_border_style(&self) -> i32 {
+        self.int(Self::KEY_MPV_SUBTITLE_BORDER_STYLE)
+    }
+
+    pub fn mpv_subtitle_border_size(&self) -> i32 {
+        self.int(Self::KEY_MPV_SUBTITLE_BORDER_SIZE)
+    }
+
+    pub fn mpv_subtitle_shadow_offset(&self) -> i32 {
+        self.int(Self::KEY_MPV_SUBTITLE_SHADOW_OFFSET)
+    }
+
+    pub fn mpv_subtitle_stretch_image_subs_to_screen(&self) -> bool {
+        self.boolean(Self::KEY_MPV_SUBTITLE_STRETCH_IMAGE_SUBS_TO_SCREEN)
+    }
+
+    pub fn mpv_subtitle_text_color(&self) -> String {
+        self.string(Self::KEY_MPV_SUBTITLE_TEXT_COLOR).to_string()
+    }
+
+    pub fn set_mpv_subtitle_text_color(&self, color: &str) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_MPV_SUBTITLE_TEXT_COLOR, color)
+    }
+
+    pub fn mpv_subtitle_border_color(&self) -> String {
+        self.string(Self::KEY_MPV_SUBTITLE_BORDER_COLOR).to_string()
+    }
+
+    pub fn set_mpv_subtitle_border_color(&self, color: &str) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_MPV_SUBTITLE_BORDER_COLOR, color)
+    }
+
+    pub fn mpv_subtitle_background_color(&self) -> String {
+        self.string(Self::KEY_MPV_SUBTITLE_BACKGROUND_COLOR)
+            .to_string()
+    }
+
+    pub fn set_mpv_subtitle_background_color(&self, color: &str) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_MPV_SUBTITLE_BACKGROUND_COLOR, color)
     }
 
     pub fn mpv_video_scale(&self) -> i32 {
@@ -270,18 +351,6 @@ impl Settings {
 
     pub fn list_sort_order(&self) -> i32 {
         self.int(Self::KEY_LIST_SORT_ORDER)
-    }
-
-    pub fn mpv_subtitle_size(&self) -> i32 {
-        self.int(Self::KEY_MPV_SUBTITLE_SIZE)
-    }
-
-    pub fn set_mpv_subtitle_font(&self, mpv_subtitle_font: String) -> Result<(), glib::BoolError> {
-        self.set_string(Self::KEY_MPV_SUBTITLE_FONT, &mpv_subtitle_font)
-    }
-
-    pub fn mpv_subtitle_font(&self) -> String {
-        self.string(Self::KEY_MPV_SUBTITLE_FONT).to_string()
     }
 
     pub fn mpv_audio_preferred_lang(&self) -> i32 {

--- a/src/ui/mpv/control_sidebar.rs
+++ b/src/ui/mpv/control_sidebar.rs
@@ -175,7 +175,7 @@ impl MPVControlSidebar {
 
         let action_text = gio::ActionEntry::builder("text-justify")
             .parameter_type(Some(&i32::static_variant_type()))
-            .state(1.to_variant())
+            .state(SETTINGS.mpv_subtitle_justify().to_variant())
             .activate(glib::clone!(
                 #[weak(rename_to = obj)]
                 self,
@@ -191,6 +191,7 @@ impl MPVControlSidebar {
                         2 => obj.set_mpv_property("sub-justify", "right"),
                         _ => {}
                     }
+                    SETTINGS.set_int("mpv-subtitle-justify", parameter).unwrap();
                     action.set_state(&parameter.to_variant());
                 }
             ))
@@ -258,6 +259,18 @@ impl MPVControlSidebar {
             .set_font_desc(&gtk::pango::FontDescription::from_string(
                 &SETTINGS.mpv_subtitle_font(),
             ));
+        imp.sub_text_color.set_rgba(&rgba_from_settings(
+            SETTINGS.mpv_subtitle_text_color(),
+            gtk::gdk::RGBA::new(1.0, 1.0, 1.0, 1.0),
+        ));
+        imp.sub_border_color.set_rgba(&rgba_from_settings(
+            SETTINGS.mpv_subtitle_border_color(),
+            gtk::gdk::RGBA::new(0.0, 0.0, 0.0, 1.0),
+        ));
+        imp.sub_background_color.set_rgba(&rgba_from_settings(
+            SETTINGS.mpv_subtitle_background_color(),
+            gtk::gdk::RGBA::new(0.0, 0.0, 0.0, 0.0),
+        ));
         SETTINGS
             .bind(
                 "mpv-show-buffer-speed",
@@ -282,7 +295,55 @@ impl MPVControlSidebar {
             )
             .build();
         SETTINGS
+            .bind("mpv-subtitle-bold", &imp.sub_bold_toggle.get(), "active")
+            .build();
+        SETTINGS
+            .bind(
+                "mpv-subtitle-italic",
+                &imp.sub_italic_toggle.get(),
+                "active",
+            )
+            .build();
+        SETTINGS
+            .bind(
+                "mpv-subtitle-position",
+                &imp.sub_position_adj.get(),
+                "value",
+            )
+            .build();
+        SETTINGS
+            .bind("mpv-subtitle-size", &imp.sub_size_adj.get(), "value")
+            .build();
+        SETTINGS
             .bind("mpv-subtitle-scale", &imp.sub_scale_adj.get(), "value")
+            .build();
+        SETTINGS
+            .bind(
+                "mpv-subtitle-border-style",
+                &imp.sub_border_style_combo.get(),
+                "selected",
+            )
+            .build();
+        SETTINGS
+            .bind(
+                "mpv-subtitle-border-size",
+                &imp.sub_border_size_adj.get(),
+                "value",
+            )
+            .build();
+        SETTINGS
+            .bind(
+                "mpv-subtitle-shadow-offset",
+                &imp.sub_shadow_offset_adj.get(),
+                "value",
+            )
+            .build();
+        SETTINGS
+            .bind(
+                "mpv-subtitle-stretch-image-subs-to-screen",
+                &imp.stretch_image_subs_to_screen_switchrow.get(),
+                "active",
+            )
             .build();
         SETTINGS
             .bind(
@@ -416,6 +477,7 @@ impl MPVControlSidebar {
     #[template_callback]
     pub fn on_sub_text_color(&self, _param: glib::ParamSpec, color: gtk::ColorDialogButton) {
         let rgba = color.rgba();
+        let _ = SETTINGS.set_mpv_subtitle_text_color(&rgba.to_string());
         self.set_mpv_property(
             "sub-color",
             rgba_to_mpv_color((rgba.red(), rgba.green(), rgba.blue(), rgba.alpha())),
@@ -425,6 +487,7 @@ impl MPVControlSidebar {
     #[template_callback]
     pub fn on_sub_border_color(&self, _param: glib::ParamSpec, color: gtk::ColorDialogButton) {
         let rgba = color.rgba();
+        let _ = SETTINGS.set_mpv_subtitle_border_color(&rgba.to_string());
         self.set_mpv_property(
             "sub-border-color",
             rgba_to_mpv_color((rgba.red(), rgba.green(), rgba.blue(), rgba.alpha())),
@@ -434,6 +497,7 @@ impl MPVControlSidebar {
     #[template_callback]
     pub fn on_sub_background_color(&self, _param: glib::ParamSpec, color: gtk::ColorDialogButton) {
         let rgba = color.rgba();
+        let _ = SETTINGS.set_mpv_subtitle_background_color(&rgba.to_string());
         self.set_mpv_property(
             "sub-back-color",
             rgba_to_mpv_color((rgba.red(), rgba.green(), rgba.blue(), rgba.alpha())),
@@ -483,6 +547,7 @@ impl MPVControlSidebar {
         imp.sub_scale_adj.set_value(1.0);
         imp.sub_font_button
             .set_font_desc(&gtk::pango::FontDescription::from_string(""));
+        let _ = self.activate_action("mpv.text-justify", Some(&1.to_variant()));
         imp.sub_border_style_combo.set_selected(0);
         imp.sub_border_size_adj.set_value(3.0);
         imp.sub_shadow_offset_adj.set_value(0.0);
@@ -586,6 +651,10 @@ impl MPVControlSidebar {
         imp.audio_offset_adj.set_value(0.0);
         imp.audio_channel_combo.set_selected(1);
     }
+}
+
+fn rgba_from_settings(value: String, default: gtk::gdk::RGBA) -> gtk::gdk::RGBA {
+    gtk::gdk::RGBA::parse(&value).unwrap_or(default)
 }
 
 fn rgba_to_mpv_color(rgba: (f32, f32, f32, f32)) -> String {

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -114,9 +114,51 @@ impl Default for TsukimiMPV {
             init.set_property("cache-secs", (SETTINGS.mpv_cache_time()) as i64)?;
             init.set_property("volume-max", MAX_VOLUME)?;
             init.set_property("volume", SETTINGS.mpv_default_volume() as i64)?;
+            init.set_property("sub-bold", SETTINGS.mpv_subtitle_bold())?;
+            init.set_property("sub-italic", SETTINGS.mpv_subtitle_italic())?;
+            init.set_property(
+                "sub-justify",
+                match SETTINGS.mpv_subtitle_justify() {
+                    0 => "left",
+                    2 => "right",
+                    _ => "center",
+                },
+            )?;
+            init.set_property("sub-pos", SETTINGS.mpv_subtitle_position() as i64)?;
             init.set_property("sub-font-size", SETTINGS.mpv_subtitle_size() as i64)?;
-            init.set_property("sub-font", SETTINGS.mpv_subtitle_font())?;
             init.set_property("sub-scale", SETTINGS.mpv_subtitle_scale())?;
+            init.set_property("sub-font", SETTINGS.mpv_subtitle_font())?;
+            init.set_property(
+                "sub-border-style",
+                match_sub_border_style(SETTINGS.mpv_subtitle_border_style()),
+            )?;
+            init.set_property(
+                "sub-border-size",
+                SETTINGS.mpv_subtitle_border_size() as i64,
+            )?;
+            init.set_property(
+                "sub-shadow-offset",
+                SETTINGS.mpv_subtitle_shadow_offset() as i64,
+            )?;
+            init.set_property(
+                "stretch-image-subs-to-screen",
+                SETTINGS.mpv_subtitle_stretch_image_subs_to_screen(),
+            )?;
+            init.set_property(
+                "sub-color",
+                settings_color_to_mpv(SETTINGS.mpv_subtitle_text_color(), (1.0, 1.0, 1.0, 1.0)),
+            )?;
+            init.set_property(
+                "sub-border-color",
+                settings_color_to_mpv(SETTINGS.mpv_subtitle_border_color(), (0.0, 0.0, 0.0, 1.0)),
+            )?;
+            init.set_property(
+                "sub-back-color",
+                settings_color_to_mpv(
+                    SETTINGS.mpv_subtitle_background_color(),
+                    (0.0, 0.0, 0.0, 0.0),
+                ),
+            )?;
             init.set_property("hwdec", match_hwdec_interop(SETTINGS.mpv_hwdec()))?;
             init.set_property("scale", match_video_upscale(SETTINGS.mpv_video_scale()))?;
             if SETTINGS.mpv_action_after_video_end() == 1 {
@@ -632,6 +674,7 @@ use url::Url;
 use super::options_matcher::{
     match_audio_channels,
     match_hwdec_interop,
+    match_sub_border_style,
     match_video_upscale,
 };
 use crate::{
@@ -642,6 +685,19 @@ use crate::{
         spawn_tokio_without_await,
     },
 };
+
+fn settings_color_to_mpv(value: String, default: (f32, f32, f32, f32)) -> String {
+    let rgba = gtk::gdk::RGBA::parse(&value)
+        .unwrap_or_else(|_| gtk::gdk::RGBA::new(default.0, default.1, default.2, default.3));
+
+    format!(
+        "{}/{}/{}/{}",
+        rgba.red(),
+        rgba.green(),
+        rgba.blue(),
+        rgba.alpha()
+    )
+}
 
 const KEYSTRING_MAP: &[(&str, &str)] = &[
     ("PGUP", "Page_Up"),


### PR DESCRIPTION
close #519, close #633.

Fields in the subtitle section, except for subtitle offset, are generally not tied to a specific video, so persisting them should be a better choice.