### PR TITLE
fix: remove duplicate recursive query parameter

### DIFF
--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -1283,7 +1283,6 @@ impl JellyfinClient {
             ("Recursive", "true"),
             ("IncludeItemTypes", "Playlist,BoxSet"),
             ("SortBy", "SortName"),
-            ("Recursive", "true"),
         ];
         self.request(&path, &params).await
     }


### PR DESCRIPTION
Remove the duplicate Recursive query parameter from the included-items request.