### PR TITLE
feat: TV / HTPC mode with gamepad navigation, subtitle rules, and subtitle search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /i18n
 /.idea
 /backup
+/.cargo-home
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +305,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytefmt"
@@ -1132,6 +1144,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "gilrs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902fb00d3f6398e635be22e5c837b303c501835cca7ac11a47bba138f7aafdd8"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7f0ce6237abcc0523f2a5502b1e3fe5802daaae47ac14e166fe49551301ea9"
+dependencies = [
+ "inotify",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.31.3",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "windows",
+]
+
+[[package]]
 name = "gio"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,7 +1294,7 @@ dependencies = [
  "libseccomp",
  "memfd",
  "memmap2",
- "nix",
+ "nix 0.30.1",
  "static_assertions",
  "thiserror",
  "tokio",
@@ -1268,7 +1314,7 @@ dependencies = [
  "gufo-common",
  "half",
  "memmap2",
- "nix",
+ "nix 0.30.1",
  "paste",
  "rmp-serde",
  "serde",
@@ -1295,7 +1341,7 @@ dependencies = [
  "libseccomp",
  "log",
  "memmap2",
- "nix",
+ "nix 0.30.1",
  "paste",
  "rayon",
  "serde",
@@ -1664,7 +1710,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1804,6 +1850,26 @@ dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2048,6 +2114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60276e2d41bbb68b323e566047a1bfbf952050b157d8b5cdc74c07c1bf4ca3b6"
 
 [[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2305,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2392,26 @@ dependencies = [
  "block",
  "objc",
  "objc_id",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3099,6 +3234,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "steam_shortcuts_util"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0543ebdb23a93b196aceebc53f70cc5a573bb74248a974b3f5fa3883e6a89b6"
+dependencies = [
+ "ascii",
+ "crc32fast",
+ "nom",
+ "nom_locate",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3619,7 @@ version = "26.7.2"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "atomic-wait",
  "base64",
  "bytefmt",
@@ -3487,6 +3635,7 @@ dependencies = [
  "gdk4-wayland",
  "gdk4-x11",
  "gettext-rs",
+ "gilrs",
  "glow",
  "glycin",
  "gstreamer",
@@ -3505,6 +3654,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "steam_shortcuts_util",
  "strsim",
  "tokio",
  "tracing",
@@ -3585,6 +3735,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"
@@ -3857,6 +4013,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3865,8 +4042,32 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3904,6 +4105,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,12 +4124,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4003,6 +4232,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ atomic-wait = "1.1.0"
 flume = "0.12.0"
 derive_builder = "0.20.2"
 anyhow = "1.0"
+async-trait = "0.1"
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter"] }
 regex = "1.12.3"
 strsim = "0.11.1"
@@ -56,6 +57,8 @@ futures-util = "0.3.31"
 itertools = "0.15.0"
 moka = { version = "0.12.15", features = ["future"] }
 glycin = { version = "3.1.0", default-features = false, features = ["gdk4", "tokio"] }
+gilrs = "0.11"
+steam_shortcuts_util = "1.1.7"
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }

--- a/docs/build_on_linux.md
+++ b/docs/build_on_linux.md
@@ -81,3 +81,27 @@ generator injects:
 
 This keeps tagged releases and development snapshots separate while still
 allowing both packages to live in the same COPR project.
+
+### Immutable Fedora hosts (Bazzite, etc.)
+
+Do not `dnf install` on the host. Use distrobox for dev builds; use
+[Flathub](https://flathub.org/apps/moe.tsuna.tsukimi) for a normal install.
+
+- **Standard** (`just build`, `just run`) — host has build deps installed.
+- **Distrobox** (`just distrobox-init`, `just dev`) — local dev only; not for releases.
+
+```sh
+just distrobox-init   # once
+just distrobox-build  # after changes
+just dev              # build, install, run
+```
+
+If compile hangs on `Blocking waiting for file lock`, run `just distrobox-compile`
+again (it kills stale cargo processes).
+
+For daily use, install from Flathub instead:
+
+```sh
+flatpak install flathub moe.tsuna.tsukimi
+flatpak run moe.tsuna.tsukimi
+```

--- a/justfile
+++ b/justfile
@@ -3,24 +3,148 @@ set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 builddir := "build"
 prefix := builddir + "/dev-prefix"
 
+# ---------------------------------------------------------------------------
+# Standard Meson workflow (mutable Fedora, dev containers with host toolchains)
+# See docs/build_on_linux.md — this is what upstream documents.
+# ---------------------------------------------------------------------------
+
 default:
     @just --list
 
 setup:
     meson setup {{ builddir }} --prefix "$PWD/{{ prefix }}"
 
-build: setup
+compile:
     meson compile -C {{ builddir }}
 
-install: build
+# First-time configure + compile.
+build: setup compile
+
+install: compile
     meson install -C {{ builddir }}
 
+# Run on the host GUI session (requires host runtime libs such as mpv-libs).
 run *ARGS: install
     cd {{ builddir }} && \
         env \
             GSETTINGS_SCHEMA_DIR="$PWD/dev-prefix/share/glib-2.0/schemas" \
             XDG_DATA_DIRS="$PWD/dev-prefix/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
+            TSUKIMI_PKGDATADIR="$PWD/dev-prefix/share/tsukimi" \
+            TSUKIMI_LOCALEDIR="$PWD/dev-prefix/share/locale" \
             ./src/tsukimi {{ ARGS }}
 
 update-i18n:
     meson compile -C {{ builddir }} tsukimi-pot
+
+# ---------------------------------------------------------------------------
+# Distrobox — local dev on immutable hosts (Bazzite, Silverblue, …)
+# Build deps live in the container. Not for COPR, Flatpak, or releases.
+# ---------------------------------------------------------------------------
+
+distrobox-name := "tsukimi-build"
+distrobox-image := "quay.io/fedora/fedora:latest"
+
+distrobox-run +CMD:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    exec </dev/null
+    export CI=1 DEBIAN_FRONTEND=noninteractive DNF_NONINTERACTIVE=1
+    if podman container exists "{{ distrobox-name }}" >/dev/null 2>&1 \
+        && [[ "$(podman inspect -f '{{{{.State.Running}}}}' "{{ distrobox-name }}" 2>/dev/null || echo false)" == "true" ]]; then
+        podman exec -i -w "/run/host${PWD}" "{{ distrobox-name }}" \
+            bash -lc 'export CARGO_HOME="$PWD/.cargo-home" CI=1 DEBIAN_FRONTEND=noninteractive; {{ CMD }}'
+    else
+        distrobox enter --name "{{ distrobox-name }}" --no-tty -- \
+            bash -lc 'export CARGO_HOME="$PWD/.cargo-home" CI=1 DEBIAN_FRONTEND=noninteractive; {{ CMD }}'
+    fi
+
+distrobox-create:
+    distrobox create --name "{{ distrobox-name }}" --image "{{ distrobox-image }}" --yes
+
+distrobox-deps:
+    just distrobox-run 'sudo -n dnf install -y \
+        gtk4-devel libadwaita-devel wayland-devel \
+        gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel \
+        openssl-devel gettext-devel libseccomp-devel libepoxy-devel mpv-devel \
+        rust cargo meson ninja-build pkgconfig-pkg-config dbus-devel libxml2 \
+        desktop-file-utils just'
+
+distrobox-setup:
+    just distrobox-run 'meson setup build --prefix "$PWD/build/dev-prefix"'
+
+distrobox-compile:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "[distrobox] compile started: $(date)"
+    if pgrep -f "cargo build --manifest-path.*/tsukimi/Cargo.toml" >/dev/null 2>&1 \
+        || pgrep -f "rustc --crate-name tsukimi" >/dev/null 2>&1; then
+        echo "[distrobox] stale cargo build detected — stopping it (avoids file-lock wait)"
+        pkill -f "cargo build --manifest-path.*/tsukimi/Cargo.toml" || true
+        pkill -f "rustc --crate-name tsukimi" || true
+        pkill -f "ninja -C.*/tsukimi/build" || true
+        sleep 2
+    fi
+    just distrobox-run 'meson compile -C build'
+    echo "[distrobox] compile finished: $(date)"
+
+distrobox-install:
+    @echo "[distrobox] install started: $(date)"
+    just distrobox-run 'meson install -C build'
+    @echo "[distrobox] install finished: $(date)"
+
+distrobox-run-app *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Drop stray `--` from nested just invocations.
+    APP_ARGS=()
+    for arg in "$@"; do
+        [[ "$arg" == "--" ]] && continue
+        APP_ARGS+=("$arg")
+    done
+    # File check — NOT ldconfig|grep -q (pipefail + SIGPIPE false-negative).
+    host_has_libmpv=false
+    if [[ -f /lib64/libmpv.so.2 || -f /usr/lib64/libmpv.so.2 ]]; then
+        host_has_libmpv=true
+    fi
+    if [[ "$host_has_libmpv" == "true" ]]; then
+        echo "[distrobox] host libmpv found — launching on host (gamepad + display)"
+        cd "{{ builddir }}" && \
+            env \
+                GSK_RENDERER="${GSK_RENDERER:-gl}" \
+                GSETTINGS_SCHEMA_DIR="$PWD/dev-prefix/share/glib-2.0/schemas" \
+                XDG_DATA_DIRS="$PWD/dev-prefix/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
+                TSUKIMI_PKGDATADIR="$PWD/dev-prefix/share/tsukimi" \
+                TSUKIMI_LOCALEDIR="$PWD/dev-prefix/share/locale" \
+                ./src/tsukimi "${APP_ARGS[@]}"
+    else
+        echo "[distrobox] no host libmpv — launching in container"
+        echo "[distrobox] tip: sudo rpm-ostree install mpv-libs && reboot"
+        ARGS="$(printf ' %q' "${APP_ARGS[@]}")"
+        just distrobox-run "cd build && env GSK_RENDERER=gl GSETTINGS_SCHEMA_DIR=\"\$PWD/dev-prefix/share/glib-2.0/schemas\" XDG_DATA_DIRS=\"\$PWD/dev-prefix/share:\${XDG_DATA_DIRS:-/usr/local/share:/usr/share}\" TSUKIMI_PKGDATADIR=\"\$PWD/dev-prefix/share/tsukimi\" TSUKIMI_LOCALEDIR=\"\$PWD/dev-prefix/share/locale\" ./src/tsukimi${ARGS}"
+    fi
+    echo "[distrobox] exited"
+
+# Recompile only (no container recreate, no meson setup).
+distrobox-build: distrobox-compile
+
+# compile → install → run
+# App flags must follow `--`, e.g. `just dev -- --tv-mode`
+dev *ARGS:
+    @echo "[distrobox] === dev: compile ==="
+    just distrobox-compile
+    @echo "[distrobox] === dev: install ==="
+    just distrobox-install
+    @echo "[distrobox] === dev: launch ==="
+    just distrobox-run-app {{ ARGS }}
+
+# Shorthand for TV / gamepad testing.
+dev-tv:
+    @echo "[distrobox] === dev: compile ==="
+    just distrobox-compile
+    @echo "[distrobox] === dev: install ==="
+    just distrobox-install
+    @echo "[distrobox] === dev: launch (tv-mode) ==="
+    just distrobox-run-app -- --tv-mode
+
+# One-time bootstrap inside distrobox.
+distrobox-init: distrobox-create distrobox-deps distrobox-setup distrobox-compile

--- a/resources/meson.build
+++ b/resources/meson.build
@@ -18,6 +18,15 @@ desktop_file = i18n.merge_file(
     install_dir: join_paths(get_option('datadir'), 'applications'),
 )
 
+tv_desktop_file = i18n.merge_file(
+    input: 'moe.tsuna.tsukimi-tv.desktop.in',
+    output: 'moe.tsuna.tsukimi-tv.desktop',
+    type: 'desktop',
+    po_dir: '../po',
+    install: true,
+    install_dir: join_paths(get_option('datadir'), 'applications'),
+)
+
 desktop_utils = find_program('desktop-file-validate', required: false)
 if desktop_utils.found()
     test('Validate desktop file', desktop_utils, args: [desktop_file])

--- a/resources/moe.tsuna.tsukimi-tv.desktop.in
+++ b/resources/moe.tsuna.tsukimi-tv.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Tsukimi (TV Mode)
+Comment=A third-party Jellyfin client for Linux — TV / HTPC mode
+Exec=tsukimi --tv-mode --fullscreen
+Icon=moe.tsuna.tsukimi
+Terminal=false
+Type=Application
+Categories=AudioVideo;Video;Player;
+StartupNotify=true

--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -279,5 +279,45 @@
       <summary>Whether the danmaku is enabled</summary>
       <default>false</default>
     </key>
+    <key name="gamepad-enabled" type="b">
+      <summary>Enable gamepad/controller input</summary>
+      <default>false</default>
+    </key>
+    <key name="tv-mode" type="b">
+      <summary>TV / HTPC visual mode</summary>
+      <default>false</default>
+    </key>
+    <key type="d" name="tv-ui-scale">
+      <summary>TV mode UI scale factor</summary>
+      <default>1.25</default>
+    </key>
+    <key name="tv-start-fullscreen" type="b">
+      <summary>Start fullscreen when TV mode is active</summary>
+      <default>true</default>
+    </key>
+    <key name="tv-hide-sidebar" type="b">
+      <summary>Collapse sidebar by default in TV mode</summary>
+      <default>true</default>
+    </key>
+    <key name="tv-show-button-hints" type="b">
+      <summary>Show on-screen controller hints in TV mode</summary>
+      <default>false</default>
+    </key>
+    <key name="playback-conditional-rules" type="s">
+      <summary>App-wide conditional audio/subtitle playback rules (JSON)</summary>
+      <default>"{\"enabled\":false,\"rules\":[],\"default\":{\"audio\":{\"mode\":\"no_override\"},\"subtitles\":{\"mode\":\"off\"}}}"</default>
+    </key>
+    <key name="opensubtitles-api-key" type="s">
+      <summary>OpenSubtitles API key</summary>
+      <default>""</default>
+    </key>
+    <key name="subdl-api-key" type="s">
+      <summary>SubDL API key</summary>
+      <default>""</default>
+    </key>
+    <key name="subtitle-providers-enabled" type="s">
+      <summary>Comma-separated enabled subtitle provider ids</summary>
+      <default>"opensubtitles,subdl"</default>
+    </key>
   </schema>
 </schemalist>

--- a/resources/resources.gresource.xml
+++ b/resources/resources.gresource.xml
@@ -42,6 +42,7 @@
   </gresource>
   <gresource prefix="/moe/tsuna/tsukimi/">
     <file compressed="true">style.css</file>
+    <file compressed="true">tv.css</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/window.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/search.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/item.ui</file>

--- a/resources/style.css
+++ b/resources/style.css
@@ -394,3 +394,8 @@ progressbar.accent > trough > progress {
     box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
     border-radius: 10px;
 }
+
+.tulistitem:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}

--- a/resources/tv.css
+++ b/resources/tv.css
@@ -1,0 +1,87 @@
+/* Tsukimi TV mode — scaled extension of style.css (same look, larger targets) */
+
+window.tv-mode {
+  font-size: calc(1em * var(--tv-scale, 1.25));
+}
+
+window.tv-mode .server-action-row,
+window.tv-mode .placeholder-page {
+  font-size: calc(1.1em * var(--tv-scale, 1.25));
+}
+
+.poster-focused,
+.tv-focused {
+  box-shadow:
+    0 0 0 calc(3px * var(--tv-scale, 1.25)) var(--accent-color),
+    0 0 calc(12px * var(--tv-scale, 1.25)) alpha(var(--accent-color), 0.45);
+  border-radius: 10px;
+}
+
+.tv-focused-scale {
+  transform: scale(1.04);
+  transition: transform 120ms ease-out;
+}
+
+window.tv-mode gridview > child:selected {
+  outline: none;
+  box-shadow: none;
+}
+
+.tv-poster-focus-title {
+  padding: calc(10px * var(--tv-scale, 1.25)) calc(12px * var(--tv-scale, 1.25));
+  background: alpha(black, 0.72);
+  border-radius: 0 0 10px 10px;
+}
+
+.tv-poster-focus-title label {
+  color: white;
+  font-size: calc(0.95em * var(--tv-scale, 1.25));
+}
+
+window.tv-mode .server-action-row.tv-focused,
+window.tv-mode button.tv-focused,
+window.tv-mode .preferences row.tv-focused,
+window.tv-mode gridview item:selected,
+window.tv-mode listview row:selected {
+  outline: calc(3px * var(--tv-scale, 1.25)) solid var(--accent-color);
+  outline-offset: calc(2px * var(--tv-scale, 1.25));
+}
+
+.tulistitem:focus-visible {
+  outline: calc(2px * var(--tv-scale, 1.25)) solid var(--accent-color);
+  outline-offset: calc(2px * var(--tv-scale, 1.25));
+}
+
+window.tv-mode .sidebar row {
+  min-height: calc(48px * var(--tv-scale, 1.25));
+}
+
+window.tv-mode .sidebar row:selected {
+  font-size: calc(1em * var(--tv-scale, 1.25));
+}
+
+window.tv-mode .circular.smaller {
+  min-height: calc(28px * var(--tv-scale, 1.25));
+  min-width: calc(28px * var(--tv-scale, 1.25));
+}
+
+.player-toolbar {
+  padding: calc(5px * var(--tv-scale, 1.25));
+}
+
+.volume-bar {
+  padding: calc(10px * var(--tv-scale, 1.25));
+}
+
+.tv-hints-bar {
+  padding: calc(12px * var(--tv-scale, 1.25)) calc(24px * var(--tv-scale, 1.25));
+  background: alpha(@window_bg_color, 0.85);
+  border-radius: calc(12px * var(--tv-scale, 1.25));
+  margin: calc(16px * var(--tv-scale, 1.25));
+}
+
+.tv-hints-bar label {
+  font-size: calc(1.1em * var(--tv-scale, 1.25));
+  color: @window_fg_color;
+  background: transparent;
+}

--- a/resources/ui/item.ui
+++ b/resources/ui/item.ui
@@ -307,7 +307,7 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkButton">
+                          <object class="GtkButton" id="season_view_more">
                             <property name="icon-name">view-more-horizontal-symbolic</property>
                             <property name="halign">start</property>
                             <signal name="clicked" handler="on_season_view_more_clicked" swapped="yes"/>

--- a/resources/ui/item_actions.ui
+++ b/resources/ui/item_actions.ui
@@ -48,6 +48,11 @@
       <attribute name="hidden-when">action-disabled</attribute>
       <attribute name="accel">&lt;Control&gt;F2</attribute>
     </item>
+    <item>
+      <attribute name="label" translatable="yes">Download Subtitles</attribute>
+      <attribute name="action">item.subtitles</attribute>
+      <attribute name="hidden-when">action-disabled</attribute>
+    </item>
     <section>
       <item>
         <attribute name="label" translatable="yes">Edit Metadata</attribute>

--- a/resources/ui/list.ui
+++ b/resources/ui/list.ui
@@ -13,7 +13,7 @@
             <property name="margin-top">10</property>
             <property name="margin-bottom">10</property>
             <child>
-              <object class="GtkStackSwitcher">
+              <object class="GtkStackSwitcher" id="stack_switcher">
                 <property name="halign">center</property>
                 <property name="stack">stack</property>
               </object>

--- a/resources/ui/listitem.ui
+++ b/resources/ui/listitem.ui
@@ -66,6 +66,37 @@
                       </object>
                     </child>
                     <child type="overlay">
+                      <object class="GtkRevealer" id="focus_title_revealer">
+                        <property name="valign">end</property>
+                        <property name="halign">fill</property>
+                        <property name="hexpand">true</property>
+                        <property name="reveal-child">false</property>
+                        <property name="transition-type">crossfade</property>
+                        <child>
+                          <object class="GtkBox" id="focus_title_box">
+                            <property name="orientation">vertical</property>
+                            <property name="halign">fill</property>
+                            <property name="hexpand">true</property>
+                            <child>
+                              <object class="GtkLabel" id="focus_title">
+                                <property name="justify">center</property>
+                                <property name="ellipsize">end</property>
+                                <property name="lines">2</property>
+                                <property name="wrap">true</property>
+                                <property name="wrap-mode">word-char</property>
+                                <attributes>
+                                  <attribute name="weight" value="PANGO_WEIGHT_BOLD" />
+                                </attributes>
+                              </object>
+                            </child>
+                            <style>
+                              <class name="tv-poster-focus-title" />
+                            </style>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="overlay">
                       <object class="GtkButton" id="direct_play_button">
                         <property name="halign">start</property>
                         <property name="valign">end</property>

--- a/resources/ui/mpvpage.ui
+++ b/resources/ui/mpvpage.ui
@@ -74,6 +74,17 @@
                     </style>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkLabel" id="finishes_at_label">
+                    <property name="halign">center</property>
+                    <property name="margin_bottom">8</property>
+                    <property name="visible">false</property>
+                    <style>
+                      <class name="accent" />
+                      <class name="speed-label" />
+                    </style>
+                  </object>
+                </child>
               </object>
             </child>
             <child type="overlay">

--- a/resources/ui/server_action_row.ui
+++ b/resources/ui/server_action_row.ui
@@ -5,6 +5,7 @@
     <property name="use-underline">True</property>
     <style>
       <class name="property"/>
+      <class name="server-action-row"/>
     </style>
     <child type="prefix">
       <object class="GtkImage" id="server_image">
@@ -24,7 +25,7 @@
       </object>
     </child>
     <child type="suffix">
-      <object class="GtkButton">
+      <object class="GtkButton" id="edit_button">
         <property name="valign">center</property>
         <property name="icon-name">document-edit-symbolic</property>
         <property name="tooltip-text" translatable="yes">Edit</property>
@@ -46,7 +47,7 @@
       </object>
     </child>
     <child type="suffix">
-      <object class="GtkButton">
+      <object class="GtkButton" id="delete_button">
         <property name="valign">center</property>
         <property name="icon-name">user-trash-symbolic</property>
         <property name="tooltip-text" translatable="yes">Delete</property>

--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -106,6 +106,9 @@
                         <property name="child">
                           <object class="GtkBox">
                             <property name="orientation">vertical</property>
+                            <style>
+                              <class name="placeholder-page"/>
+                            </style>
                             <child>
                               <object class="AdwHeaderBar">
                                 <child type="end">

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,6 +70,8 @@ mod imp {
 
             let window = crate::Window::new(&self.obj());
             window.load_window_state();
+            crate::tv::apply_tv_startup(&window, crate::Args::global().fullscreen());
+            window.setup_input();
             window.present();
         }
     }

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -2,7 +2,10 @@ use std::{
     env,
     fs::File,
     io,
-    sync::Mutex,
+    sync::{
+        Mutex,
+        OnceLock,
+    },
 };
 
 use clap::Parser;
@@ -21,7 +24,9 @@ use crate::dyn_event;
 /// vulkan renderer has poor performance
 const DEFAULT_RENDERER: &str = "ngl";
 
-#[derive(Parser, Debug)]
+static PARSED_ARGS: OnceLock<Args> = OnceLock::new();
+
+#[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Args {
     /// File to write the log to. If not specified, logs will be written to
@@ -40,9 +45,28 @@ pub struct Args {
     /// XDG_CACHE_HOME override.
     #[clap(long)]
     xdg_cache_home: Option<String>,
+
+    /// Enable TV / HTPC visual mode (larger UI, fullscreen-friendly startup).
+    #[clap(long)]
+    tv_mode: bool,
+
+    /// Start in fullscreen (implies TV-friendly startup).
+    #[clap(long)]
+    fullscreen: bool,
 }
 
 impl Args {
+    pub fn global() -> &'static Args {
+        PARSED_ARGS.get_or_init(Args::parse)
+    }
+
+    pub fn tv_mode(&self) -> bool {
+        self.tv_mode
+    }
+
+    pub fn fullscreen(&self) -> bool {
+        self.fullscreen
+    }
     /// Build the tracing subscriber using parameters from the command line
     /// arguments
     ///
@@ -122,6 +146,7 @@ impl Args {
     }
 
     pub fn init(&self) {
+        let _ = PARSED_ARGS.set(self.clone());
         self.init_tracing_subscriber();
         self.init_gsk_renderer();
         self.init_glib_to_tracing();

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -276,8 +276,9 @@ impl JellyfinClient {
     where
         T: for<'de> Deserialize<'de> + Send + 'static,
     {
-        let request = self.prepare_request(Method::GET, path, params)?;
-        let res = self.send_request(request).await?;
+        let res = self
+            .send_get_with_retry(|| self.prepare_request(Method::GET, path, params))
+            .await?;
 
         let res = match res.error_for_status() {
             Ok(r) => r,
@@ -304,15 +305,17 @@ impl JellyfinClient {
     pub async fn request_picture(
         &self, path: &str, params: &[(&str, &str)], etag: Option<String>,
     ) -> Result<Response> {
-        let request = self
-            .prepare_request(Method::GET, path, params)?
-            .header("If-None-Match", etag.unwrap_or_default());
-        let res = self.send_request(request).await?;
-        Ok(res)
+        self.send_get_with_retry(|| {
+            Ok(self
+                .prepare_request(Method::GET, path, params)?
+                .header("If-None-Match", etag.clone().unwrap_or_default()))
+        })
+        .await
     }
 
     pub async fn delete(&self, path: &str, params: &[(&str, &str)]) -> Result<Response> {
         let request = self.prepare_request(Method::DELETE, path, params)?;
+        let _permit = self.semaphore.acquire().await?;
         self.send_request(request).await
     }
 
@@ -323,6 +326,7 @@ impl JellyfinClient {
         let request = self
             .prepare_request(Method::POST, path, params)?
             .json(&body);
+        let _permit = self.semaphore.acquire().await?;
         self.send_request(request).await
     }
 
@@ -333,6 +337,7 @@ impl JellyfinClient {
         let request = self
             .prepare_request_headers(Method::POST, path, &[], content_type)?
             .body(body);
+        let _permit = self.semaphore.acquire().await?;
         self.send_request(request).await
     }
 
@@ -377,8 +382,37 @@ impl JellyfinClient {
             .headers(headers))
     }
 
-    async fn send_request(&self, request: RequestBuilder) -> Result<Response> {
+    async fn send_get_with_retry(
+        &self, build: impl Fn() -> Result<RequestBuilder>,
+    ) -> Result<Response> {
+        const MAX_ATTEMPTS: u32 = 3;
         let _permit = self.semaphore.acquire().await?;
+        let mut last_error = None;
+
+        for attempt in 0..MAX_ATTEMPTS {
+            match build()?.send().await {
+                Ok(response) => return Ok(response),
+                Err(error) if error.is_timeout() && attempt + 1 < MAX_ATTEMPTS => {
+                    warn!(
+                        "Request timed out (attempt {} of {}), retrying",
+                        attempt + 1,
+                        MAX_ATTEMPTS
+                    );
+                    last_error = Some(error);
+                    tokio::time::sleep(Duration::from_millis(750 * (attempt + 1) as u64)).await;
+                }
+                Err(error) => return Err(anyhow!(error.to_user_facing())),
+            }
+        }
+
+        Err(anyhow!(
+            last_error
+                .expect("retry loop exits early on success")
+                .to_user_facing()
+        ))
+    }
+
+    async fn send_request(&self, request: RequestBuilder) -> Result<Response> {
         request
             .send()
             .await
@@ -914,6 +948,15 @@ impl JellyfinClient {
         url.join(path.trim_start_matches('/')).unwrap().to_string()
     }
 
+    pub async fn fetch_bytes(&self, path: &str) -> Result<Vec<u8>> {
+        let response = self
+            .send_get_with_retry(|| {
+                self.prepare_request(Method::GET, path.trim_start_matches('/'), &[])
+            })
+            .await?;
+        Ok(response.bytes().await?.to_vec())
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn get_list(
         &self, id: &str, start: u32, include_item_types: &str, list_type: ListType,
@@ -948,6 +991,7 @@ impl JellyfinClient {
                     ("IncludeItemTypes", include_item_type),
                     ("SortBy", sortby),
                     ("SortOrder", sort_order),
+                    ("EnableTotalRecordCount", "true"),
                     ("EnableImageTypes", "Primary,Backdrop,Thumb,Banner"),
                     if list_type == ListType::Liked {
                         ("Filters", "IsFavorite")

--- a/src/client/proxy.rs
+++ b/src/client/proxy.rs
@@ -3,13 +3,17 @@ use reqwest::{
     Proxy,
 };
 
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+const CONNECT_TIMEOUT_SECS: u64 = 15;
+
 pub struct ReqClient;
 
 impl ReqClient {
     pub fn build() -> Client {
         let mut client_builder = reqwest::Client::builder()
             .user_agent(crate::USER_AGENT.as_str())
-            .timeout(std::time::Duration::from_secs(10));
+            .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .connect_timeout(std::time::Duration::from_secs(CONNECT_TIMEOUT_SECS));
 
         if let Some(proxy) = get_proxy_settings() {
             client_builder =

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -65,6 +65,20 @@ pub struct MediaStream {
     pub channel_layout: Option<String>,
     #[serde(rename = "Index")]
     pub index: i64,
+    #[serde(rename = "IsForced", default)]
+    pub is_forced: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TrickplayInfo {
+    #[serde(rename = "Width", default)]
+    pub width: Option<u32>,
+    #[serde(rename = "Height", default)]
+    pub height: Option<u32>,
+    #[serde(rename = "Interval", default)]
+    pub interval: Option<u32>,
+    #[serde(rename = "UrlTemplate", default)]
+    pub url_template: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -97,6 +111,8 @@ pub struct MediaSource {
     // jellyfin
     #[serde(rename = "ETag")]
     pub etag: Option<String>,
+    #[serde(rename = "Trickplay", default)]
+    pub trickplay: Option<Vec<TrickplayInfo>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/gstl/player.rs
+++ b/src/gstl/player.rs
@@ -367,16 +367,22 @@ pub mod imp {
         }
 
         pub fn pause(&self) {
-            self.pipeline()
-                .set_state(gst::State::Paused)
-                .expect("Unable to set the pipeline to the `Paused` state");
+            if let Err(error) = self.pipeline().set_state(gst::State::Paused) {
+                tracing::warn!("Unable to pause playback: {error:?}");
+                return;
+            }
             self.notify_paused();
         }
 
         pub fn unpause(&self) {
-            self.pipeline()
-                .set_state(gst::State::Playing)
-                .expect("Unable to set the pipeline to the `Playing` state");
+            if self.state() != gst::State::Paused {
+                tracing::debug!("unpause ignored in state {:?}", self.state());
+                return;
+            }
+            if let Err(error) = self.pipeline().set_state(gst::State::Playing) {
+                tracing::warn!("Unable to resume playback: {error:?}");
+                return;
+            }
             self.notify_playing();
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,18 @@ mod gstl;
 mod macros;
 #[cfg(target_os = "linux")]
 mod mpris_common;
+mod playback;
+mod steam;
+mod subtitles;
+mod tv;
 mod ui;
 mod utils;
 
 pub mod client;
 
 pub use arg::Args;
-pub use config::*;
 use clap::Parser;
+pub use config::*;
 use gettextrs::*;
 use gtk::prelude::*;
 
@@ -38,13 +42,43 @@ pub const CLIENT_ID: &str = "Tsukimi";
 const APP_RESOURCE_PATH: &str = "/moe/tsuna/tsukimi";
 const GRESOURCE_FILE: &str = "tsukimi.gresource";
 
+/// Runtime override for local dev (`just dev`, distrobox). Production builds use
+/// compile-time `LOCALEDIR`; dev runs set `TSUKIMI_LOCALEDIR` because distrobox
+/// compiles with `/run/host/...` paths that are invalid when launching on the host.
+fn localizedir() -> &'static str {
+    static RUNTIME: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        env::var("TSUKIMI_LOCALEDIR")
+            .map(|path| Box::leak(path.into_boxed_str()) as &str)
+            .unwrap_or(LOCALEDIR)
+    })
+}
+
+fn pkgdatadir() -> std::path::PathBuf {
+    env::var("TSUKIMI_PKGDATADIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(PKGDATADIR))
+}
+
 pub fn run() -> gtk::glib::ExitCode {
-    Args::parse().init();
+    let args = Args::parse();
+    args.init();
+
+    let tv_active = tv::resolve_tv_mode(args.tv_mode(), args.fullscreen());
+    tv::set_tv_mode_active(tv_active);
+    tracing::info!(
+        "TV mode active: {tv_active} (cli={}, settings={})",
+        args.tv_mode(),
+        crate::ui::SETTINGS.tv_mode()
+    );
+    if tv_active && crate::steam::is_steam_big_picture() {
+        tracing::info!("Steam Big Picture detected, enabling TV mode for this session");
+    }
 
     // Initialize gettext
     setlocale(LocaleCategory::LcAll, String::new());
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8").expect("Failed to set textdomain codeset");
-    bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR)
+    bindtextdomain(GETTEXT_PACKAGE, localizedir())
         .expect("Invalid argument passed to bindtextdomain");
 
     textdomain(GETTEXT_PACKAGE).expect("Invalid string passed to textdomain");
@@ -61,7 +95,7 @@ pub fn run() -> gtk::glib::ExitCode {
 }
 
 fn register_gio_resources() {
-    let path = std::path::Path::new(PKGDATADIR).join(GRESOURCE_FILE);
+    let path = pkgdatadir().join(GRESOURCE_FILE);
     let resources = gtk::gio::Resource::load(path).expect("Failed to load resources.");
     gtk::gio::resources_register(&resources);
 }

--- a/src/playback/language_codes.rs
+++ b/src/playback/language_codes.rs
@@ -1,0 +1,170 @@
+use gettextrs::gettext;
+
+pub struct LanguageOption {
+    pub code: &'static str,
+    pub label: &'static str,
+}
+
+pub const LANGUAGE_OPTIONS: &[LanguageOption] = &[
+    LanguageOption {
+        code: "eng",
+        label: "English",
+    },
+    LanguageOption {
+        code: "jpn",
+        label: "Japanese",
+    },
+    LanguageOption {
+        code: "deu",
+        label: "German",
+    },
+    LanguageOption {
+        code: "fra",
+        label: "French",
+    },
+    LanguageOption {
+        code: "spa",
+        label: "Spanish",
+    },
+    LanguageOption {
+        code: "ita",
+        label: "Italian",
+    },
+    LanguageOption {
+        code: "por",
+        label: "Portuguese",
+    },
+    LanguageOption {
+        code: "rus",
+        label: "Russian",
+    },
+    LanguageOption {
+        code: "kor",
+        label: "Korean",
+    },
+    LanguageOption {
+        code: "zho",
+        label: "Chinese",
+    },
+    LanguageOption {
+        code: "cmn",
+        label: "Mandarin",
+    },
+    LanguageOption {
+        code: "yue",
+        label: "Cantonese",
+    },
+    LanguageOption {
+        code: "ara",
+        label: "Arabic",
+    },
+    LanguageOption {
+        code: "hin",
+        label: "Hindi",
+    },
+    LanguageOption {
+        code: "nld",
+        label: "Dutch",
+    },
+    LanguageOption {
+        code: "swe",
+        label: "Swedish",
+    },
+    LanguageOption {
+        code: "nor",
+        label: "Norwegian",
+    },
+    LanguageOption {
+        code: "dan",
+        label: "Danish",
+    },
+    LanguageOption {
+        code: "fin",
+        label: "Finnish",
+    },
+    LanguageOption {
+        code: "pol",
+        label: "Polish",
+    },
+    LanguageOption {
+        code: "ces",
+        label: "Czech",
+    },
+    LanguageOption {
+        code: "hun",
+        label: "Hungarian",
+    },
+    LanguageOption {
+        code: "ron",
+        label: "Romanian",
+    },
+    LanguageOption {
+        code: "tur",
+        label: "Turkish",
+    },
+    LanguageOption {
+        code: "tha",
+        label: "Thai",
+    },
+    LanguageOption {
+        code: "vie",
+        label: "Vietnamese",
+    },
+    LanguageOption {
+        code: "ind",
+        label: "Indonesian",
+    },
+    LanguageOption {
+        code: "msa",
+        label: "Malay",
+    },
+    LanguageOption {
+        code: "heb",
+        label: "Hebrew",
+    },
+    LanguageOption {
+        code: "ukr",
+        label: "Ukrainian",
+    },
+];
+
+pub fn language_combo_labels() -> Vec<String> {
+    LANGUAGE_OPTIONS
+        .iter()
+        .map(|opt| format!("{} ({})", opt.label, opt.code))
+        .collect()
+}
+
+pub fn code_at_index(index: u32) -> String {
+    LANGUAGE_OPTIONS
+        .get(index as usize)
+        .map(|opt| opt.code.to_string())
+        .unwrap_or_else(|| "eng".to_string())
+}
+
+pub fn index_for_code(code: &str) -> u32 {
+    LANGUAGE_OPTIONS
+        .iter()
+        .position(|opt| opt.code.eq_ignore_ascii_case(code))
+        .unwrap_or(0) as u32
+}
+
+pub fn when_language_combo_labels() -> Vec<String> {
+    let mut labels = vec![gettext("Any")];
+    labels.extend(language_combo_labels());
+    labels
+}
+
+pub fn code_at_when_index(index: u32) -> Option<String> {
+    if index == 0 {
+        return None;
+    }
+    Some(code_at_index(index - 1))
+}
+
+pub fn index_for_when_code(code: Option<&str>) -> u32 {
+    match code {
+        None | Some("") => 0,
+        Some(code) => index_for_code(code) + 1,
+    }
+}

--- a/src/playback/mod.rs
+++ b/src/playback/mod.rs
@@ -1,0 +1,6 @@
+pub mod language_codes;
+pub mod resolver;
+pub mod rule_editor;
+pub mod rules;
+
+pub use rule_editor::PlaybackRuleEditor;

--- a/src/playback/resolver.rs
+++ b/src/playback/resolver.rs
@@ -1,0 +1,188 @@
+use crate::{
+    client::structs::MediaStream,
+    playback::rules::{
+        self,
+        AudioOutcome,
+        PlaybackOutcome,
+        PlaybackRules,
+        SubtitleOutcome,
+    },
+    ui::{
+        SETTINGS,
+        widgets::item_utils::make_subtitle_version_choice,
+    },
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedPlaybackTracks {
+    pub prefer_audio_lang: Option<String>,
+    pub prefer_subtitle_lang: Option<String>,
+    pub forced_subtitles_only: bool,
+    pub subtitles_off: bool,
+}
+
+pub fn resolve_playback_tracks(audio_language: Option<&str>) -> ResolvedPlaybackTracks {
+    let config = PlaybackRules::load();
+    if !config.enabled {
+        return legacy_fallback();
+    }
+    let outcome = PlaybackRules::evaluate(audio_language, &config);
+    resolved_from_outcome(&outcome)
+}
+
+pub fn detect_default_audio_language(streams: &[MediaStream]) -> Option<String> {
+    let audio_streams: Vec<_> = streams
+        .iter()
+        .filter(|stream| stream.stream_type == "Audio")
+        .collect();
+    if audio_streams.is_empty() {
+        return None;
+    }
+
+    let preferred = SETTINGS.mpv_audio_preferred_lang_str();
+    if !preferred.is_empty()
+        && let Some(stream) = audio_streams
+            .iter()
+            .find(|stream| rules::language_matches(stream.language.as_deref(), &preferred))
+    {
+        return stream.language.clone();
+    }
+
+    audio_streams
+        .first()
+        .and_then(|stream| stream.language.clone())
+}
+
+pub fn resolve_slang(resolved: &ResolvedPlaybackTracks) -> String {
+    if resolved.subtitles_off {
+        return String::new();
+    }
+    resolved
+        .prefer_subtitle_lang
+        .clone()
+        .unwrap_or_else(|| SETTINGS.mpv_subtitle_preferred_lang_str())
+}
+
+pub fn resolve_alang(resolved: &ResolvedPlaybackTracks) -> String {
+    resolved
+        .prefer_audio_lang
+        .clone()
+        .unwrap_or_else(|| SETTINGS.mpv_audio_preferred_lang_str())
+}
+
+fn legacy_fallback() -> ResolvedPlaybackTracks {
+    ResolvedPlaybackTracks {
+        prefer_audio_lang: {
+            let lang = SETTINGS.mpv_audio_preferred_lang_str();
+            if lang.is_empty() { None } else { Some(lang) }
+        },
+        prefer_subtitle_lang: {
+            let lang = SETTINGS.mpv_subtitle_preferred_lang_str();
+            if lang.is_empty() { None } else { Some(lang) }
+        },
+        forced_subtitles_only: false,
+        subtitles_off: SETTINGS.mpv_subtitle_preferred_lang_str().is_empty(),
+    }
+}
+
+fn resolved_from_outcome(outcome: &PlaybackOutcome) -> ResolvedPlaybackTracks {
+    let mut resolved = legacy_fallback();
+
+    match &outcome.audio {
+        AudioOutcome::NoOverride => {}
+        AudioOutcome::PreferLanguage { language } => {
+            resolved.prefer_audio_lang = Some(language.clone());
+        }
+        AudioOutcome::Original => {
+            resolved.prefer_audio_lang = None;
+        }
+    }
+
+    match &outcome.subtitles {
+        SubtitleOutcome::Off => {
+            resolved.subtitles_off = true;
+            resolved.prefer_subtitle_lang = None;
+            resolved.forced_subtitles_only = false;
+        }
+        SubtitleOutcome::Forced { language } => {
+            resolved.subtitles_off = false;
+            resolved.forced_subtitles_only = true;
+            if !language.is_empty() {
+                resolved.prefer_subtitle_lang = Some(language.clone());
+            }
+        }
+        SubtitleOutcome::Full { language } => {
+            resolved.subtitles_off = false;
+            resolved.forced_subtitles_only = false;
+            if !language.is_empty() {
+                resolved.prefer_subtitle_lang = Some(language.clone());
+            }
+        }
+        SubtitleOutcome::PreferLanguage { language } => {
+            resolved.subtitles_off = false;
+            resolved.forced_subtitles_only = false;
+            resolved.prefer_subtitle_lang = Some(language.clone());
+        }
+    }
+
+    resolved
+}
+
+pub fn pick_subtitle_stream<'a>(
+    streams: &'a [MediaStream], resolved: &ResolvedPlaybackTracks,
+) -> Option<&'a MediaStream> {
+    if resolved.subtitles_off {
+        return None;
+    }
+
+    let subtitle_streams: Vec<_> = streams
+        .iter()
+        .filter(|s| s.stream_type == "Subtitle")
+        .collect();
+
+    if subtitle_streams.is_empty() {
+        return None;
+    }
+
+    if resolved.forced_subtitles_only
+        && let Some(stream) = subtitle_streams
+            .iter()
+            .find(|s| s.is_forced.unwrap_or(false))
+    {
+        return Some(*stream);
+    }
+
+    if let Some(lang) = resolved.prefer_subtitle_lang.as_deref()
+        && let Some(stream) = subtitle_streams
+            .iter()
+            .find(|s| rules::language_matches(stream_language(s), lang))
+    {
+        return Some(*stream);
+    }
+
+    let lang_list: Vec<(i64, String)> = subtitle_streams
+        .iter()
+        .map(|s| {
+            (
+                s.index,
+                s.display_title
+                    .clone()
+                    .or_else(|| s.title.clone())
+                    .unwrap_or_default(),
+            )
+        })
+        .collect();
+
+    if let Some((_, list_index)) = make_subtitle_version_choice(lang_list) {
+        return subtitle_streams.get(list_index).copied();
+    }
+
+    subtitle_streams.first().copied()
+}
+
+fn stream_language(stream: &MediaStream) -> Option<&str> {
+    stream
+        .language
+        .as_deref()
+        .or(stream.display_language.as_deref())
+}

--- a/src/playback/rule_editor.rs
+++ b/src/playback/rule_editor.rs
@@ -1,0 +1,345 @@
+use adw::prelude::*;
+use gettextrs::gettext;
+
+use super::{
+    language_codes::{
+        code_at_index,
+        code_at_when_index,
+        index_for_code,
+        index_for_when_code,
+        language_combo_labels,
+        when_language_combo_labels,
+    },
+    rules::{
+        AudioOutcome,
+        LanguageCondition,
+        PlaybackOutcome,
+        PlaybackRule,
+        PlaybackRulesConfig,
+        RuleCondition,
+        SubtitleOutcome,
+    },
+};
+use crate::ui::input::{
+    InputAction,
+    SettingsNavigator,
+    popover_navigator,
+};
+
+thread_local! {
+    static ACTIVE_EDITOR: std::cell::RefCell<Option<PlaybackRuleEditor>> = const { std::cell::RefCell::new(None) };
+}
+
+static SETTINGS_NAVIGATOR: std::sync::LazyLock<std::sync::Mutex<SettingsNavigator>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(SettingsNavigator::default()));
+
+pub fn handle_active_input(action: InputAction) -> bool {
+    ACTIVE_EDITOR.with(|slot| {
+        let Some(editor) = slot.borrow().clone() else {
+            return false;
+        };
+        if !editor.dialog.is_visible() {
+            *slot.borrow_mut() = None;
+            return false;
+        }
+        if popover_navigator::handle_widget_tree(
+            &editor.dialog.clone().upcast::<gtk::Widget>(),
+            action,
+        ) {
+            return true;
+        }
+        SETTINGS_NAVIGATOR
+            .lock()
+            .unwrap()
+            .handle_widgets(&editor.focus_widgets(), action, || {
+                editor.dialog.close();
+            })
+    })
+}
+
+#[derive(Clone)]
+pub struct PlaybackRuleEditor {
+    dialog: adw::Dialog,
+    priority_entry: adw::SpinRow,
+    when_op_combo: adw::ComboRow,
+    when_lang_combo: adw::ComboRow,
+    subtitle_combo: adw::ComboRow,
+    subtitle_lang_combo: adw::ComboRow,
+    save_button: gtk::Button,
+    cancel_button: gtk::Button,
+    editing_default: bool,
+}
+
+impl PlaybackRuleEditor {
+    pub fn new_rule_dialog(next_priority: u32) -> Self {
+        let editor = Self::build_dialog(&gettext("Add Subtitle Rule"), false);
+        editor.priority_entry.set_value(next_priority as f64);
+        editor
+            .when_lang_combo
+            .set_selected(index_for_when_code(Some("jpn")));
+        editor.when_op_combo.set_selected(0);
+        editor.subtitle_combo.set_selected(0);
+        editor
+    }
+
+    pub fn edit_rule_dialog(rule: &PlaybackRule) -> Self {
+        let mut editor = Self::build_dialog(&gettext("Edit Subtitle Rule"), false);
+        editor.load_rule(rule);
+        editor
+    }
+
+    pub fn default_outcome_dialog(config: &PlaybackRulesConfig) -> Self {
+        let mut editor = Self::build_dialog(&gettext("Default Subtitle Outcome"), true);
+        editor.load_outcome(&config.default);
+        editor
+    }
+
+    fn language_combo_row(title: &str) -> adw::ComboRow {
+        let labels = language_combo_labels();
+        let refs: Vec<&str> = labels.iter().map(String::as_str).collect();
+        let combo = adw::ComboRow::new();
+        combo.set_title(title);
+        combo.set_model(Some(&gtk::StringList::new(&refs)));
+        combo
+    }
+
+    fn build_dialog(title: &str, editing_default: bool) -> Self {
+        let dialog = adw::Dialog::builder()
+            .title(title)
+            .content_width(480)
+            .content_height(360)
+            .build();
+
+        let content = gtk::Box::new(gtk::Orientation::Vertical, 12);
+        content.set_margin_top(12);
+        content.set_margin_bottom(12);
+        content.set_margin_start(12);
+        content.set_margin_end(12);
+
+        let priority_entry = adw::SpinRow::with_range(1.0, 999.0, 1.0);
+        priority_entry.set_title(&gettext("Priority"));
+
+        let when_lang_labels = when_language_combo_labels();
+        let when_lang_refs: Vec<&str> = when_lang_labels.iter().map(String::as_str).collect();
+        let when_lang_combo = adw::ComboRow::new();
+        when_lang_combo.set_title(&gettext("When audio language"));
+        when_lang_combo.set_model(Some(&gtk::StringList::new(&when_lang_refs)));
+
+        let when_op_combo = adw::ComboRow::new();
+        when_op_combo.set_title(&gettext("Condition"));
+        when_op_combo.set_model(Some(&gtk::StringList::new(&[
+            &gettext("Equals"),
+            &gettext("Not equals"),
+        ])));
+
+        let subtitle_combo = adw::ComboRow::new();
+        subtitle_combo.set_title(&gettext("Subtitles"));
+        subtitle_combo.set_model(Some(&gtk::StringList::new(&[
+            &gettext("Off"),
+            &gettext("Forced"),
+            &gettext("Full"),
+            &gettext("Prefer language"),
+        ])));
+
+        let subtitle_lang_combo = Self::language_combo_row(&gettext("Subtitle language"));
+
+        let button_box = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+        button_box.set_halign(gtk::Align::End);
+        let save_button = gtk::Button::with_label(&gettext("Save"));
+        save_button.add_css_class("suggested-action");
+        let cancel_button = gtk::Button::with_label(&gettext("Cancel"));
+        button_box.append(&cancel_button);
+        button_box.append(&save_button);
+
+        content.append(&priority_entry);
+        content.append(&when_lang_combo);
+        content.append(&when_op_combo);
+        content.append(&subtitle_combo);
+        content.append(&subtitle_lang_combo);
+        content.append(&button_box);
+        dialog.set_child(Some(&content));
+
+        if editing_default {
+            priority_entry.set_visible(false);
+            when_lang_combo.set_visible(false);
+            when_op_combo.set_visible(false);
+        }
+
+        when_lang_combo.connect_selected_notify({
+            let when_op_combo = when_op_combo.clone();
+            move |combo| {
+                when_op_combo.set_visible(combo.selected() > 0);
+            }
+        });
+        when_op_combo.set_visible(when_lang_combo.selected() > 0);
+
+        cancel_button.connect_clicked({
+            let dialog = dialog.clone();
+            move |_| {
+                ACTIVE_EDITOR.with(|slot| *slot.borrow_mut() = None);
+                dialog.close();
+            }
+        });
+
+        dialog.connect_closed(|_| {
+            ACTIVE_EDITOR.with(|slot| *slot.borrow_mut() = None);
+        });
+
+        Self {
+            dialog,
+            priority_entry,
+            when_op_combo,
+            when_lang_combo,
+            subtitle_combo,
+            subtitle_lang_combo,
+            save_button,
+            cancel_button,
+            editing_default,
+        }
+    }
+
+    pub fn present(&self, parent: Option<&impl IsA<gtk::Widget>>) {
+        ACTIVE_EDITOR.with(|slot| {
+            *slot.borrow_mut() = Some(self.clone());
+        });
+        self.dialog.present(parent);
+    }
+
+    pub fn focus_widgets(&self) -> Vec<gtk::Widget> {
+        let mut widgets = Vec::new();
+        if self.priority_entry.is_visible() {
+            widgets.push(self.priority_entry.clone().upcast());
+        }
+        if self.when_lang_combo.is_visible() {
+            widgets.push(self.when_lang_combo.clone().upcast());
+        }
+        if self.when_op_combo.is_visible() {
+            widgets.push(self.when_op_combo.clone().upcast());
+        }
+        widgets.push(self.subtitle_combo.clone().upcast());
+        widgets.push(self.subtitle_lang_combo.clone().upcast());
+        widgets.push(self.save_button.clone().upcast());
+        widgets.push(self.cancel_button.clone().upcast());
+        widgets
+    }
+
+    pub fn connect_save<F>(&self, callback: F)
+    where
+        F: Fn(PlaybackRule) + 'static,
+    {
+        let dialog = self.dialog.clone();
+        let editor = PlaybackRuleEditorRef {
+            priority_entry: self.priority_entry.clone(),
+            when_op_combo: self.when_op_combo.clone(),
+            when_lang_combo: self.when_lang_combo.clone(),
+            subtitle_combo: self.subtitle_combo.clone(),
+            subtitle_lang_combo: self.subtitle_lang_combo.clone(),
+            editing_default: self.editing_default,
+        };
+        self.save_button.connect_clicked(move |_| {
+            let rule = if editor.editing_default {
+                PlaybackRule {
+                    priority: 0,
+                    when: RuleCondition {
+                        audio_language: LanguageCondition::Any,
+                    },
+                    then: editor.build_outcome(),
+                }
+            } else {
+                editor.build_rule()
+            };
+            callback(rule);
+            ACTIVE_EDITOR.with(|slot| *slot.borrow_mut() = None);
+            dialog.close();
+        });
+    }
+
+    fn load_rule(&mut self, rule: &PlaybackRule) {
+        self.priority_entry.set_value(rule.priority as f64);
+        match &rule.when.audio_language {
+            LanguageCondition::Any => {
+                self.when_lang_combo.set_selected(0);
+            }
+            LanguageCondition::Equals(lang) => {
+                self.when_lang_combo
+                    .set_selected(index_for_when_code(Some(lang)));
+                self.when_op_combo.set_selected(0);
+            }
+            LanguageCondition::NotEquals(lang) => {
+                self.when_lang_combo
+                    .set_selected(index_for_when_code(Some(lang)));
+                self.when_op_combo.set_selected(1);
+            }
+        }
+        self.when_op_combo
+            .set_visible(self.when_lang_combo.selected() > 0);
+        self.load_outcome(&rule.then);
+    }
+
+    fn load_outcome(&mut self, outcome: &PlaybackOutcome) {
+        match &outcome.subtitles {
+            SubtitleOutcome::Off => self.subtitle_combo.set_selected(0),
+            SubtitleOutcome::Forced { language } => {
+                self.subtitle_combo.set_selected(1);
+                self.subtitle_lang_combo
+                    .set_selected(index_for_code(language));
+            }
+            SubtitleOutcome::Full { language } => {
+                self.subtitle_combo.set_selected(2);
+                self.subtitle_lang_combo
+                    .set_selected(index_for_code(language));
+            }
+            SubtitleOutcome::PreferLanguage { language } => {
+                self.subtitle_combo.set_selected(3);
+                self.subtitle_lang_combo
+                    .set_selected(index_for_code(language));
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PlaybackRuleEditorRef {
+    priority_entry: adw::SpinRow,
+    when_op_combo: adw::ComboRow,
+    when_lang_combo: adw::ComboRow,
+    subtitle_combo: adw::ComboRow,
+    subtitle_lang_combo: adw::ComboRow,
+    editing_default: bool,
+}
+
+impl PlaybackRuleEditorRef {
+    fn build_rule(&self) -> PlaybackRule {
+        PlaybackRule {
+            priority: self.priority_entry.value() as u32,
+            when: self.build_condition(),
+            then: self.build_outcome(),
+        }
+    }
+
+    fn build_condition(&self) -> RuleCondition {
+        let audio_language = match code_at_when_index(self.when_lang_combo.selected()) {
+            None => LanguageCondition::Any,
+            Some(lang) => match self.when_op_combo.selected() {
+                1 => LanguageCondition::NotEquals(lang),
+                _ => LanguageCondition::Equals(lang),
+            },
+        };
+        RuleCondition { audio_language }
+    }
+
+    fn build_outcome(&self) -> PlaybackOutcome {
+        let sub_lang = code_at_index(self.subtitle_lang_combo.selected());
+        let subtitles = match self.subtitle_combo.selected() {
+            1 => SubtitleOutcome::Forced { language: sub_lang },
+            2 => SubtitleOutcome::Full { language: sub_lang },
+            3 => SubtitleOutcome::PreferLanguage { language: sub_lang },
+            _ => SubtitleOutcome::Off,
+        };
+
+        PlaybackOutcome {
+            audio: AudioOutcome::NoOverride,
+            subtitles,
+        }
+    }
+}

--- a/src/playback/rules.rs
+++ b/src/playback/rules.rs
@@ -1,0 +1,143 @@
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::ui::SETTINGS;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlaybackRulesConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub rules: Vec<PlaybackRule>,
+    #[serde(default)]
+    pub default: PlaybackOutcome,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlaybackRule {
+    pub priority: u32,
+    pub when: RuleCondition,
+    pub then: PlaybackOutcome,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleCondition {
+    #[serde(default)]
+    pub audio_language: LanguageCondition,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(tag = "op", content = "value")]
+pub enum LanguageCondition {
+    #[default]
+    #[serde(rename = "any")]
+    Any,
+    #[serde(rename = "equals")]
+    Equals(String),
+    #[serde(rename = "not_equals")]
+    NotEquals(String),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PlaybackOutcome {
+    #[serde(default)]
+    pub audio: AudioOutcome,
+    #[serde(default)]
+    pub subtitles: SubtitleOutcome,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(tag = "mode")]
+pub enum AudioOutcome {
+    #[default]
+    #[serde(rename = "no_override")]
+    NoOverride,
+    #[serde(rename = "prefer_language")]
+    PreferLanguage { language: String },
+    #[serde(rename = "original")]
+    Original,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(tag = "mode")]
+pub enum SubtitleOutcome {
+    #[default]
+    #[serde(rename = "off")]
+    Off,
+    #[serde(rename = "forced")]
+    Forced {
+        #[serde(default)]
+        language: String,
+    },
+    #[serde(rename = "full")]
+    Full {
+        #[serde(default)]
+        language: String,
+    },
+    #[serde(rename = "prefer_language")]
+    PreferLanguage { language: String },
+}
+
+pub struct PlaybackRules;
+
+impl PlaybackRules {
+    pub fn load() -> PlaybackRulesConfig {
+        SETTINGS.playback_conditional_rules()
+    }
+
+    pub fn evaluate(audio_language: Option<&str>, config: &PlaybackRulesConfig) -> PlaybackOutcome {
+        if !config.enabled {
+            return PlaybackOutcome::default();
+        }
+
+        let lang = audio_language.unwrap_or("");
+
+        let mut rules = config.rules.clone();
+        rules.sort_by_key(|r| r.priority);
+
+        for rule in rules {
+            if condition_matches(&rule.when, lang) {
+                return rule.then.clone();
+            }
+        }
+
+        config.default.clone()
+    }
+}
+
+fn condition_matches(condition: &RuleCondition, audio_language: &str) -> bool {
+    match &condition.audio_language {
+        LanguageCondition::Any => true,
+        LanguageCondition::Equals(expected) => language_matches(Some(audio_language), expected),
+        LanguageCondition::NotEquals(expected) => !language_matches(Some(audio_language), expected),
+    }
+}
+
+pub fn language_matches(actual: Option<&str>, expected: &str) -> bool {
+    let Some(actual) = actual else {
+        return false;
+    };
+    let actual = actual.to_lowercase();
+    let expected = expected.to_lowercase();
+    actual == expected
+        || actual.starts_with(&format!("{expected}-"))
+        || expected.starts_with(&actual)
+        || lang_display_name(&actual).contains(&lang_display_name(&expected))
+}
+
+fn lang_display_name(code: &str) -> String {
+    match code {
+        "eng" | "en" => "english".into(),
+        "jpn" | "ja" | "jap" => "japanese".into(),
+        "chs" | "zh" | "chi" | "zho" | "cmn" => "chinese".into(),
+        "fre" | "fr" | "fra" => "french".into(),
+        "ger" | "de" | "deu" => "german".into(),
+        "spa" | "es" => "spanish".into(),
+        "rus" | "ru" => "russian".into(),
+        "por" | "pt" => "portuguese".into(),
+        "ara" | "ar" => "arabic".into(),
+        other => other.to_string(),
+    }
+}

--- a/src/steam/detect.rs
+++ b/src/steam/detect.rs
@@ -1,0 +1,12 @@
+use std::env;
+
+fn env_is(name: &str, value: &str) -> bool {
+    env::var(name).ok().is_some_and(|v| v == value)
+}
+
+/// Detect Steam Big Picture / Steam Deck Gaming mode via environment variables.
+pub fn is_steam_big_picture() -> bool {
+    env_is("SteamTenfoot", "1")
+        || (env_is("SteamOS", "1") && env_is("SteamGamepadUI", "1"))
+        || env_is("SteamDeck", "1")
+}

--- a/src/steam/mod.rs
+++ b/src/steam/mod.rs
@@ -1,0 +1,4 @@
+pub mod detect;
+pub mod shortcuts;
+
+pub use detect::is_steam_big_picture;

--- a/src/steam/shortcuts.rs
+++ b/src/steam/shortcuts.rs
@@ -1,0 +1,131 @@
+use std::{
+    fs,
+    path::{
+        Path,
+        PathBuf,
+    },
+    process::Command,
+};
+
+use steam_shortcuts_util::{
+    Shortcut,
+    parse_shortcuts,
+    shortcut::ShortcutOwned,
+    shortcuts_to_bytes,
+};
+
+use crate::ui::widgets::utils::GlobalToast;
+
+pub fn is_steam_running() -> bool {
+    Command::new("pgrep")
+        .arg("-x")
+        .arg("steam")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+pub fn find_steam_root() -> Option<PathBuf> {
+    let candidates = [
+        dirs::home_dir().map(|h| h.join(".steam/root")),
+        dirs::home_dir().map(|h| h.join(".local/share/Steam")),
+        dirs::home_dir().map(|h| h.join(".var/app/com.valvesoftware.Steam/data/Steam")),
+    ];
+    candidates.into_iter().flatten().find(|path| path.is_dir())
+}
+
+fn find_active_user_id(steam_root: &Path) -> Option<String> {
+    let loginusers = fs::read_to_string(steam_root.join("config/loginusers.vdf")).ok()?;
+    let mut most_recent_id = None;
+    let mut in_user = false;
+    for line in loginusers.lines() {
+        let line = line.trim();
+        if line.starts_with('"') && line.ends_with('{') {
+            in_user = true;
+            most_recent_id = Some(
+                line.trim_matches('"')
+                    .trim_end_matches('{')
+                    .trim()
+                    .to_string(),
+            );
+        }
+        if in_user && line.contains("\"MostRecent\"") && line.contains("\"1\"") {
+            return most_recent_id;
+        }
+        if line == "}" {
+            in_user = false;
+        }
+    }
+    None
+}
+
+pub fn shortcut_exists(steam_root: &Path, user_id: &str, exe: &str) -> bool {
+    let path = steam_root.join(format!("userdata/{user_id}/config/shortcuts.vdf"));
+    let Ok(content) = fs::read(&path) else {
+        return false;
+    };
+    let Ok(shortcuts) = parse_shortcuts(content.as_slice()) else {
+        return false;
+    };
+    shortcuts
+        .iter()
+        .any(|s| s.exe == exe || s.exe.contains("tsukimi"))
+}
+
+pub fn add_tsukimi_to_steam(window: &crate::Window) -> Result<(), String> {
+    if is_steam_running() {
+        return Err(
+            "Close Steam completely before adding Tsukimi. Steam overwrites shortcuts on exit."
+                .into(),
+        );
+    }
+
+    let steam_root = find_steam_root().ok_or("Steam installation not found")?;
+    let user_id = find_active_user_id(&steam_root).ok_or("Could not find active Steam user")?;
+
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let exe_str = exe.to_string_lossy().to_string();
+    let start_dir = exe
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if shortcut_exists(&steam_root, &user_id, &exe_str) {
+        return Err("Tsukimi is already in your Steam library".into());
+    }
+
+    let shortcuts_path = steam_root.join(format!("userdata/{user_id}/config/shortcuts.vdf"));
+    let mut owned: Vec<ShortcutOwned> = if shortcuts_path.exists() {
+        let content = fs::read(&shortcuts_path).map_err(|e| e.to_string())?;
+        parse_shortcuts(content.as_slice())?
+            .into_iter()
+            .map(|s| s.to_owned())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let order = owned.len().to_string();
+    let new_shortcut = Shortcut::new(
+        &order,
+        "Tsukimi",
+        &exe_str,
+        &start_dir,
+        "",
+        "",
+        "--tv-mode --fullscreen",
+    );
+    let mut owned_shortcut = new_shortcut.to_owned();
+    owned_shortcut.tags = vec!["Installed".to_string(), "Ready to Play".to_string()];
+    owned.push(owned_shortcut);
+
+    let borrowed: Vec<Shortcut> = owned.iter().map(|s| s.borrow()).collect();
+
+    if let Some(parent) = shortcuts_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    fs::write(&shortcuts_path, shortcuts_to_bytes(&borrowed)).map_err(|e| e.to_string())?;
+
+    window.toast("Added to Steam. Restart Steam, then launch Tsukimi from Big Picture.");
+    Ok(())
+}

--- a/src/subtitles/dialog.rs
+++ b/src/subtitles/dialog.rs
@@ -1,0 +1,539 @@
+use std::{
+    cell::RefCell,
+    path::PathBuf,
+    rc::Rc,
+};
+
+use adw::prelude::*;
+use gettextrs::gettext;
+
+use super::provider::{
+    SubtitleProviderRegistry,
+    SubtitleResult,
+};
+use crate::{
+    playback::language_codes,
+    tv::{
+        osk,
+        set_tv_focused,
+    },
+    ui::{
+        SETTINGS,
+        input::InputAction,
+    },
+    utils::spawn,
+};
+
+thread_local! {
+    static ACTIVE_DIALOG: RefCell<Option<Rc<SubtitleSearchDialogInner>>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SubtitleZone {
+    Search,
+    Language,
+    SearchButton,
+    Results,
+    Download,
+    Close,
+}
+
+type DownloadCallback = Box<dyn Fn(PathBuf)>;
+
+struct SubtitleSearchDialogInner {
+    dialog: adw::Dialog,
+    search_entry: adw::EntryRow,
+    language_combo: adw::ComboRow,
+    results_list: gtk::ListBox,
+    status_label: gtk::Label,
+    search_button: gtk::Button,
+    download_button: gtk::Button,
+    close_button: gtk::Button,
+    results: RefCell<Vec<SubtitleResult>>,
+    selected_index: RefCell<Option<usize>>,
+    on_downloaded: RefCell<Option<DownloadCallback>>,
+    imdb_id: RefCell<Option<String>>,
+    zone: RefCell<SubtitleZone>,
+    result_index: RefCell<usize>,
+}
+
+pub struct SubtitleSearchDialog {
+    inner: Rc<SubtitleSearchDialogInner>,
+}
+
+pub fn handle_active_input(action: InputAction) -> bool {
+    ACTIVE_DIALOG.with(|slot| {
+        let Some(inner) = slot.borrow().clone() else {
+            return false;
+        };
+        if !inner.dialog.is_visible() {
+            *slot.borrow_mut() = None;
+            return false;
+        }
+        if inner.has_open_popover() {
+            return false;
+        }
+        inner.handle_input(action)
+    })
+}
+
+impl SubtitleSearchDialogInner {
+    fn has_open_popover(&self) -> bool {
+        let Some(content) = self.dialog.child() else {
+            return false;
+        };
+        popover_open_in_tree(content.upcast_ref())
+    }
+
+    fn clear_focus(&self) {
+        set_tv_focused(&self.search_entry, false);
+        set_tv_focused(&self.language_combo, false);
+        set_tv_focused(&self.search_button, false);
+        set_tv_focused(&self.download_button, false);
+        set_tv_focused(&self.close_button, false);
+        let mut child = self.results_list.first_child();
+        while let Some(row) = child {
+            set_tv_focused(&row, false);
+            child = row.next_sibling();
+        }
+    }
+
+    fn apply_zone_focus(&self) {
+        self.clear_focus();
+        match *self.zone.borrow() {
+            SubtitleZone::Search => set_tv_focused(&self.search_entry, true),
+            SubtitleZone::Language => set_tv_focused(&self.language_combo, true),
+            SubtitleZone::SearchButton => set_tv_focused(&self.search_button, true),
+            SubtitleZone::Download => set_tv_focused(&self.download_button, true),
+            SubtitleZone::Close => set_tv_focused(&self.close_button, true),
+            SubtitleZone::Results => {
+                let idx = *self.result_index.borrow();
+                if let Some(row) = self.results_list.row_at_index(idx as i32) {
+                    self.results_list.select_row(Some(&row));
+                    set_tv_focused(&row, true);
+                }
+            }
+        }
+    }
+
+    fn visible_zones(&self) -> Vec<SubtitleZone> {
+        let mut zones = vec![
+            SubtitleZone::Search,
+            SubtitleZone::Language,
+            SubtitleZone::SearchButton,
+        ];
+        if !self.results.borrow().is_empty() {
+            zones.push(SubtitleZone::Results);
+        }
+        zones.push(SubtitleZone::Download);
+        zones.push(SubtitleZone::Close);
+        zones
+    }
+
+    fn selected_language_code(&self) -> String {
+        let index = self.language_combo.selected();
+        if index == 0 {
+            return String::new();
+        }
+        language_codes::code_at_index(index - 1)
+    }
+
+    fn handle_input(&self, action: InputAction) -> bool {
+        match action {
+            InputAction::Back => {
+                self.dialog.close();
+                true
+            }
+            InputAction::NavigateUp | InputAction::NavigateDown => {
+                let zones = self.visible_zones();
+                let current = *self.zone.borrow();
+                let pos = zones.iter().position(|z| *z == current).unwrap_or(0) as i32;
+                let delta = if matches!(action, InputAction::NavigateDown) {
+                    1
+                } else {
+                    -1
+                };
+                let next = (pos + delta).clamp(0, zones.len() as i32 - 1) as usize;
+                *self.zone.borrow_mut() = zones[next];
+                self.apply_zone_focus();
+                true
+            }
+            InputAction::NavigateLeft | InputAction::NavigateRight => {
+                if *self.zone.borrow() != SubtitleZone::Results {
+                    return false;
+                }
+                let count = self.results.borrow().len();
+                if count == 0 {
+                    return false;
+                }
+                let delta = if matches!(action, InputAction::NavigateRight) {
+                    1
+                } else {
+                    -1
+                };
+                let current = *self.result_index.borrow() as i32;
+                let next = (current + delta).clamp(0, count as i32 - 1) as usize;
+                *self.result_index.borrow_mut() = next;
+                self.apply_zone_focus();
+                true
+            }
+            InputAction::Activate => match *self.zone.borrow() {
+                SubtitleZone::Search => {
+                    self.search_entry.grab_focus();
+                    true
+                }
+                SubtitleZone::Language => {
+                    self.language_combo.grab_focus();
+                    adw::prelude::ActionRowExt::activate(&self.language_combo);
+                    true
+                }
+                SubtitleZone::SearchButton => {
+                    self.search_button.emit_clicked();
+                    true
+                }
+                SubtitleZone::Results => {
+                    let idx = *self.result_index.borrow();
+                    *self.selected_index.borrow_mut() = Some(idx);
+                    self.download_button.set_sensitive(true);
+                    if let Some(row) = self.results_list.row_at_index(idx as i32) {
+                        self.results_list.select_row(Some(&row));
+                    }
+                    true
+                }
+                SubtitleZone::Download => {
+                    self.download_button.emit_clicked();
+                    true
+                }
+                SubtitleZone::Close => {
+                    self.close_button.emit_clicked();
+                    true
+                }
+            },
+            _ => false,
+        }
+    }
+
+    fn unregister(&self) {
+        ACTIVE_DIALOG.with(|slot| {
+            *slot.borrow_mut() = None;
+        });
+    }
+}
+
+impl SubtitleSearchDialog {
+    pub fn new(query: &str, language: &str, imdb_id: Option<&str>) -> Self {
+        let dialog = adw::Dialog::builder()
+            .title(gettext("Download Subtitles"))
+            .content_width(520)
+            .content_height(480)
+            .build();
+
+        let content = gtk::Box::new(gtk::Orientation::Vertical, 12);
+        content.set_margin_top(12);
+        content.set_margin_bottom(12);
+        content.set_margin_start(12);
+        content.set_margin_end(12);
+
+        let search_entry = adw::EntryRow::new();
+        search_entry.set_title(&gettext("Search"));
+        search_entry.set_text(query);
+
+        let language_labels: Vec<String> = std::iter::once(gettext("Any language"))
+            .chain(language_codes::language_combo_labels())
+            .collect();
+        let language_model = gtk::StringList::new(
+            &language_labels
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>(),
+        );
+        let language_combo = adw::ComboRow::new();
+        language_combo.set_title(&gettext("Language"));
+        language_combo.set_model(Some(&language_model));
+        language_combo.set_selected(language_combo_index(language));
+
+        let search_button = gtk::Button::with_label(&gettext("Search"));
+        search_button.add_css_class("suggested-action");
+
+        let results_scrolled = gtk::ScrolledWindow::builder()
+            .vexpand(true)
+            .min_content_height(240)
+            .build();
+        let results_list = gtk::ListBox::new();
+        results_list.set_selection_mode(gtk::SelectionMode::Single);
+        results_scrolled.set_child(Some(&results_list));
+
+        let status_label = gtk::Label::new(None);
+        status_label.add_css_class("dim-label");
+        status_label.set_halign(gtk::Align::Start);
+
+        let button_box = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+        button_box.set_halign(gtk::Align::End);
+        let download_button = gtk::Button::with_label(&gettext("Download"));
+        download_button.set_sensitive(false);
+        let close_button = gtk::Button::with_label(&gettext("Close"));
+        button_box.append(&download_button);
+        button_box.append(&close_button);
+
+        content.append(&search_entry);
+        content.append(&language_combo);
+        content.append(&search_button);
+        content.append(&results_scrolled);
+        content.append(&status_label);
+        content.append(&button_box);
+        dialog.set_child(Some(&content));
+
+        osk::attach_on_screen_keyboard(&search_entry);
+
+        let inner = Rc::new(SubtitleSearchDialogInner {
+            dialog: dialog.clone(),
+            search_entry,
+            language_combo,
+            results_list,
+            status_label,
+            search_button,
+            download_button,
+            close_button: close_button.clone(),
+            results: RefCell::new(Vec::new()),
+            selected_index: RefCell::new(None),
+            on_downloaded: RefCell::new(None),
+            imdb_id: RefCell::new(imdb_id.map(str::to_string)),
+            zone: RefCell::new(SubtitleZone::Search),
+            result_index: RefCell::new(0),
+        });
+
+        close_button.connect_clicked({
+            let inner = inner.clone();
+            let dialog = dialog.clone();
+            move |_| {
+                inner.unregister();
+                dialog.close();
+            }
+        });
+
+        dialog.connect_closed({
+            let inner = inner.clone();
+            move |_| {
+                inner.unregister();
+            }
+        });
+
+        let this = Self {
+            inner: inner.clone(),
+        };
+        this.wire_signals(inner);
+        this
+    }
+
+    pub fn present(&self, parent: Option<&impl IsA<gtk::Widget>>) {
+        *self.inner.zone.borrow_mut() = SubtitleZone::Search;
+        *self.inner.result_index.borrow_mut() = 0;
+        self.inner.apply_zone_focus();
+        ACTIVE_DIALOG.with(|slot| {
+            *slot.borrow_mut() = Some(self.inner.clone());
+        });
+        self.inner.dialog.present(parent);
+    }
+
+    pub fn connect_subtitle_downloaded<F>(&self, callback: F)
+    where
+        F: Fn(PathBuf) + 'static,
+    {
+        *self.inner.on_downloaded.borrow_mut() = Some(Box::new(callback));
+    }
+
+    fn wire_signals(&self, inner: Rc<SubtitleSearchDialogInner>) {
+        {
+            let inner = inner.clone();
+            self.inner.search_button.connect_clicked(move |_| {
+                let query = inner.search_entry.text().to_string();
+                if query.len() < 2 {
+                    inner
+                        .status_label
+                        .set_text(&gettext("Enter at least 2 characters"));
+                    return;
+                }
+                let language = inner.selected_language_code();
+                let registry = SubtitleProviderRegistry::new();
+                if registry.searchable_providers().is_empty() {
+                    inner
+                        .status_label
+                        .set_text(&gettext("Configure subtitle provider API keys in Settings"));
+                    return;
+                }
+                inner.status_label.set_text(&gettext("Searching..."));
+                inner.download_button.set_sensitive(false);
+                while let Some(child) = inner.results_list.first_child() {
+                    inner.results_list.remove(&child);
+                }
+                inner.results.borrow_mut().clear();
+                *inner.selected_index.borrow_mut() = None;
+                *inner.result_index.borrow_mut() = 0;
+
+                let results_list = inner.results_list.clone();
+                let status_label = inner.status_label.clone();
+                let results = inner.results.clone();
+                let inner_for_spawn = inner.clone();
+
+                spawn(async move {
+                    let registry = SubtitleProviderRegistry::new();
+                    let imdb_id = inner_for_spawn.imdb_id.borrow().clone();
+                    let found = registry
+                        .search_all(&query, imdb_id.as_deref(), &language)
+                        .await;
+
+                    for result in found {
+                        let row = adw::ActionRow::new();
+                        row.set_title(&result.title);
+                        row.set_subtitle(&format!("{} · {}", result.provider, result.language));
+                        results_list.append(&row);
+                        results.borrow_mut().push(result);
+                    }
+
+                    let count = results.borrow().len();
+                    if count == 0 {
+                        status_label.set_text(&gettext(
+                            "No subtitles found (check provider API keys and rate limits)",
+                        ));
+                    } else if let Some(first) = results_list.row_at_index(0) {
+                        results_list.select_row(Some(&first));
+                        status_label.set_text(&format!("{count} {}", gettext("results")));
+                        *inner_for_spawn.result_index.borrow_mut() = 0;
+                        if *inner_for_spawn.zone.borrow() == SubtitleZone::Results {
+                            inner_for_spawn.apply_zone_focus();
+                        }
+                    }
+                });
+            });
+        }
+
+        {
+            let inner = inner.clone();
+            self.inner
+                .results_list
+                .connect_row_selected(move |list, row| {
+                    let index = row.and_then(|selected| {
+                        let mut child = list.first_child();
+                        let mut index = 0usize;
+                        while let Some(row_widget) = child {
+                            let next = row_widget.next_sibling();
+                            if let Ok(list_row) = row_widget.downcast::<gtk::ListBoxRow>()
+                                && list_row.eq(selected)
+                            {
+                                return Some(index);
+                            }
+                            index += 1;
+                            child = next;
+                        }
+                        None
+                    });
+                    *inner.selected_index.borrow_mut() = index;
+                    if let Some(index) = index {
+                        *inner.result_index.borrow_mut() = index;
+                    }
+                    inner
+                        .download_button
+                        .set_sensitive(inner.selected_index.borrow().is_some());
+                });
+        }
+
+        {
+            let inner = inner.clone();
+            self.inner.download_button.connect_clicked(move |_| {
+                let Some(index) = *inner.selected_index.borrow() else {
+                    return;
+                };
+                let Some(result) = inner.results.borrow().get(index).cloned() else {
+                    return;
+                };
+
+                inner.status_label.set_text(&gettext("Downloading..."));
+                inner.download_button.set_sensitive(false);
+
+                let status_label = inner.status_label.clone();
+                let download_button = inner.download_button.clone();
+                let dialog = inner.dialog.clone();
+                let inner = inner.clone();
+
+                spawn(async move {
+                    let registry = SubtitleProviderRegistry::new();
+                    let provider = registry
+                        .searchable_providers()
+                        .into_iter()
+                        .find(|provider| provider.id() == result.provider);
+                    let Some(provider) = provider else {
+                        status_label.set_text(&gettext("Provider unavailable"));
+                        download_button.set_sensitive(true);
+                        return;
+                    };
+                    match provider.download(&result).await {
+                        Ok(path) => {
+                            status_label.set_text(&gettext("Subtitle downloaded"));
+                            if let Some(callback) = inner.on_downloaded.borrow().as_ref() {
+                                callback(path);
+                            }
+                            inner.unregister();
+                            dialog.close();
+                        }
+                        Err(err) => {
+                            status_label
+                                .set_text(&format!("{}: {err}", gettext("Download failed")));
+                            download_button.set_sensitive(true);
+                        }
+                    }
+                });
+            });
+        }
+    }
+}
+
+pub fn preferred_subtitle_language_code() -> String {
+    match SETTINGS.mpv_subtitle_preferred_lang() {
+        1 => "en".into(),
+        2 => "zh-CN".into(),
+        3 => "ja".into(),
+        4 => "zh-TW".into(),
+        5 => "ar".into(),
+        6 => "nb".into(),
+        7 => "pt".into(),
+        8 => "fr".into(),
+        9 => "ru".into(),
+        _ => String::new(),
+    }
+}
+
+fn language_combo_index(language: &str) -> u32 {
+    if language.trim().is_empty() {
+        return 0;
+    }
+    let normalized = match language {
+        "en" => "eng",
+        "ja" => "jpn",
+        "zh-CN" | "zh" => "zho",
+        "zh-TW" => "zho",
+        "fr" => "fra",
+        "ar" => "ara",
+        "nb" | "no" => "nor",
+        "pt" => "por",
+        "ru" => "rus",
+        other => other,
+    };
+    language_codes::index_for_code(normalized) + 1
+}
+
+fn popover_open_in_tree(root: &gtk::Widget) -> bool {
+    let mut stack = vec![root.clone()];
+    while let Some(widget) = stack.pop() {
+        if let Ok(popover) = widget.clone().downcast::<gtk::Popover>()
+            && popover.is_visible()
+        {
+            return true;
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    false
+}

--- a/src/subtitles/mod.rs
+++ b/src/subtitles/mod.rs
@@ -1,0 +1,9 @@
+pub mod dialog;
+pub mod opensubtitles;
+pub mod provider;
+pub mod subdl;
+
+pub use dialog::{
+    SubtitleSearchDialog,
+    preferred_subtitle_language_code,
+};

--- a/src/subtitles/opensubtitles.rs
+++ b/src/subtitles/opensubtitles.rs
@@ -1,0 +1,161 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::provider::{
+    SubtitleProvider,
+    SubtitleResult,
+};
+use crate::ui::SETTINGS;
+
+const API_BASE: &str = "https://api.opensubtitles.com/api/v1";
+const USER_AGENT: &str = "Tsukimi v26.7.2";
+
+pub struct OpenSubtitlesProvider;
+
+impl OpenSubtitlesProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Deserialize)]
+struct SearchResponse {
+    data: Vec<SearchEntry>,
+}
+
+#[derive(Deserialize)]
+struct SearchEntry {
+    #[allow(dead_code)]
+    id: String,
+    attributes: SearchAttributes,
+}
+
+#[derive(Deserialize)]
+struct SearchAttributes {
+    language: String,
+    #[serde(default)]
+    release: Option<String>,
+    feature_details: FeatureDetails,
+    files: Vec<SubtitleFile>,
+}
+
+#[derive(Deserialize)]
+struct FeatureDetails {
+    #[serde(default)]
+    title: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SubtitleFile {
+    file_id: i64,
+}
+
+#[derive(serde::Serialize)]
+struct DownloadRequest {
+    file_id: i64,
+}
+
+#[derive(Deserialize)]
+struct DownloadResponse {
+    link: String,
+}
+
+#[async_trait::async_trait]
+impl SubtitleProvider for OpenSubtitlesProvider {
+    fn id(&self) -> &'static str {
+        "opensubtitles"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "OpenSubtitles"
+    }
+
+    fn is_enabled(&self) -> bool {
+        SETTINGS.subtitle_provider_enabled(self.id())
+            && !SETTINGS.opensubtitles_api_key().is_empty()
+    }
+
+    fn has_credentials(&self) -> bool {
+        !SETTINGS.opensubtitles_api_key().trim().is_empty()
+    }
+
+    async fn search(
+        &self, query: &str, imdb_id: Option<&str>, language: &str,
+    ) -> anyhow::Result<Vec<SubtitleResult>> {
+        let api_key = SETTINGS.opensubtitles_api_key();
+        if api_key.is_empty() {
+            anyhow::bail!("OpenSubtitles API key is not configured");
+        }
+
+        let client = reqwest::Client::new();
+        let mut request = client
+            .get(format!("{API_BASE}/subtitles"))
+            .header("Api-Key", api_key)
+            .header("User-Agent", USER_AGENT)
+            .query(&[("query", query)]);
+
+        if !language.is_empty() {
+            request = request.query(&[("languages", language)]);
+        }
+        if let Some(imdb) = imdb_id.filter(|id| !id.is_empty()) {
+            request = request.query(&[("imdb_id", imdb)]);
+        }
+
+        let response = request.send().await?;
+        if !response.status().is_success() {
+            anyhow::bail!("OpenSubtitles search failed: {}", response.status());
+        }
+
+        let payload: SearchResponse = response.json().await?;
+        let mut results = Vec::new();
+        for entry in payload.data {
+            let Some(file) = entry.attributes.files.first() else {
+                continue;
+            };
+            let title = entry
+                .attributes
+                .release
+                .or(entry.attributes.feature_details.title)
+                .unwrap_or_else(|| query.to_string());
+            results.push(SubtitleResult {
+                provider: self.id().to_string(),
+                id: file.file_id.to_string(),
+                title,
+                language: entry.attributes.language,
+                download_url: None,
+            });
+        }
+        Ok(results)
+    }
+
+    async fn download(&self, result: &SubtitleResult) -> anyhow::Result<PathBuf> {
+        let api_key = SETTINGS.opensubtitles_api_key();
+        let file_id: i64 = result.id.parse()?;
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!("{API_BASE}/download"))
+            .header("Api-Key", api_key)
+            .header("User-Agent", USER_AGENT)
+            .json(&DownloadRequest { file_id })
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            anyhow::bail!("OpenSubtitles download failed: {}", response.status());
+        }
+        let payload: DownloadResponse = response.json().await?;
+        let sub_bytes = client.get(payload.link).send().await?.bytes().await?;
+        let path = subtitle_cache_path(&result.id, "srt");
+        std::fs::write(&path, sub_bytes)?;
+        Ok(path)
+    }
+}
+
+pub(crate) fn subtitle_cache_path(id: &str, extension: &str) -> PathBuf {
+    let dir = dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("tsukimi")
+        .join("subtitles");
+    std::fs::create_dir_all(&dir).ok();
+    dir.join(format!("{id}.{extension}"))
+}

--- a/src/subtitles/provider.rs
+++ b/src/subtitles/provider.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+
+use crate::subtitles::{
+    opensubtitles::OpenSubtitlesProvider,
+    subdl::SubDLProvider,
+};
+
+#[derive(Debug, Clone)]
+pub struct SubtitleResult {
+    pub provider: String,
+    pub id: String,
+    pub title: String,
+    pub language: String,
+    pub download_url: Option<String>,
+}
+
+#[async_trait::async_trait]
+pub trait SubtitleProvider: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn display_name(&self) -> &'static str;
+    fn is_enabled(&self) -> bool;
+    fn has_credentials(&self) -> bool {
+        self.is_enabled()
+    }
+    async fn search(
+        &self, query: &str, imdb_id: Option<&str>, language: &str,
+    ) -> anyhow::Result<Vec<SubtitleResult>>;
+    async fn download(&self, result: &SubtitleResult) -> anyhow::Result<PathBuf>;
+}
+
+pub struct SubtitleProviderRegistry {
+    providers: Vec<Box<dyn SubtitleProvider>>,
+}
+
+impl Default for SubtitleProviderRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubtitleProviderRegistry {
+    pub fn new() -> Self {
+        Self {
+            providers: vec![
+                Box::new(OpenSubtitlesProvider::new()),
+                Box::new(SubDLProvider::new()),
+            ],
+        }
+    }
+
+    pub fn searchable_providers(&self) -> Vec<&dyn SubtitleProvider> {
+        self.providers
+            .iter()
+            .filter(|p| p.has_credentials())
+            .map(|p| p.as_ref())
+            .collect()
+    }
+
+    pub async fn search_all(
+        &self, query: &str, imdb_id: Option<&str>, language: &str,
+    ) -> Vec<SubtitleResult> {
+        let providers = self.searchable_providers();
+        if providers.is_empty() {
+            tracing::warn!("no subtitle providers configured with API keys");
+            return Vec::new();
+        }
+        let mut results = Vec::new();
+        for provider in providers {
+            if !provider.is_enabled() {
+                tracing::info!(
+                    "searching {} (API key configured; enable in Settings to use for auto-download)",
+                    provider.display_name()
+                );
+            }
+            match provider.search(query, imdb_id, language).await {
+                Ok(mut found) => results.append(&mut found),
+                Err(err) => tracing::warn!(
+                    "subtitle search failed for {}: {err}",
+                    provider.display_name()
+                ),
+            }
+        }
+        results
+    }
+}

--- a/src/subtitles/subdl.rs
+++ b/src/subtitles/subdl.rs
@@ -1,0 +1,109 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::{
+    opensubtitles::subtitle_cache_path,
+    provider::{
+        SubtitleProvider,
+        SubtitleResult,
+    },
+};
+use crate::ui::SETTINGS;
+
+const API_BASE: &str = "https://api.subdl.com/api/v1/subtitles";
+
+pub struct SubDLProvider;
+
+impl SubDLProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Deserialize)]
+struct SubDLResponse {
+    #[serde(default)]
+    subtitles: Vec<SubDLEntry>,
+}
+
+#[derive(Deserialize)]
+struct SubDLEntry {
+    #[serde(default)]
+    language: String,
+    #[serde(default)]
+    release_name: Option<String>,
+    #[serde(default)]
+    url: String,
+}
+
+#[async_trait::async_trait]
+impl SubtitleProvider for SubDLProvider {
+    fn id(&self) -> &'static str {
+        "subdl"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "SubDL"
+    }
+
+    fn is_enabled(&self) -> bool {
+        SETTINGS.subtitle_provider_enabled(self.id()) && !SETTINGS.subdl_api_key().is_empty()
+    }
+
+    fn has_credentials(&self) -> bool {
+        !SETTINGS.subdl_api_key().trim().is_empty()
+    }
+
+    async fn search(
+        &self, query: &str, imdb_id: Option<&str>, language: &str,
+    ) -> anyhow::Result<Vec<SubtitleResult>> {
+        let api_key = SETTINGS.subdl_api_key();
+        if api_key.is_empty() {
+            anyhow::bail!("SubDL API key is not configured");
+        }
+
+        let client = reqwest::Client::new();
+        let mut request = client
+            .get(API_BASE)
+            .query(&[("api_key", api_key.as_str()), ("film_name", query)]);
+        if !language.is_empty() {
+            request = request.query(&[("languages", language.to_uppercase())]);
+        }
+        if let Some(imdb) = imdb_id.filter(|id| !id.is_empty()) {
+            request = request.query(&[("imdb_id", imdb)]);
+        }
+
+        let response = request.send().await?;
+        if !response.status().is_success() {
+            anyhow::bail!("SubDL search failed: {}", response.status());
+        }
+
+        let payload: SubDLResponse = response.json().await?;
+        Ok(payload
+            .subtitles
+            .into_iter()
+            .enumerate()
+            .filter(|(_, entry)| !entry.url.is_empty())
+            .map(|(index, entry)| SubtitleResult {
+                provider: self.id().to_string(),
+                id: format!("subdl-{index}"),
+                title: entry.release_name.unwrap_or_else(|| query.to_string()),
+                language: entry.language,
+                download_url: Some(entry.url),
+            })
+            .collect())
+    }
+
+    async fn download(&self, result: &SubtitleResult) -> anyhow::Result<PathBuf> {
+        let url = result
+            .download_url
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("SubDL result has no download URL"))?;
+        let client = reqwest::Client::new();
+        let sub_bytes = client.get(url).send().await?.bytes().await?;
+        let path = subtitle_cache_path(&result.id, "srt");
+        std::fs::write(&path, sub_bytes)?;
+        Ok(path)
+    }
+}

--- a/src/tv/cursor.rs
+++ b/src/tv/cursor.rs
@@ -1,0 +1,131 @@
+use std::{
+    cell::RefCell,
+    sync::atomic::{
+        AtomicBool,
+        AtomicU64,
+        Ordering,
+    },
+};
+
+use gtk::{
+    gdk,
+    glib::WeakRef,
+    prelude::*,
+};
+
+use super::focus::controller_navigation_enabled;
+
+fn cursor_auto_hide_enabled() -> bool {
+    controller_navigation_enabled() && crate::ui::SETTINGS.gamepad_enabled()
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+static POINTER_HIDDEN: AtomicBool = AtomicBool::new(false);
+static LAST_GAMEPAD_CURSOR_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Ignore mouse motion briefly after gamepad input (scroll/focus can spuriously wake the pointer).
+const POINTER_SUPPRESS_AFTER_GAMEPAD_MS: u64 = 500;
+
+thread_local! {
+    static WINDOW: RefCell<Option<WeakRef<crate::Window>>> = const { RefCell::new(None) };
+    static BLANK_CURSOR: RefCell<Option<gdk::Cursor>> = const { RefCell::new(None) };
+}
+
+pub fn register_window(window: &crate::Window) {
+    WINDOW.with(|slot| *slot.borrow_mut() = Some(window.downgrade()));
+}
+
+pub fn on_pointer_activity() {
+    if !cursor_auto_hide_enabled() {
+        restore();
+        return;
+    }
+    if now_ms().saturating_sub(LAST_GAMEPAD_CURSOR_MS.load(Ordering::Relaxed))
+        < POINTER_SUPPRESS_AFTER_GAMEPAD_MS
+    {
+        return;
+    }
+    show();
+    crate::ui::widgets::hover_scale::request_pointer_targeting_sync();
+}
+
+pub fn on_gamepad_activity() {
+    if !cursor_auto_hide_enabled() {
+        return;
+    }
+    LAST_GAMEPAD_CURSOR_MS.store(now_ms(), Ordering::Relaxed);
+    hide();
+    crate::ui::widgets::hover_scale::request_pointer_targeting_sync();
+}
+
+/// While gamepad is driving the UI, ignore stale pointer hover under the last mouse
+/// position (including newly bound widgets after pagination or page changes).
+pub fn suppress_pointer_hover() -> bool {
+    if !cursor_auto_hide_enabled() {
+        return false;
+    }
+    POINTER_HIDDEN.load(Ordering::Relaxed) || super::osk::gamepad_owns_direct_input()
+}
+
+pub fn restore() {
+    show();
+}
+
+fn hide() {
+    with_surface(|surface| {
+        if let Some(cursor) = blank_cursor() {
+            surface.set_cursor(Some(&cursor));
+            POINTER_HIDDEN.store(true, Ordering::Relaxed);
+        }
+    });
+}
+
+fn show() {
+    with_surface(|surface| {
+        if !POINTER_HIDDEN.load(Ordering::Relaxed) {
+            return;
+        }
+        surface.set_cursor(gdk::Cursor::from_name("default", None).as_ref());
+        POINTER_HIDDEN.store(false, Ordering::Relaxed);
+    });
+}
+
+fn with_surface(f: impl FnOnce(&gdk::Surface)) {
+    WINDOW.with(|slot| {
+        let Some(window) = slot.borrow().as_ref().and_then(|weak| weak.upgrade()) else {
+            return;
+        };
+        let Some(surface) = window.native().and_then(|native| native.surface()) else {
+            return;
+        };
+        f(&surface);
+    });
+}
+
+fn blank_cursor() -> Option<gdk::Cursor> {
+    BLANK_CURSOR.with(|slot| {
+        if slot.borrow().is_none() {
+            let cursor = if let Some(cursor) = gdk::Cursor::from_name("none", None) {
+                cursor
+            } else {
+                let bytes = gtk::glib::Bytes::from_static(&[0, 0, 0, 0]);
+                let texture = gdk::MemoryTextureBuilder::new()
+                    .set_width(1)
+                    .set_height(1)
+                    .set_format(gdk::MemoryFormat::R8g8b8a8)
+                    .set_stride(4)
+                    .set_bytes(Some(&bytes))
+                    .build();
+                gdk::Cursor::from_texture(&texture, 0, 0, None)
+            };
+            *slot.borrow_mut() = Some(cursor);
+        }
+        slot.borrow().clone()
+    })
+}

--- a/src/tv/focus.rs
+++ b/src/tv/focus.rs
@@ -1,0 +1,24 @@
+use gtk::prelude::*;
+
+use crate::ui::SETTINGS;
+
+pub fn tv_focus_enabled() -> bool {
+    crate::tv::is_tv_mode_active() || SETTINGS.gamepad_enabled()
+}
+
+/// Whether gamepad/keyboard should drive TV-style navigation instead of GTK defaults.
+pub fn controller_navigation_enabled() -> bool {
+    tv_focus_enabled()
+}
+
+pub fn set_tv_focused(widget: &impl IsA<gtk::Widget>, focused: bool) {
+    if !tv_focus_enabled() {
+        widget.remove_css_class("tv-focused");
+        return;
+    }
+    if focused {
+        widget.add_css_class("tv-focused");
+    } else {
+        widget.remove_css_class("tv-focused");
+    }
+}

--- a/src/tv/mod.rs
+++ b/src/tv/mod.rs
@@ -1,0 +1,124 @@
+use std::{
+    cell::RefCell,
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
+    },
+};
+
+use gtk::{
+    CssProvider,
+    gdk::Display,
+};
+
+use crate::{
+    Window,
+    ui::SETTINGS,
+};
+
+pub mod cursor;
+pub mod focus;
+pub mod osk;
+
+pub use focus::{
+    controller_navigation_enabled,
+    set_tv_focused,
+};
+
+pub static TV_MODE_ACTIVE: AtomicBool = AtomicBool::new(false);
+static TV_CSS_ATTACHED: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    static TV_PROVIDER: RefCell<Option<CssProvider>> = const { RefCell::new(None) };
+}
+
+pub fn is_tv_mode_active() -> bool {
+    TV_MODE_ACTIVE.load(Ordering::Relaxed)
+}
+
+pub fn set_tv_mode_active(active: bool) {
+    TV_MODE_ACTIVE.store(active, Ordering::Relaxed);
+}
+
+/// Resolve whether TV visual mode should be active for this session.
+pub fn resolve_tv_mode(cli_tv_mode: bool, cli_fullscreen: bool) -> bool {
+    cli_tv_mode || crate::steam::is_steam_big_picture() || SETTINGS.tv_mode() || cli_fullscreen
+}
+
+fn build_tv_css() -> String {
+    let scale = SETTINGS.tv_ui_scale();
+    let mut css = format!(
+        r#"
+        :root {{
+            --tv-scale: {scale};
+        }}
+        "#
+    );
+
+    if let Ok(bytes) = gtk::gio::resources_lookup_data(
+        "/moe/tsuna/tsukimi/tv.css",
+        gtk::gio::ResourceLookupFlags::NONE,
+    ) && let Ok(extra) = std::str::from_utf8(&bytes)
+    {
+        css.push_str(extra);
+    }
+
+    css
+}
+
+pub fn sync_tv_style() {
+    let display = Display::default().expect("Could not connect to a display.");
+    TV_PROVIDER.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(CssProvider::new());
+        }
+        let provider = slot.as_ref().expect("TV CSS provider");
+        provider.load_from_string(&build_tv_css());
+        if !TV_CSS_ATTACHED.swap(true, Ordering::Relaxed) {
+            gtk::style_context_add_provider_for_display(
+                &display,
+                provider,
+                gtk::STYLE_PROVIDER_PRIORITY_APPLICATION + 1,
+            );
+        }
+    });
+}
+
+pub fn apply_to_window(window: &Window, cli_fullscreen: bool) {
+    set_tv_mode_active(true);
+    if !SETTINGS.gamepad_enabled() {
+        let _ = SETTINGS.set_gamepad_enabled(true);
+    }
+    sync_tv_style();
+    window.enable_tv_mode_ui(cli_fullscreen);
+}
+
+pub fn remove_from_window(window: &Window) {
+    set_tv_mode_active(false);
+    window.disable_tv_mode_ui();
+}
+
+pub fn apply_tv_startup(window: &Window, cli_fullscreen: bool) {
+    if !is_tv_mode_active() {
+        return;
+    }
+
+    apply_to_window(window, cli_fullscreen);
+}
+
+pub fn tv_scale_factor() -> f64 {
+    if is_tv_mode_active() {
+        SETTINGS.tv_ui_scale()
+    } else {
+        1.0
+    }
+}
+
+pub fn scale_i32(value: i32) -> i32 {
+    (value as f64 * tv_scale_factor()).round() as i32
+}
+
+pub fn scale_pair((w, h): (i32, i32)) -> (i32, i32) {
+    (scale_i32(w), scale_i32(h))
+}

--- a/src/tv/osk.rs
+++ b/src/tv/osk.rs
@@ -1,0 +1,404 @@
+use std::{
+    cell::RefCell,
+    rc::Rc,
+};
+
+use gtk::{
+    glib::object::IsA,
+    prelude::*,
+};
+
+use crate::{
+    tv::{
+        controller_navigation_enabled,
+        is_tv_mode_active,
+        set_tv_focused,
+    },
+    ui::input::InputAction,
+};
+
+static LAST_GAMEPAD_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static LAST_DIRECT_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+thread_local! {
+    static OSK: RefCell<Option<Rc<OnScreenKeyboard>>> = const { RefCell::new(None) };
+}
+
+const ROW_LENGTHS: [usize; 5] = [10, 10, 9, 9, 3];
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Call when the user moves or clicks with a mouse/trackpad.
+pub fn mark_pointer_input() {
+    LAST_DIRECT_MS.store(now_ms(), std::sync::atomic::Ordering::Relaxed);
+    super::cursor::on_pointer_activity();
+}
+
+/// Call when the user types on a physical keyboard.
+pub fn mark_keyboard_input() {
+    LAST_DIRECT_MS.store(now_ms(), std::sync::atomic::Ordering::Relaxed);
+    hide_keyboard();
+}
+
+/// Call when a gamepad button or stick produces navigation input.
+pub fn mark_gamepad_input() {
+    LAST_GAMEPAD_MS.store(now_ms(), std::sync::atomic::Ordering::Relaxed);
+    if crate::tv::cursor::suppress_pointer_hover() {
+        crate::ui::widgets::hover_scale::request_pointer_targeting_sync();
+    }
+}
+
+/// True when gamepad input is more recent than mouse/keyboard direct input.
+pub fn gamepad_owns_direct_input() -> bool {
+    LAST_GAMEPAD_MS.load(std::sync::atomic::Ordering::Relaxed)
+        > LAST_DIRECT_MS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+fn should_offer_osk() -> bool {
+    !crate::steam::is_steam_big_picture()
+        && (is_tv_mode_active() || controller_navigation_enabled())
+}
+
+#[allow(dead_code)]
+pub fn is_visible() -> bool {
+    OSK.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .is_some_and(|osk| osk.revealer.reveals_child())
+    })
+}
+
+pub fn handle_input(action: InputAction) -> bool {
+    OSK.with(|slot| {
+        let Some(osk) = slot.borrow().clone() else {
+            return false;
+        };
+        if !osk.revealer.reveals_child() {
+            return false;
+        }
+        osk.handle_input(action)
+    })
+}
+
+struct OnScreenKeyboard {
+    revealer: gtk::Revealer,
+    target: RefCell<Option<gtk::Widget>>,
+    shifted: RefCell<bool>,
+    buttons: RefCell<Vec<gtk::Button>>,
+    focused_index: RefCell<usize>,
+}
+
+impl OnScreenKeyboard {
+    fn ensure() -> Rc<Self> {
+        OSK.with(|slot| {
+            if let Some(existing) = slot.borrow().clone() {
+                return existing;
+            }
+
+            let revealer = gtk::Revealer::builder()
+                .valign(gtk::Align::End)
+                .transition_type(gtk::RevealerTransitionType::SlideUp)
+                .reveal_child(false)
+                .build();
+            revealer.add_css_class("tv-osk");
+
+            let keyboard = Rc::new(Self {
+                revealer: revealer.clone(),
+                target: RefCell::new(None),
+                shifted: RefCell::new(false),
+                buttons: RefCell::new(Vec::new()),
+                focused_index: RefCell::new(0),
+            });
+
+            let grid = gtk::Grid::builder()
+                .row_spacing(6)
+                .column_spacing(6)
+                .margin_top(8)
+                .margin_bottom(8)
+                .margin_start(12)
+                .margin_end(12)
+                .build();
+
+            let rows: &[&[&str]] = &[
+                &["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
+                &["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
+                &["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+                &["⇧", "z", "x", "c", "v", "b", "n", "m", "⌫"],
+                &["␣", "↵", "✕"],
+            ];
+
+            for (row_idx, row) in rows.iter().enumerate() {
+                for (col_idx, key) in row.iter().enumerate() {
+                    let button = gtk::Button::with_label(key);
+                    button.add_css_class("flat");
+                    button.set_hexpand(*key == "␣");
+                    if *key == "␣" {
+                        grid.attach(&button, col_idx as i32, row_idx as i32, 3, 1);
+                    } else {
+                        grid.attach(&button, col_idx as i32, row_idx as i32, 1, 1);
+                    }
+
+                    keyboard.buttons.borrow_mut().push(button.clone());
+
+                    let keyboard = keyboard.clone();
+                    let label = (*key).to_string();
+                    button.connect_clicked(move |_| keyboard.on_key_pressed(&label));
+                }
+            }
+
+            let frame = gtk::Frame::new(None);
+            frame.set_child(Some(&grid));
+            revealer.set_child(Some(&frame));
+
+            *slot.borrow_mut() = Some(keyboard.clone());
+            keyboard
+        })
+    }
+
+    fn attach_to_window(&self, widget: &gtk::Widget) {
+        let Some(root) = widget.root() else {
+            return;
+        };
+        if self.revealer.parent().is_some() {
+            return;
+        }
+        let root_widget = root.upcast_ref::<gtk::Widget>();
+        if let Some(overlay) = find_window_overlay(root_widget) {
+            overlay.add_overlay(&self.revealer);
+        }
+    }
+
+    fn show_for(&self, widget: &gtk::Widget) {
+        self.attach_to_window(widget);
+        *self.target.borrow_mut() = Some(widget.clone());
+        widget.grab_focus();
+        *self.focused_index.borrow_mut() = 0;
+        self.apply_key_focus();
+        self.revealer.set_reveal_child(true);
+    }
+
+    fn hide(&self) {
+        self.clear_key_focus();
+        self.revealer.set_reveal_child(false);
+        *self.target.borrow_mut() = None;
+        *self.shifted.borrow_mut() = false;
+    }
+
+    fn handle_input(&self, action: InputAction) -> bool {
+        match action {
+            InputAction::NavigateLeft => self.move_focus(-1, 0),
+            InputAction::NavigateRight => self.move_focus(1, 0),
+            InputAction::NavigateUp => self.move_focus(0, -1),
+            InputAction::NavigateDown => self.move_focus(0, 1),
+            InputAction::Activate => {
+                self.activate_focused_key();
+                true
+            }
+            InputAction::Back => {
+                self.hide();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn move_focus(&self, delta_col: i32, delta_row: i32) -> bool {
+        let buttons = self.buttons.borrow();
+        if buttons.is_empty() {
+            return false;
+        }
+        let (row, col) = self.index_to_row_col(*self.focused_index.borrow());
+        let (next_row, next_col) = if delta_row != 0 {
+            let target_row =
+                (row as i32 + delta_row).clamp(0, ROW_LENGTHS.len() as i32 - 1) as usize;
+            let max_col = ROW_LENGTHS[target_row].saturating_sub(1) as i32;
+            let target_col = col.min(max_col as usize);
+            (target_row, target_col)
+        } else {
+            let max_col = ROW_LENGTHS[row].saturating_sub(1) as i32;
+            let target_col = (col as i32 + delta_col).clamp(0, max_col) as usize;
+            (row, target_col)
+        };
+        let next_index = self.row_col_to_index(next_row, next_col);
+        *self.focused_index.borrow_mut() = next_index;
+        self.apply_key_focus();
+        true
+    }
+
+    fn row_col_to_index(&self, row: usize, col: usize) -> usize {
+        ROW_LENGTHS.iter().take(row).sum::<usize>() + col.min(ROW_LENGTHS[row].saturating_sub(1))
+    }
+
+    fn index_to_row_col(&self, index: usize) -> (usize, usize) {
+        let mut remaining = index;
+        for (row, len) in ROW_LENGTHS.iter().enumerate() {
+            if remaining < *len {
+                return (row, remaining);
+            }
+            remaining -= len;
+        }
+        (
+            ROW_LENGTHS.len() - 1,
+            ROW_LENGTHS.last().copied().unwrap_or(1) - 1,
+        )
+    }
+
+    fn apply_key_focus(&self) {
+        let buttons = self.buttons.borrow();
+        let index = *self.focused_index.borrow();
+        for (idx, button) in buttons.iter().enumerate() {
+            set_tv_focused(button, idx == index);
+        }
+        if let Some(button) = buttons.get(index) {
+            button.grab_focus();
+        }
+    }
+
+    fn clear_key_focus(&self) {
+        for button in self.buttons.borrow().iter() {
+            set_tv_focused(button, false);
+        }
+    }
+
+    fn activate_focused_key(&self) {
+        let buttons = self.buttons.borrow();
+        let index = *self.focused_index.borrow();
+        if let Some(button) = buttons.get(index) {
+            button.emit_clicked();
+        }
+    }
+
+    fn on_key_pressed(&self, key: &str) {
+        let Some(target) = self.target.borrow().clone() else {
+            return;
+        };
+
+        match key {
+            "✕" => self.hide(),
+            "⇧" => {
+                let mut shifted = self.shifted.borrow_mut();
+                *shifted = !*shifted;
+            }
+            "⌫" => {
+                if let Some(editable) = editable_from_widget(&target) {
+                    let start = editable.selection_bound();
+                    let end = editable.position();
+                    if start != end {
+                        editable.delete_selection();
+                    } else if start > 0 {
+                        editable.delete_text(start - 1, start);
+                    }
+                }
+            }
+            "␣" => insert_text(&target, " ", *self.shifted.borrow()),
+            "↵" => {
+                if let Ok(entry) = target.clone().downcast::<gtk::Entry>() {
+                    entry.activate();
+                } else if let Ok(entry) = target.clone().downcast::<gtk::SearchEntry>() {
+                    entry.activate();
+                } else if let Ok(row) = target.clone().downcast::<adw::EntryRow>() {
+                    row.activate();
+                } else if let Ok(row) = target.clone().downcast::<adw::PasswordEntryRow>() {
+                    row.activate();
+                }
+                self.hide();
+            }
+            _ => insert_text(&target, key, *self.shifted.borrow()),
+        }
+    }
+}
+
+fn editable_from_widget(widget: &gtk::Widget) -> Option<gtk::Editable> {
+    widget.clone().downcast::<gtk::Editable>().ok()
+}
+
+fn insert_text(widget: &gtk::Widget, text: &str, shifted: bool) {
+    let Some(editable) = editable_from_widget(widget) else {
+        return;
+    };
+    let text = if shifted {
+        text.to_uppercase()
+    } else {
+        text.to_string()
+    };
+    let mut pos = editable.position();
+    editable.insert_text(&text, &mut pos);
+    if shifted && let Some(osk) = OSK.with(|slot| slot.borrow().clone()) {
+        *osk.shifted.borrow_mut() = false;
+    }
+}
+
+fn show_keyboard_for(widget: &gtk::Widget) {
+    if !should_offer_osk() {
+        return;
+    }
+    if now_ms().saturating_sub(LAST_DIRECT_MS.load(std::sync::atomic::Ordering::Relaxed)) < 500 {
+        return;
+    }
+    OnScreenKeyboard::ensure().show_for(widget);
+}
+
+/// Show the on-screen keyboard for a text entry (e.g. after controller Activate).
+pub fn show_for_widget(widget: &impl IsA<gtk::Widget>) {
+    show_keyboard_for(widget.upcast_ref());
+}
+
+pub fn hide_keyboard() {
+    OSK.with(|slot| {
+        if let Some(osk) = slot.borrow().as_ref() {
+            osk.hide();
+        }
+    });
+}
+
+fn find_window_overlay(root: &gtk::Widget) -> Option<gtk::Overlay> {
+    let mut stack = vec![root.clone()];
+    while let Some(widget) = stack.pop() {
+        if let Some(overlay) = widget.downcast_ref::<gtk::Overlay>() {
+            return Some(overlay.clone());
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    None
+}
+
+pub fn attach_on_screen_keyboard(widget: &impl IsA<gtk::Widget>) {
+    let widget = widget.upcast_ref::<gtk::Widget>().clone();
+
+    let focus = gtk::EventControllerFocus::new();
+    focus.connect_enter({
+        let widget = widget.clone();
+        move |_| show_keyboard_for(&widget)
+    });
+    focus.connect_leave({
+        let widget = widget.clone();
+        move |_| {
+            let hide = OSK.with(|slot| {
+                slot.borrow()
+                    .as_ref()
+                    .and_then(|osk| osk.target.borrow().clone())
+                    .is_some_and(|target| target == widget)
+            });
+            if hide {
+                hide_keyboard();
+            }
+        }
+    });
+    widget.add_controller(focus);
+
+    let click = gtk::GestureClick::new();
+    click.connect_pressed({
+        let widget = widget.clone();
+        move |_, _, _, _| show_keyboard_for(&widget)
+    });
+    widget.add_controller(click);
+}

--- a/src/ui/input/actions.rs
+++ b/src/ui/input/actions.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputAction {
+    NavigateLeft,
+    NavigateRight,
+    NavigateUp,
+    NavigateDown,
+    Activate,
+    Back,
+    Menu,
+    Home,
+    Search,
+    ToggleHints,
+    PageScrollLeft,
+    PageScrollRight,
+    PlayPause,
+    SwitchGamepad,
+}

--- a/src/ui/input/dialog_navigator.rs
+++ b/src/ui/input/dialog_navigator.rs
@@ -1,0 +1,342 @@
+use adw::prelude::*;
+use gtk::glib::subclass::types::ObjectSubclassIsExt;
+
+use super::{
+    actions::InputAction,
+    settings_navigator::SettingsNavigator,
+};
+use crate::{
+    Window,
+    tv::set_tv_focused,
+};
+
+thread_local! {
+    static NAVIGATOR: std::cell::RefCell<SettingsNavigator> =
+        std::cell::RefCell::new(SettingsNavigator::default());
+}
+
+pub fn handle(window: &Window, action: InputAction) -> bool {
+    if window
+        .imp()
+        .active_settings
+        .borrow()
+        .as_ref()
+        .is_some_and(|settings| settings.is_visible())
+        || window
+            .imp()
+            .active_account_dialog
+            .borrow()
+            .as_ref()
+            .is_some_and(|dialog| dialog.is_visible())
+    {
+        return false;
+    }
+
+    if let Some(buttons) = find_alert_buttons(window) {
+        return handle_buttons(&buttons, action, || {});
+    }
+
+    let Some(dialog) = find_visible_dialog(window) else {
+        return false;
+    };
+
+    if let Some(grid) = find_visible_grid_in_dialog(&dialog) {
+        return handle_grid_selection(&grid, action, || {
+            let _ = dialog.close();
+        });
+    }
+
+    if let Some(listbox) = find_visible_listbox_in_dialog(&dialog) {
+        return handle_listbox(&listbox, action, || {
+            let _ = dialog.close();
+        });
+    }
+
+    let root = dialog_content_root(&dialog);
+    let widgets = collect_focusable_widgets(&root);
+    NAVIGATOR.with(|nav| {
+        nav.borrow().handle_widgets(&widgets, action, || {
+            let _ = dialog.close();
+        })
+    })
+}
+
+fn dialog_content_root(dialog: &adw::Dialog) -> gtk::Widget {
+    let Some(child) = dialog.child() else {
+        return dialog.upcast_ref::<gtk::Widget>().clone();
+    };
+    if let Some(nav) = find_descendant::<adw::NavigationView>(child.upcast_ref())
+        && let Some(page) = nav.visible_page()
+    {
+        return page.upcast::<gtk::Widget>();
+    }
+    child
+}
+
+fn find_visible_dialog(window: &Window) -> Option<adw::Dialog> {
+    let mut stack = vec![window.upcast_ref::<gtk::Widget>().clone()];
+    let mut found = None;
+    while let Some(widget) = stack.pop() {
+        if let Ok(dialog) = widget.clone().downcast::<adw::Dialog>()
+            && dialog.is_visible()
+        {
+            found = Some(dialog);
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    found
+}
+
+fn find_alert_buttons(window: &Window) -> Option<Vec<gtk::Button>> {
+    let buttons = collect_alert_buttons(window.upcast_ref());
+    if !buttons.is_empty() {
+        Some(buttons)
+    } else {
+        None
+    }
+}
+
+fn collect_alert_buttons(root: &gtk::Widget) -> Vec<gtk::Button> {
+    let mut buttons = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(widget) = stack.pop() {
+        if let Ok(button) = widget.clone().downcast::<gtk::Button>()
+            && button.is_visible()
+            && button.is_sensitive()
+            && button.parent().and_then(|p| p.parent()).is_some_and(|gp| {
+                gp.has_css_class("dialog")
+                    || gp.type_().name().contains("Alert")
+                    || gp.type_().name().contains("Message")
+            })
+        {
+            buttons.push(button);
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    buttons
+}
+
+fn handle_buttons(buttons: &[gtk::Button], action: InputAction, on_back: impl FnOnce()) -> bool {
+    if buttons.is_empty() {
+        return false;
+    }
+    let focused = buttons
+        .iter()
+        .position(|button| button.has_css_class("tv-focused"))
+        .unwrap_or(0) as i32;
+    match action {
+        InputAction::NavigateRight | InputAction::NavigateDown => {
+            let next = (focused + 1).min(buttons.len() as i32 - 1) as usize;
+            apply_button_focus(buttons, next);
+            true
+        }
+        InputAction::NavigateLeft | InputAction::NavigateUp => {
+            let next = focused.saturating_sub(1) as usize;
+            apply_button_focus(buttons, next);
+            true
+        }
+        InputAction::Activate => {
+            let index = buttons
+                .iter()
+                .position(|button| button.has_css_class("tv-focused"))
+                .unwrap_or(0);
+            buttons[index].emit_clicked();
+            true
+        }
+        InputAction::Back => {
+            on_back();
+            buttons.first().map(gtk::Button::emit_clicked);
+            true
+        }
+        _ => false,
+    }
+}
+
+fn apply_button_focus(buttons: &[gtk::Button], index: usize) {
+    for button in buttons {
+        set_tv_focused(button, false);
+    }
+    if let Some(button) = buttons.get(index) {
+        set_tv_focused(button, true);
+        button.grab_focus();
+    }
+}
+
+fn find_visible_grid_in_dialog(dialog: &adw::Dialog) -> Option<gtk::GridView> {
+    find_descendant(&dialog_content_root(dialog))
+}
+
+fn find_visible_listbox_in_dialog(dialog: &adw::Dialog) -> Option<gtk::ListBox> {
+    find_descendant(&dialog_content_root(dialog))
+}
+
+fn find_descendant<T: IsA<gtk::Widget>>(root: &gtk::Widget) -> Option<T> {
+    let mut stack = vec![root.clone()];
+    while let Some(widget) = stack.pop() {
+        if let Ok(found) = widget.clone().downcast::<T>() {
+            return Some(found);
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    None
+}
+
+fn handle_grid_selection(
+    grid: &gtk::GridView, action: InputAction, on_back: impl FnOnce(),
+) -> bool {
+    let Some(selection) = grid
+        .model()
+        .and_then(|model| model.downcast::<gtk::SingleSelection>().ok())
+    else {
+        return false;
+    };
+    let count = selection.n_items() as i32;
+    if count == 0 {
+        return false;
+    }
+    let current = if selection.selected() == gtk::INVALID_LIST_POSITION {
+        0
+    } else {
+        selection.selected() as i32
+    };
+    let cols = estimate_grid_columns(grid);
+    let (row, col) = (current / cols, current % cols);
+    match action {
+        InputAction::NavigateLeft => {
+            let next = (current - 1).clamp(0, count - 1) as u32;
+            selection.set_selected(next);
+            grid.scroll_to(next, gtk::ListScrollFlags::NONE, None);
+            true
+        }
+        InputAction::NavigateRight => {
+            let next = (current + 1).clamp(0, count - 1) as u32;
+            selection.set_selected(next);
+            grid.scroll_to(next, gtk::ListScrollFlags::NONE, None);
+            true
+        }
+        InputAction::NavigateUp => {
+            let next = ((row - 1) * cols + col).clamp(0, count - 1) as u32;
+            selection.set_selected(next);
+            grid.scroll_to(next, gtk::ListScrollFlags::NONE, None);
+            true
+        }
+        InputAction::NavigateDown => {
+            let next = ((row + 1) * cols + col).clamp(0, count - 1) as u32;
+            selection.set_selected(next);
+            grid.scroll_to(next, gtk::ListScrollFlags::NONE, None);
+            true
+        }
+        InputAction::Activate => {
+            let position = selection.selected();
+            if position != gtk::INVALID_LIST_POSITION {
+                grid.emit_by_name::<()>("activate", &[&position]);
+            }
+            true
+        }
+        InputAction::Back => {
+            on_back();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn estimate_grid_columns(grid: &gtk::GridView) -> i32 {
+    let width = grid.width().max(1);
+    let max_cols = grid.max_columns().max(1) as i32;
+    let item_width = (width / max_cols).max(1);
+    (width / item_width).max(1)
+}
+
+fn handle_listbox(listbox: &gtk::ListBox, action: InputAction, on_back: impl FnOnce()) -> bool {
+    let rows: Vec<gtk::ListBoxRow> = listbox
+        .observe_children()
+        .into_iter()
+        .filter_map(|child| child.ok())
+        .filter_map(|child| child.downcast::<gtk::ListBoxRow>().ok())
+        .collect();
+    if rows.is_empty() {
+        return false;
+    }
+    let current = listbox
+        .selected_row()
+        .and_then(|row| rows.iter().position(|r| r == &row))
+        .unwrap_or(0) as i32;
+    match action {
+        InputAction::NavigateDown | InputAction::NavigateRight => {
+            let next = (current + 1).min(rows.len() as i32 - 1) as usize;
+            apply_listbox_focus(listbox, &rows, next);
+            true
+        }
+        InputAction::NavigateUp | InputAction::NavigateLeft => {
+            let next = current.saturating_sub(1) as usize;
+            apply_listbox_focus(listbox, &rows, next);
+            true
+        }
+        InputAction::Activate => {
+            if let Some(row) = listbox.selected_row() {
+                row.activate();
+            }
+            true
+        }
+        InputAction::Back => {
+            on_back();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn apply_listbox_focus(listbox: &gtk::ListBox, rows: &[gtk::ListBoxRow], index: usize) {
+    let Some(row) = rows.get(index) else {
+        return;
+    };
+    for row in rows {
+        set_tv_focused(row, false);
+    }
+    listbox.select_row(Some(row));
+    set_tv_focused(row, true);
+    row.grab_focus();
+}
+
+pub fn collect_focusable_widgets(root: &gtk::Widget) -> Vec<gtk::Widget> {
+    let mut rows = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(widget) = stack.pop() {
+        if widget.downcast_ref::<adw::PreferencesRow>().is_some()
+            || widget.downcast_ref::<adw::ActionRow>().is_some()
+            || widget.downcast_ref::<adw::ButtonRow>().is_some()
+            || widget.downcast_ref::<adw::ComboRow>().is_some()
+            || widget.downcast_ref::<adw::EntryRow>().is_some()
+            || widget.downcast_ref::<adw::PasswordEntryRow>().is_some()
+            || widget.downcast_ref::<adw::SpinRow>().is_some()
+            || widget.downcast_ref::<adw::SwitchRow>().is_some()
+            || widget.downcast_ref::<gtk::CheckButton>().is_some()
+            || (widget.downcast_ref::<gtk::Button>().is_some()
+                && widget.parent().is_some_and(|p| !p.is_ancestor(root)))
+        {
+            if widget.is_visible() && widget.is_sensitive() {
+                rows.push(widget);
+            }
+            continue;
+        }
+        let mut child = widget.first_child();
+        while let Some(c) = child {
+            stack.push(c.clone());
+            child = c.next_sibling();
+        }
+    }
+    rows
+}

--- a/src/ui/input/focus_manager.rs
+++ b/src/ui/input/focus_manager.rs
@@ -1,0 +1,354 @@
+use std::cell::RefCell;
+
+use gtk::{
+    glib::{
+        WeakRef,
+        subclass::types::ObjectSubclassIsExt,
+    },
+    prelude::*,
+};
+
+use super::actions::InputAction;
+use crate::{
+    Window,
+    ui::widgets::{
+        home::HomePage,
+        hortu_scrolled::HortuScrolled,
+    },
+};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FocusArea {
+    Sidebar,
+    Content,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct HomeFocusSnapshot {
+    pub content_index: usize,
+    pub sidebar_focused: bool,
+}
+
+pub struct FocusManager {
+    area: RefCell<FocusArea>,
+    content_rows: RefCell<Vec<WeakRef<HortuScrolled>>>,
+    content_index: RefCell<usize>,
+}
+
+impl Default for FocusManager {
+    fn default() -> Self {
+        Self {
+            area: RefCell::new(FocusArea::Content),
+            content_rows: RefCell::new(Vec::new()),
+            content_index: RefCell::new(0),
+        }
+    }
+}
+
+impl FocusManager {
+    pub fn register_home(&self, home: &HomePage) {
+        self.set_rows(home.focus_hortu_rows());
+        *self.content_index.borrow_mut() = 0;
+        *self.area.borrow_mut() = FocusArea::Content;
+        self.clear_all_row_selections();
+        self.focus_current_row();
+    }
+
+    pub fn refresh_home_rows(&self, home: &HomePage) {
+        self.set_rows(home.focus_hortu_rows());
+        let rows_len = self.content_rows.borrow().len();
+        if rows_len == 0 {
+            return;
+        }
+        let idx = (*self.content_index.borrow()).min(rows_len - 1);
+        *self.content_index.borrow_mut() = idx;
+        self.focus_current_row();
+    }
+
+    pub fn register_rows(&self, rows: Vec<HortuScrolled>) {
+        self.set_rows(rows);
+        *self.content_index.borrow_mut() = 0;
+        *self.area.borrow_mut() = FocusArea::Content;
+        self.clear_all_row_selections();
+        self.focus_current_row();
+    }
+
+    pub fn snapshot_home_focus(&self) -> HomeFocusSnapshot {
+        HomeFocusSnapshot {
+            content_index: *self.content_index.borrow(),
+            sidebar_focused: *self.area.borrow() == FocusArea::Sidebar,
+        }
+    }
+
+    pub fn restore_home_focus(&self, home: &HomePage, snapshot: HomeFocusSnapshot) {
+        self.set_rows(home.focus_hortu_rows());
+        let rows_len = self.content_rows.borrow().len();
+        let idx = if rows_len == 0 {
+            0
+        } else {
+            snapshot.content_index.min(rows_len - 1)
+        };
+        *self.content_index.borrow_mut() = idx;
+        *self.area.borrow_mut() = FocusArea::Content;
+        self.clear_all_row_selections();
+        self.focus_current_row();
+    }
+
+    pub fn clear_all_row_selections(&self) {
+        for weak in self.content_rows.borrow().iter() {
+            if let Some(row) = weak.upgrade() {
+                row.clear_selection();
+                row.clear_keyboard_focus();
+            }
+        }
+    }
+
+    pub fn clear(&self) {
+        self.clear_all_row_selections();
+        self.content_rows.borrow_mut().clear();
+        *self.content_index.borrow_mut() = 0;
+    }
+
+    fn set_rows(&self, rows: Vec<HortuScrolled>) {
+        *self.content_rows.borrow_mut() = rows.into_iter().map(|r| r.downgrade()).collect();
+    }
+
+    pub fn handle(&self, window: &Window, action: InputAction) -> bool {
+        if *self.area.borrow() == FocusArea::Sidebar {
+            return self.handle_sidebar(window, action);
+        }
+
+        match action {
+            InputAction::NavigateLeft => self.navigate_horizontal(window, -1),
+            InputAction::NavigateRight => self.navigate_horizontal(window, 1),
+            InputAction::NavigateUp => self.navigate_vertical(window, -1),
+            InputAction::NavigateDown => self.navigate_vertical(window, 1),
+            InputAction::Activate => self.activate(window),
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::Menu => self.toggle_sidebar(window),
+            InputAction::Home => {
+                window.homepage();
+                true
+            }
+            InputAction::Search => {
+                window.searchpage();
+                true
+            }
+            InputAction::PageScrollLeft => self.page_scroll(-1),
+            InputAction::PageScrollRight => self.page_scroll(1),
+            _ => false,
+        }
+    }
+
+    pub fn handle_rows_only(&self, window: &Window, action: InputAction) -> bool {
+        match action {
+            InputAction::NavigateLeft => self.navigate_horizontal(window, -1),
+            InputAction::NavigateRight => self.navigate_horizontal(window, 1),
+            InputAction::NavigateUp => self.navigate_vertical_no_sidebar(window, -1),
+            InputAction::NavigateDown => self.navigate_vertical_no_sidebar(window, 1),
+            InputAction::Activate => self.activate(window),
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::Menu => self.toggle_sidebar(window),
+            InputAction::Home => {
+                window.homepage();
+                true
+            }
+            InputAction::Search => {
+                window.searchpage();
+                true
+            }
+            InputAction::PageScrollLeft => self.page_scroll(-1),
+            InputAction::PageScrollRight => self.page_scroll(1),
+            _ => false,
+        }
+    }
+
+    fn is_navigable_row(row: &HortuScrolled) -> bool {
+        row.is_visible() && row.item_count() > 0
+    }
+
+    fn visible_row_at(&self, index: usize) -> Option<(usize, HortuScrolled)> {
+        let rows = self.content_rows.borrow();
+        for (offset, weak) in rows.iter().enumerate().skip(index) {
+            if let Some(row) = weak.upgrade()
+                && Self::is_navigable_row(&row)
+            {
+                return Some((offset, row));
+            }
+        }
+        None
+    }
+
+    fn focus_current_row(&self) {
+        if *self.area.borrow() == FocusArea::Sidebar {
+            return;
+        }
+        let index = *self.content_index.borrow();
+        if let Some((_, row)) = self.visible_row_at(index) {
+            row.ensure_selection();
+            row.show_scroll_controls_for_focus();
+            row.scroll_into_parent_viewport();
+        }
+    }
+
+    fn navigate_horizontal(&self, window: &Window, delta: i32) -> bool {
+        if *self.area.borrow() == FocusArea::Sidebar {
+            return false;
+        }
+        let index = *self.content_index.borrow();
+        let Some((_, row)) = self.visible_row_at(index) else {
+            return false;
+        };
+        if delta < 0
+            && !row.is_header_focused()
+            && row.selection_at_start()
+            && !window.tv_sidebar_collapsed()
+        {
+            self.enter_sidebar(window);
+            return true;
+        }
+        row.move_selection(delta);
+        true
+    }
+
+    fn navigate_vertical(&self, window: &Window, delta: i32) -> bool {
+        if *self.area.borrow() == FocusArea::Sidebar {
+            return self.move_sidebar_selection(window, delta);
+        }
+        self.navigate_vertical_no_sidebar(window, delta)
+    }
+
+    fn navigate_vertical_no_sidebar(&self, window: &Window, delta: i32) -> bool {
+        let rows = self.content_rows.borrow();
+        let mut idx = *self.content_index.borrow();
+        let step = if delta > 0 { 1 } else { -1 };
+
+        loop {
+            if step > 0 {
+                idx += 1;
+            } else if idx == 0 {
+                if window.tv_sidebar_collapsed() {
+                    return true;
+                }
+                self.enter_sidebar(window);
+                return true;
+            } else {
+                idx -= 1;
+            }
+
+            if idx >= rows.len() {
+                return true;
+            }
+
+            if let Some(row) = rows[idx].upgrade()
+                && Self::is_navigable_row(&row)
+            {
+                if let Some(current) = self.visible_row_at(*self.content_index.borrow()) {
+                    current.1.clear_selection();
+                }
+                *self.content_index.borrow_mut() = idx;
+                self.focus_current_row();
+                return true;
+            }
+        }
+    }
+
+    fn activate(&self, window: &Window) -> bool {
+        if *self.area.borrow() == FocusArea::Sidebar {
+            window.activate_sidebar_selection();
+            return true;
+        }
+        let index = *self.content_index.borrow();
+        let Some((_, row)) = self.visible_row_at(index) else {
+            return false;
+        };
+        row.activate_selected(window);
+        true
+    }
+
+    fn page_scroll(&self, direction: i32) -> bool {
+        if *self.area.borrow() == FocusArea::Sidebar {
+            return false;
+        }
+        let index = *self.content_index.borrow();
+        let Some((_, row)) = self.visible_row_at(index) else {
+            return false;
+        };
+        if direction < 0 {
+            row.scroll_page_left();
+        } else {
+            row.scroll_page_right();
+        }
+        true
+    }
+
+    fn handle_sidebar(&self, window: &Window, action: InputAction) -> bool {
+        match action {
+            InputAction::NavigateRight => {
+                self.enter_content(window);
+                true
+            }
+            InputAction::NavigateDown => self.move_sidebar_selection(window, 1),
+            InputAction::NavigateUp => self.move_sidebar_selection(window, -1),
+            InputAction::NavigateLeft => true,
+            InputAction::Activate => {
+                window.activate_sidebar_selection();
+                self.enter_content(window);
+                true
+            }
+            InputAction::Back | InputAction::Menu => {
+                self.enter_content(window);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn enter_sidebar(&self, window: &Window) {
+        window.set_sidebar_panel_visible(true);
+        *self.area.borrow_mut() = FocusArea::Sidebar;
+        window.imp().selectlist.get().grab_focus();
+    }
+
+    fn enter_content(&self, window: &Window) {
+        window.set_sidebar_panel_visible(false);
+        *self.area.borrow_mut() = FocusArea::Content;
+        self.focus_current_row();
+    }
+
+    fn toggle_sidebar(&self, window: &Window) -> bool {
+        if window.tv_sidebar_collapsed() {
+            let split_view = window.imp().split_view.get();
+            if split_view.shows_sidebar() {
+                self.enter_content(window);
+            } else {
+                self.enter_sidebar(window);
+            }
+            return true;
+        }
+        gtk::prelude::ActionGroupExt::activate_action(window, "win.sidebar", None);
+        true
+    }
+
+    fn move_sidebar_selection(&self, window: &Window, delta: i32) -> bool {
+        let sidebar = window.imp().selectlist.get();
+        let mut index = sidebar.selected() as i32;
+        let step = if delta > 0 { 1 } else { -1 };
+
+        index += step;
+        if index < 0 {
+            return true;
+        }
+        if sidebar.item(index as u32).is_none() {
+            return true;
+        }
+        sidebar.set_selected(index as u32);
+        true
+    }
+}

--- a/src/ui/input/gamepad.rs
+++ b/src/ui/input/gamepad.rs
@@ -1,0 +1,317 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+};
+
+use super::{
+    actions::InputAction,
+    gamepad_profile::GamepadProfile,
+};
+use crate::{
+    Window,
+    ui::widgets::utils::GlobalToast,
+};
+use gilrs::{
+    Axis,
+    Button,
+    EventType,
+    GamepadId,
+    Gilrs,
+    GilrsBuilder,
+};
+
+pub struct GamepadManager {
+    gilrs: RefCell<Option<Gilrs>>,
+    active_profile: RefCell<GamepadProfile>,
+    active_name: RefCell<String>,
+    primary_id: RefCell<Option<GamepadId>>,
+    button_active: RefCell<HashMap<(GamepadId, Button), bool>>,
+    axis_active: RefCell<HashMap<(GamepadId, Axis), bool>>,
+    stick_deadzone: f32,
+}
+
+impl Default for GamepadManager {
+    fn default() -> Self {
+        Self {
+            gilrs: RefCell::new(open_gilrs()),
+            active_profile: RefCell::new(GamepadProfile::Generic),
+            active_name: RefCell::new(String::new()),
+            primary_id: RefCell::new(None),
+            button_active: RefCell::new(HashMap::new()),
+            axis_active: RefCell::new(HashMap::new()),
+            stick_deadzone: 0.15,
+        }
+    }
+}
+
+impl GamepadManager {
+    pub fn has_connected_controller(&self) -> bool {
+        self.primary_id.borrow().is_some()
+    }
+
+    pub fn poll(&mut self, window: &Window) -> Vec<InputAction> {
+        let mut actions = Vec::new();
+        let mut recreate = false;
+
+        {
+            let mut gilrs_guard = self.gilrs.borrow_mut();
+            if gilrs_guard.is_none() {
+                *gilrs_guard = open_gilrs();
+            }
+            let Some(gilrs) = gilrs_guard.as_mut() else {
+                return actions;
+            };
+
+            self.refresh_primary_gamepad(gilrs);
+
+            while let Some(event) = gilrs.next_event() {
+                let gamepad = gilrs.gamepad(event.id);
+                let name = gamepad.name().to_string();
+
+                if !is_game_controller(&name) {
+                    continue;
+                }
+
+                match event.event {
+                    EventType::Connected => {
+                        self.clear_gamepad_state(event.id);
+                        self.refresh_primary_gamepad(gilrs);
+                        *self.active_name.borrow_mut() = name.clone();
+                        *self.active_profile.borrow_mut() = GamepadProfile::detect(&name);
+                        window.toast(format!("{} connected", name));
+                        continue;
+                    }
+                    EventType::Disconnected => {
+                        self.clear_gamepad_state(event.id);
+                        *self.primary_id.borrow_mut() = None;
+                        self.active_name.borrow_mut().clear();
+                        window.toast(format!("{} disconnected", name));
+                        recreate = true;
+                        break;
+                    }
+                    _ => {}
+                }
+
+                self.refresh_primary_gamepad(gilrs);
+                if self.primary_id.borrow().is_some_and(|id| id != event.id) {
+                    continue;
+                }
+
+                if let Some(action) = self.map_event(event.id, event.event) {
+                    actions.push(action);
+                }
+            }
+
+            self.poll_cached_state(gilrs, &mut actions);
+        }
+
+        if recreate {
+            self.reset_after_disconnect();
+        }
+
+        actions
+    }
+
+    pub fn active_profile(&self) -> GamepadProfile {
+        *self.active_profile.borrow()
+    }
+
+    pub fn active_name(&self) -> String {
+        self.active_name.borrow().clone()
+    }
+
+    fn refresh_primary_gamepad(&self, gilrs: &Gilrs) {
+        let best = gilrs
+            .gamepads()
+            .filter(|(_, gamepad)| is_game_controller(gamepad.name()))
+            .max_by_key(|(_, gamepad)| gamepad_priority(gamepad.name()))
+            .map(|(id, _)| id);
+        *self.primary_id.borrow_mut() = best;
+        if let Some(id) = best {
+            self.track_active_gamepad(id, gilrs);
+        }
+    }
+
+    fn track_active_gamepad(&self, id: GamepadId, gilrs: &Gilrs) {
+        let name = gilrs.gamepad(id).name().to_string();
+        *self.active_name.borrow_mut() = name.clone();
+        *self.active_profile.borrow_mut() = GamepadProfile::detect(&name);
+    }
+
+    fn clear_gamepad_state(&self, id: GamepadId) {
+        self.button_active
+            .borrow_mut()
+            .retain(|(gamepad_id, _), _| *gamepad_id != id);
+        self.axis_active
+            .borrow_mut()
+            .retain(|(gamepad_id, _), _| *gamepad_id != id);
+    }
+
+    fn reset_after_disconnect(&self) {
+        self.button_active.borrow_mut().clear();
+        self.axis_active.borrow_mut().clear();
+        *self.primary_id.borrow_mut() = None;
+        *self.gilrs.borrow_mut() = open_gilrs();
+    }
+
+    fn poll_cached_state(&self, gilrs: &Gilrs, actions: &mut Vec<InputAction>) {
+        let Some(id) = *self.primary_id.borrow() else {
+            return;
+        };
+        let gamepad = gilrs.gamepad(id);
+        if !gamepad.is_connected() {
+            return;
+        }
+
+        let button_map = [
+            (Button::South, InputAction::Activate),
+            (Button::East, InputAction::Back),
+            (Button::West, InputAction::Search),
+            (Button::Start, InputAction::Menu),
+            (Button::Select, InputAction::ToggleHints),
+            (Button::Mode, InputAction::SwitchGamepad),
+            (Button::DPadUp, InputAction::NavigateUp),
+            (Button::DPadDown, InputAction::NavigateDown),
+            (Button::DPadLeft, InputAction::NavigateLeft),
+            (Button::DPadRight, InputAction::NavigateRight),
+            (Button::LeftTrigger, InputAction::PageScrollLeft),
+            (Button::RightTrigger, InputAction::PageScrollRight),
+            (Button::LeftTrigger2, InputAction::PageScrollLeft),
+            (Button::RightTrigger2, InputAction::PageScrollRight),
+        ];
+
+        for (button, action) in button_map {
+            if self.consume_button_edge(id, button, gamepad.is_pressed(button)) {
+                crate::tv::osk::mark_gamepad_input();
+                actions.push(action);
+            }
+        }
+
+        self.poll_stick_axis(id, &gamepad, Axis::LeftStickX, actions);
+        self.poll_stick_axis(id, &gamepad, Axis::LeftStickY, actions);
+    }
+
+    fn poll_stick_axis(
+        &self, id: GamepadId, gamepad: &gilrs::Gamepad<'_>, axis: Axis,
+        actions: &mut Vec<InputAction>,
+    ) {
+        let value = gamepad.value(axis);
+        let active = value.abs() >= self.stick_deadzone;
+        if !self.consume_axis_edge(id, axis, active) {
+            return;
+        }
+        crate::tv::osk::mark_gamepad_input();
+        let action = match axis {
+            Axis::LeftStickX if value > 0.0 => InputAction::NavigateRight,
+            Axis::LeftStickX => InputAction::NavigateLeft,
+            Axis::LeftStickY if value < 0.0 => InputAction::NavigateUp,
+            Axis::LeftStickY => InputAction::NavigateDown,
+            _ => return,
+        };
+        actions.push(action);
+    }
+
+    fn consume_button_edge(&self, id: GamepadId, button: Button, pressed: bool) -> bool {
+        let key = (id, button);
+        let was_pressed = self
+            .button_active
+            .borrow()
+            .get(&key)
+            .copied()
+            .unwrap_or(false);
+        self.button_active.borrow_mut().insert(key, pressed);
+        pressed && !was_pressed
+    }
+
+    fn consume_axis_edge(&self, id: GamepadId, axis: Axis, active: bool) -> bool {
+        let key = (id, axis);
+        let was_active = self
+            .axis_active
+            .borrow()
+            .get(&key)
+            .copied()
+            .unwrap_or(false);
+        self.axis_active.borrow_mut().insert(key, active);
+        active && !was_active
+    }
+
+    fn map_event(&self, id: GamepadId, event: EventType) -> Option<InputAction> {
+        use InputAction::*;
+        match event {
+            EventType::ButtonPressed(button, _) => {
+                self.button_active.borrow_mut().insert((id, button), true);
+                self.button_action(button)
+            }
+            EventType::ButtonRepeated(button, _) => self.button_action(button),
+            EventType::ButtonChanged(button, value, _) if value > 0.5 => {
+                if self.consume_button_edge(id, button, true) {
+                    self.button_action(button)
+                } else {
+                    None
+                }
+            }
+            EventType::ButtonChanged(button, value, _) if value <= 0.5 => {
+                self.button_active.borrow_mut().insert((id, button), false);
+                None
+            }
+            EventType::AxisChanged(axis, value, _) => {
+                let active = value.abs() >= self.stick_deadzone;
+                if !self.consume_axis_edge(id, axis, active) {
+                    return None;
+                }
+                match axis {
+                    Axis::LeftStickX if value > 0.0 => Some(NavigateLeft),
+                    Axis::LeftStickX => Some(NavigateRight),
+                    Axis::LeftStickY if value < 0.0 => Some(NavigateDown),
+                    Axis::LeftStickY => Some(NavigateUp),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn button_action(&self, button: Button) -> Option<InputAction> {
+        use InputAction::*;
+        match button {
+            Button::South => Some(Activate),
+            Button::East => Some(Back),
+            Button::West => Some(Search),
+            Button::Start => Some(Menu),
+            Button::Select => Some(ToggleHints),
+            Button::Mode => Some(SwitchGamepad),
+            Button::DPadUp => Some(NavigateUp),
+            Button::DPadDown => Some(NavigateDown),
+            Button::DPadLeft => Some(NavigateLeft),
+            Button::DPadRight => Some(NavigateRight),
+            Button::LeftTrigger | Button::LeftTrigger2 => Some(PageScrollLeft),
+            Button::RightTrigger | Button::RightTrigger2 => Some(PageScrollRight),
+            _ => None,
+        }
+    }
+}
+
+fn open_gilrs() -> Option<Gilrs> {
+    GilrsBuilder::new().with_force_feedback(false).build().ok()
+}
+
+fn is_game_controller(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    !lower.contains("stick")
+        && !lower.contains("throttle")
+        && !lower.contains("rudder")
+        && !lower.contains("pedal")
+        && !lower.contains("hotas")
+        && !lower.contains("flight")
+        && !lower.contains("yoke")
+}
+
+fn gamepad_priority(name: &str) -> i32 {
+    match GamepadProfile::detect(name) {
+        GamepadProfile::Xbox
+        | GamepadProfile::PlayStation
+        | GamepadProfile::SteamDeck
+        | GamepadProfile::Nintendo => 100,
+        GamepadProfile::Generic => 10,
+    }
+}

--- a/src/ui/input/gamepad_profile.rs
+++ b/src/ui/input/gamepad_profile.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GamepadProfile {
+    #[default]
+    Generic,
+    Xbox,
+    PlayStation,
+    SteamDeck,
+    Nintendo,
+}
+
+impl GamepadProfile {
+    pub fn detect(name: &str) -> Self {
+        let lower = name.to_lowercase();
+        if lower.contains("xbox") || lower.contains("microsoft") || lower.contains("360 controller")
+        {
+            Self::Xbox
+        } else if lower.contains("sony")
+            || lower.contains("playstation")
+            || lower.contains("dualshock")
+            || lower.contains("dualsense")
+        {
+            Self::PlayStation
+        } else if lower.contains("steam deck") || lower.contains("steam controller") {
+            Self::SteamDeck
+        } else if lower.contains("nintendo")
+            || lower.contains("pro controller")
+            || lower.contains("joy-con")
+        {
+            Self::Nintendo
+        } else {
+            Self::Generic
+        }
+    }
+
+    pub fn activate_label(self) -> &'static str {
+        match self {
+            Self::PlayStation => "✕",
+            Self::Nintendo => "B",
+            Self::Xbox | Self::SteamDeck | Self::Generic => "A",
+        }
+    }
+
+    pub fn back_label(self) -> &'static str {
+        match self {
+            Self::PlayStation => "○",
+            Self::Nintendo => "A",
+            Self::Xbox | Self::SteamDeck | Self::Generic => "B",
+        }
+    }
+}

--- a/src/ui/input/grid_navigator.rs
+++ b/src/ui/input/grid_navigator.rs
@@ -1,0 +1,64 @@
+use gtk::glib::subclass::types::ObjectSubclassIsExt;
+
+use super::actions::InputAction;
+use crate::{
+    Window,
+    ui::widgets::single_grid::SingleGrid,
+};
+
+pub struct GridNavigator;
+
+impl GridNavigator {
+    pub fn handle(&self, window: &Window, grid: &SingleGrid, action: InputAction) -> bool {
+        let scrolled = grid.tuview_scrolled();
+
+        match action {
+            InputAction::NavigateLeft => {
+                scrolled.move_grid_selection(0, -1);
+                true
+            }
+            InputAction::NavigateRight => {
+                scrolled.move_grid_selection(0, 1);
+                true
+            }
+            InputAction::NavigateUp => {
+                scrolled.move_grid_selection(-1, 0);
+                true
+            }
+            InputAction::NavigateDown => {
+                scrolled.move_grid_selection(1, 0);
+                true
+            }
+            InputAction::Activate => {
+                scrolled.activate_selected(window);
+                true
+            }
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::Menu => {
+                window.set_sidebar_panel_visible(
+                    !window.tv_sidebar_collapsed()
+                        || !window.imp().split_view.get().shows_sidebar(),
+                );
+                true
+            }
+            InputAction::PageScrollLeft => {
+                scrolled.move_grid_selection(0, -scrolled.grid_column_count());
+                true
+            }
+            InputAction::PageScrollRight => {
+                scrolled.move_grid_selection(0, scrolled.grid_column_count());
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Default for GridNavigator {
+    fn default() -> Self {
+        Self
+    }
+}

--- a/src/ui/input/item_navigator.rs
+++ b/src/ui/input/item_navigator.rs
@@ -1,0 +1,247 @@
+use gtk::{
+    glib::subclass::types::ObjectSubclassIsExt,
+    prelude::*,
+};
+
+use super::actions::InputAction;
+use crate::{
+    Window,
+    ui::widgets::{
+        horbu_scrolled::HorbuScrolled,
+        hortu_scrolled::HortuScrolled,
+        item::ItemPage,
+    },
+};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ItemZone {
+    TopBar,
+    Hortu(usize),
+    Horbu(usize),
+    Episodes,
+    MediaInfo,
+}
+
+pub struct ItemPageNavigator {
+    zone: std::cell::Cell<ItemZone>,
+    hortu_rows: std::cell::RefCell<Vec<HortuScrolled>>,
+    horbu_rows: std::cell::RefCell<Vec<HorbuScrolled>>,
+}
+
+impl Default for ItemPageNavigator {
+    fn default() -> Self {
+        Self {
+            zone: std::cell::Cell::new(ItemZone::TopBar),
+            hortu_rows: std::cell::RefCell::new(Vec::new()),
+            horbu_rows: std::cell::RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl ItemPageNavigator {
+    pub fn handle(&self, window: &Window, page: &ItemPage, action: InputAction) -> bool {
+        *self.hortu_rows.borrow_mut() = page.focus_hortu_rows();
+        *self.horbu_rows.borrow_mut() = page.focus_horbu_rows();
+
+        match action {
+            InputAction::NavigateDown => {
+                if self.zone.get() == ItemZone::TopBar && page.navigate_top_bar_spatial(0, 1) {
+                    return true;
+                }
+                if self.zone.get() == ItemZone::Episodes && page.is_episode_toolbar_focused() {
+                    page.focus_episode_list();
+                    return true;
+                }
+                self.navigate_zone(page, 1)
+            }
+            InputAction::NavigateUp => {
+                if self.zone.get() == ItemZone::TopBar && page.navigate_top_bar_spatial(0, -1) {
+                    return true;
+                }
+                if self.zone.get() == ItemZone::Episodes && !page.is_episode_toolbar_focused() {
+                    page.focus_episode_toolbar(0);
+                    return true;
+                }
+                self.navigate_zone(page, -1)
+            }
+            InputAction::NavigateLeft => {
+                if self.zone.get() == ItemZone::TopBar && page.navigate_top_bar_spatial(-1, 0) {
+                    return true;
+                }
+                if self.zone.get() == ItemZone::Episodes && page.is_episode_toolbar_focused() {
+                    page.navigate_episode_toolbar(-1);
+                    return true;
+                }
+                self.navigate_horizontal(page, -1)
+            }
+            InputAction::NavigateRight => {
+                if self.zone.get() == ItemZone::TopBar && page.navigate_top_bar_spatial(1, 0) {
+                    return true;
+                }
+                if self.zone.get() == ItemZone::Episodes && page.is_episode_toolbar_focused() {
+                    page.navigate_episode_toolbar(1);
+                    return true;
+                }
+                self.navigate_horizontal(page, 1)
+            }
+            InputAction::Activate => self.activate(window, page),
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::Menu => {
+                window.set_sidebar_panel_visible(
+                    !window.tv_sidebar_collapsed()
+                        || !window.imp().split_view.get().shows_sidebar(),
+                );
+                true
+            }
+            InputAction::Search => {
+                page.open_subtitle_search();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn visible_zones(&self, page: &ItemPage) -> Vec<ItemZone> {
+        let mut zones = vec![ItemZone::TopBar];
+        if page.has_episode_list() {
+            zones.push(ItemZone::Episodes);
+        }
+        for (i, row) in self.hortu_rows.borrow().iter().enumerate() {
+            if row.is_visible() && row.item_count() > 0 {
+                zones.push(ItemZone::Hortu(i));
+            }
+        }
+        for (i, row) in self.horbu_rows.borrow().iter().enumerate() {
+            if row.is_visible() && row.button_count() > 0 {
+                zones.push(ItemZone::Horbu(i));
+            }
+        }
+        if page.mediainfo_card_count() > 0 {
+            zones.push(ItemZone::MediaInfo);
+        }
+        zones
+    }
+
+    fn navigate_zone(&self, page: &ItemPage, delta: i32) -> bool {
+        let zones = self.visible_zones(page);
+        if zones.is_empty() {
+            return false;
+        }
+        let current = self.zone.get();
+        let pos = zones.iter().position(|z| *z == current).unwrap_or(0) as i32;
+        let next = (pos + delta).clamp(0, zones.len() as i32 - 1) as usize;
+        if zones[next] == current {
+            return true;
+        }
+        self.clear_zone_focus(page);
+        self.zone.set(zones[next]);
+        self.apply_zone_focus(page);
+        true
+    }
+
+    fn navigate_horizontal(&self, page: &ItemPage, delta: i32) -> bool {
+        match self.zone.get() {
+            ItemZone::Hortu(idx) => {
+                if let Some(row) = self.hortu_rows.borrow().get(idx) {
+                    row.move_selection(delta);
+                }
+                true
+            }
+            ItemZone::Horbu(idx) => {
+                if let Some(row) = self.horbu_rows.borrow().get(idx) {
+                    row.move_selection(delta);
+                }
+                true
+            }
+            ItemZone::Episodes => {
+                page.navigate_episodes(delta);
+                true
+            }
+            ItemZone::MediaInfo => {
+                page.move_mediainfo_selection(delta);
+                true
+            }
+            ItemZone::TopBar => false,
+        }
+    }
+
+    fn activate(&self, window: &Window, page: &ItemPage) -> bool {
+        match self.zone.get() {
+            ItemZone::TopBar => {
+                page.activate_focused_top_bar();
+                true
+            }
+            ItemZone::Hortu(idx) => {
+                if let Some(row) = self.hortu_rows.borrow().get(idx) {
+                    row.activate_selected(window);
+                }
+                true
+            }
+            ItemZone::Horbu(idx) => {
+                if let Some(row) = self.horbu_rows.borrow().get(idx) {
+                    row.activate_selected();
+                }
+                true
+            }
+            ItemZone::Episodes => {
+                if page.is_episode_toolbar_focused() {
+                    page.activate_episode_toolbar();
+                } else {
+                    page.activate_focused_episode();
+                }
+                true
+            }
+            ItemZone::MediaInfo => true,
+        }
+    }
+
+    fn clear_zone_focus(&self, page: &ItemPage) {
+        page.clear_top_bar_focus();
+        page.clear_episode_toolbar_focus();
+        for row in self.hortu_rows.borrow().iter() {
+            row.clear_selection();
+        }
+        for row in self.horbu_rows.borrow().iter() {
+            row.clear_selection();
+        }
+        page.clear_episode_focus();
+        page.clear_mediainfo_focus();
+    }
+
+    fn apply_zone_focus(&self, page: &ItemPage) {
+        match self.zone.get() {
+            ItemZone::TopBar => {
+                page.scroll_to_hero_page();
+                page.focus_default_top_bar_spatial();
+            }
+            ItemZone::Episodes => {
+                page.scroll_to_hero_page();
+                if page.has_episode_toolbar() {
+                    page.focus_episode_toolbar(0);
+                } else {
+                    page.focus_episode_list();
+                }
+            }
+            ItemZone::Hortu(idx) => {
+                if let Some(row) = self.hortu_rows.borrow().get(idx).cloned() {
+                    page.focus_details_row(move || {
+                        row.ensure_selection();
+                        row.scroll_into_parent_viewport();
+                    });
+                }
+            }
+            ItemZone::Horbu(idx) => {
+                if let Some(row) = self.horbu_rows.borrow().get(idx).cloned() {
+                    page.focus_details_row(move || {
+                        row.ensure_selection();
+                        row.scroll_into_parent_viewport();
+                    });
+                }
+            }
+            ItemZone::MediaInfo => page.scroll_mediainfo_into_view(),
+        }
+    }
+}

--- a/src/ui/input/liked_navigator.rs
+++ b/src/ui/input/liked_navigator.rs
@@ -1,0 +1,35 @@
+use gtk::prelude::*;
+
+use crate::{
+    Window,
+    ui::{
+        input::{
+            actions::InputAction,
+            focus_manager::FocusManager,
+        },
+        widgets::liked::LikedPage,
+    },
+};
+
+#[derive(Default)]
+pub struct LikedNavigator {
+    focus: FocusManager,
+}
+
+impl LikedNavigator {
+    pub fn register(&self, liked: &LikedPage) {
+        self.focus.register_rows(liked.focus_hortu_rows());
+    }
+
+    pub fn handle(&self, window: &Window, liked: &LikedPage, action: InputAction) -> bool {
+        if self.focus.handle_rows_only(window, action) {
+            return true;
+        }
+        // Re-register if rows were empty on first visit.
+        if liked.focus_hortu_rows().iter().any(|r| r.is_visible()) {
+            self.register(liked);
+            return self.focus.handle_rows_only(window, action);
+        }
+        false
+    }
+}

--- a/src/ui/input/mod.rs
+++ b/src/ui/input/mod.rs
@@ -1,0 +1,41 @@
+pub mod actions;
+pub mod dialog_navigator;
+pub mod focus_manager;
+pub mod gamepad;
+pub mod gamepad_profile;
+pub mod grid_navigator;
+pub mod item_navigator;
+pub mod liked_navigator;
+pub mod mpv_navigator;
+pub mod navigation;
+pub mod placeholder_navigator;
+pub mod popover_navigator;
+pub mod pushed_navigator;
+pub mod router;
+pub mod search_navigator;
+pub mod settings_navigator;
+
+pub use actions::InputAction;
+pub use focus_manager::{
+    FocusManager,
+    HomeFocusSnapshot,
+};
+pub use gamepad::GamepadManager;
+pub use gamepad_profile::GamepadProfile;
+pub use grid_navigator::GridNavigator;
+pub use item_navigator::ItemPageNavigator;
+pub use liked_navigator::LikedNavigator;
+pub use mpv_navigator::MpvNavigator;
+pub use navigation::{
+    MainTab,
+    NavigationContext,
+    PushedPageKind,
+};
+pub use placeholder_navigator::PlaceholderNavigator;
+pub use pushed_navigator::{
+    MediaViewerNavigator,
+    PushedNavigator,
+};
+pub use router::key_to_action;
+pub use search_navigator::SearchNavigator;
+pub use settings_navigator::SettingsNavigator;

--- a/src/ui/input/mpv_navigator.rs
+++ b/src/ui/input/mpv_navigator.rs
@@ -1,0 +1,120 @@
+use gtk::{
+    glib::subclass::types::ObjectSubclassIsExt,
+    prelude::*,
+};
+
+use super::actions::InputAction;
+use crate::{
+    Window,
+    ui::{
+        models::SETTINGS,
+        mpv::page::MPVPage,
+    },
+};
+
+pub struct MpvNavigator {
+    playlist_index: std::cell::Cell<u32>,
+}
+
+impl Default for MpvNavigator {
+    fn default() -> Self {
+        Self {
+            playlist_index: std::cell::Cell::new(0),
+        }
+    }
+}
+
+impl MpvNavigator {
+    pub fn handle(&self, window: &Window, mpv: &MPVPage, action: InputAction) -> bool {
+        let sidebar = window.imp().mpv_view.get();
+        let sidebar_visible = sidebar.shows_sidebar();
+
+        if sidebar_visible {
+            return self.handle_sidebar(window, action);
+        }
+
+        match action {
+            InputAction::Back => {
+                mpv.on_stop_clicked();
+                true
+            }
+            InputAction::PlayPause => {
+                mpv.on_play_pause_clicked();
+                true
+            }
+            InputAction::NavigateLeft => {
+                mpv.seek_relative(-(SETTINGS.mpv_seek_backward_step() as f64));
+                true
+            }
+            InputAction::NavigateRight => {
+                mpv.seek_relative(SETTINGS.mpv_seek_forward_step() as f64);
+                true
+            }
+            InputAction::NavigateUp => {
+                mpv.adjust_volume(5);
+                true
+            }
+            InputAction::NavigateDown => {
+                mpv.adjust_volume(-5);
+                true
+            }
+            InputAction::Menu => {
+                sidebar.set_show_sidebar(!sidebar.shows_sidebar());
+                true
+            }
+            InputAction::Search => {
+                mpv.open_subtitle_search();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_sidebar(&self, window: &Window, action: InputAction) -> bool {
+        let selection = &window.imp().mpv_playlist_selection;
+        let count = selection.n_items();
+        if count == 0 {
+            return false;
+        }
+        let mut index = self.playlist_index.get().min(count - 1);
+
+        match action {
+            InputAction::NavigateDown | InputAction::NavigateRight => {
+                index = (index + 1).min(count - 1);
+                self.playlist_index.set(index);
+                selection.set_selected(index);
+                self.highlight_playlist_row(window, index);
+                true
+            }
+            InputAction::NavigateUp | InputAction::NavigateLeft => {
+                index = index.saturating_sub(1);
+                self.playlist_index.set(index);
+                selection.set_selected(index);
+                self.highlight_playlist_row(window, index);
+                true
+            }
+            InputAction::Activate => {
+                selection.set_selected(index);
+                if let Some(item) = selection
+                    .item(index)
+                    .and_downcast::<crate::ui::provider::tu_object::TuObject>()
+                {
+                    item.activate(&window.imp().mpv_playlist.get());
+                }
+                true
+            }
+            InputAction::Back | InputAction::Menu => {
+                window.imp().mpv_view.get().set_show_sidebar(false);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn highlight_playlist_row(&self, window: &Window, index: u32) {
+        let imp = window.imp();
+        imp.mpv_playlist_selection.set_selected(index);
+        imp.mpv_playlist
+            .scroll_to(index, gtk::ListScrollFlags::NONE, None);
+    }
+}

--- a/src/ui/input/navigation.rs
+++ b/src/ui/input/navigation.rs
@@ -1,0 +1,81 @@
+use adw::prelude::*;
+use gtk::glib::subclass::types::ObjectSubclassIsExt;
+
+use crate::Window;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MainTab {
+    Home,
+    Liked,
+    Search,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushedPageKind {
+    Item,
+    Grid,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavigationContext {
+    Mpv,
+    Placeholder,
+    MediaViewer,
+    Modal,
+    Pushed(PushedPageKind),
+    Main(MainTab),
+}
+
+impl Window {
+    pub fn resolve_navigation_context(&self) -> NavigationContext {
+        if self.is_on_mpv_stack_pub() {
+            return NavigationContext::Mpv;
+        }
+        if self.is_on_placeholder() {
+            return NavigationContext::Placeholder;
+        }
+        if self.imp().media_viewer.get().is_revealed() {
+            return NavigationContext::MediaViewer;
+        }
+        if self
+            .imp()
+            .active_settings
+            .borrow()
+            .as_ref()
+            .is_some_and(|s| s.is_visible())
+            || self
+                .imp()
+                .active_account_dialog
+                .borrow()
+                .as_ref()
+                .is_some_and(|d| d.is_visible())
+        {
+            return NavigationContext::Modal;
+        }
+
+        if self.now_page_tag().as_deref() != Some("mainpage") {
+            if let Some(page) = self.imp().mainview.visible_page() {
+                if page
+                    .downcast_ref::<crate::ui::widgets::item::ItemPage>()
+                    .is_some()
+                {
+                    return NavigationContext::Pushed(PushedPageKind::Item);
+                }
+                if page
+                    .downcast_ref::<crate::ui::widgets::single_grid::SingleGrid>()
+                    .is_some()
+                {
+                    return NavigationContext::Pushed(PushedPageKind::Grid);
+                }
+            }
+            return NavigationContext::Pushed(PushedPageKind::Other);
+        }
+
+        match self.imp().insidestack.visible_child_name().as_deref() {
+            Some("likedpage") => NavigationContext::Main(MainTab::Liked),
+            Some("searchpage") => NavigationContext::Main(MainTab::Search),
+            _ => NavigationContext::Main(MainTab::Home),
+        }
+    }
+}

--- a/src/ui/input/placeholder_navigator.rs
+++ b/src/ui/input/placeholder_navigator.rs
@@ -1,0 +1,175 @@
+use std::cell::RefCell;
+
+use gtk::prelude::*;
+
+use super::actions::InputAction;
+use crate::{
+    Window,
+    tv::set_tv_focused,
+    ui::widgets::server_action_row::ServerActionRow,
+};
+
+pub struct PlaceholderNavigator {
+    selected_index: RefCell<u32>,
+    selected_column: RefCell<u32>,
+    last_row: RefCell<Option<gtk::ListBoxRow>>,
+    add_server_button: RefCell<Option<gtk::Button>>,
+}
+
+impl Default for PlaceholderNavigator {
+    fn default() -> Self {
+        Self {
+            selected_index: RefCell::new(0),
+            selected_column: RefCell::new(0),
+            last_row: RefCell::new(None),
+            add_server_button: RefCell::new(None),
+        }
+    }
+}
+
+impl PlaceholderNavigator {
+    pub fn reset(&self) {
+        *self.selected_index.borrow_mut() = 0;
+        *self.selected_column.borrow_mut() = 0;
+        self.clear_row_focus();
+        self.clear_add_server_focus();
+    }
+
+    pub fn select_initial(&self, listbox: &gtk::ListBox) {
+        if listbox.observe_children().n_items() > 0 {
+            select_row(self, listbox, 0);
+        }
+    }
+
+    pub fn focus_add_server(&self, button: &gtk::Button) {
+        self.clear_row_focus();
+        *self.add_server_button.borrow_mut() = Some(button.clone());
+        set_tv_focused(button, true);
+        button.grab_focus();
+    }
+
+    pub fn handle(
+        &self, window: &Window, login_stack: &gtk::Stack, listbox: &gtk::ListBox,
+        action: InputAction,
+    ) -> bool {
+        if login_stack.visible_child_name().as_deref() == Some("no-server") {
+            return self.handle_no_server(window, action);
+        }
+
+        let count = listbox.observe_children().n_items();
+        if count == 0 {
+            return match action {
+                InputAction::Activate => {
+                    window.new_account();
+                    true
+                }
+                _ => false,
+            };
+        }
+
+        let mut index = *self.selected_index.borrow();
+        if index >= count {
+            index = count.saturating_sub(1);
+        }
+        let mut column = *self.selected_column.borrow();
+
+        match action {
+            InputAction::NavigateDown => {
+                index = (index + 1).min(count - 1);
+                column = 0;
+                *self.selected_index.borrow_mut() = index;
+                *self.selected_column.borrow_mut() = column;
+                select_row(self, listbox, index);
+                true
+            }
+            InputAction::NavigateUp => {
+                index = index.saturating_sub(1);
+                column = 0;
+                *self.selected_index.borrow_mut() = index;
+                *self.selected_column.borrow_mut() = column;
+                select_row(self, listbox, index);
+                true
+            }
+            InputAction::NavigateRight => {
+                if let Some(row) = listbox.row_at_index(index as i32)
+                    && let Ok(server_row) = row.downcast::<ServerActionRow>()
+                {
+                    let max_col = server_row.tv_focus_widgets().len().saturating_sub(1) as u32;
+                    column = (column + 1).min(max_col);
+                    *self.selected_column.borrow_mut() = column;
+                    server_row.set_tv_column_focus(column as usize);
+                    return true;
+                }
+                false
+            }
+            InputAction::NavigateLeft => {
+                if column > 0 {
+                    column = column.saturating_sub(1);
+                    *self.selected_column.borrow_mut() = column;
+                    if let Some(row) = listbox.row_at_index(index as i32)
+                        && let Ok(server_row) = row.downcast::<ServerActionRow>()
+                    {
+                        server_row.set_tv_column_focus(column as usize);
+                    }
+                    return true;
+                }
+                false
+            }
+            InputAction::Activate => {
+                if let Some(row) = listbox.row_at_index(index as i32) {
+                    if let Ok(server_row) = row.clone().downcast::<ServerActionRow>() {
+                        server_row.activate_column(column);
+                    } else {
+                        row.activate();
+                    }
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_no_server(&self, window: &Window, action: InputAction) -> bool {
+        match action {
+            InputAction::Activate => {
+                window.new_account();
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+fn select_row(navigator: &PlaceholderNavigator, listbox: &gtk::ListBox, index: u32) {
+    navigator.clear_row_focus();
+    navigator.clear_add_server_focus();
+    *navigator.selected_column.borrow_mut() = 0;
+    if let Some(row) = listbox.row_at_index(index as i32) {
+        listbox.select_row(Some(&row));
+        row.grab_focus();
+        if let Ok(server_row) = row.clone().downcast::<ServerActionRow>() {
+            server_row.set_tv_column_focus(0);
+        } else {
+            set_tv_focused(&row, true);
+        }
+        *navigator.last_row.borrow_mut() = Some(row);
+    }
+}
+
+impl PlaceholderNavigator {
+    fn clear_row_focus(&self) {
+        if let Some(row) = self.last_row.borrow_mut().take() {
+            if let Ok(server_row) = row.clone().downcast::<ServerActionRow>() {
+                server_row.clear_tv_column_focus();
+            } else {
+                set_tv_focused(&row, false);
+            }
+        }
+    }
+
+    fn clear_add_server_focus(&self) {
+        if let Some(button) = self.add_server_button.borrow_mut().take() {
+            set_tv_focused(&button, false);
+        }
+    }
+}

--- a/src/ui/input/popover_navigator.rs
+++ b/src/ui/input/popover_navigator.rs
@@ -1,0 +1,480 @@
+use std::cell::Cell;
+
+use adw::prelude::*;
+use gtk::{
+    gio,
+    gio::prelude::MenuModelExt,
+    glib,
+    glib::subclass::types::ObjectSubclassIsExt,
+};
+
+use super::actions::InputAction;
+use crate::{
+    Window,
+    tv::set_tv_focused,
+};
+
+thread_local! {
+    static MENU_POPOVER: Cell<usize> = const { Cell::new(0) };
+    static MENU_INDEX: Cell<u32> = const { Cell::new(0) };
+}
+
+struct FlatMenuEntry {
+    action: glib::GString,
+}
+
+pub fn handle(window: &Window, action: InputAction) -> bool {
+    if let Some(settings) = window.imp().active_settings.borrow().clone()
+        && settings.is_visible()
+        && handle_widget_tree(settings.upcast_ref(), action)
+    {
+        return true;
+    }
+    if let Some(account) = window.imp().active_account_dialog.borrow().clone()
+        && account.is_visible()
+        && handle_widget_tree(account.upcast_ref(), action)
+    {
+        return true;
+    }
+    if handle_widget_tree(window.upcast_ref(), action) {
+        return true;
+    }
+    if let Some(root) = window.root() {
+        let root_widget = root.upcast_ref::<gtk::Widget>();
+        if root_widget != window.upcast_ref::<gtk::Widget>() {
+            return handle_widget_tree(root_widget, action);
+        }
+    }
+    false
+}
+
+pub fn handle_widget_tree(root: &gtk::Widget, action: InputAction) -> bool {
+    if let Some(popover) = find_open_menu_popover(root) {
+        return handle_popover(&popover, action);
+    }
+    let Some(popover) = find_visible_popover(root) else {
+        return false;
+    };
+    handle_popover(&popover, action)
+}
+
+pub fn popdown_visible_popover(root: &gtk::Widget) -> bool {
+    if let Some(popover) = find_open_menu_popover(root).or_else(|| find_visible_popover(root)) {
+        popover.popdown();
+        return true;
+    }
+    false
+}
+
+fn find_open_menu_popover(root: &gtk::Widget) -> Option<gtk::Popover> {
+    let mut stack = vec![root.clone()];
+    let mut menu_popover = None;
+    while let Some(widget) = stack.pop() {
+        if let Ok(menu) = widget.clone().downcast::<gtk::PopoverMenu>()
+            && menu.is_visible()
+        {
+            menu_popover = Some(menu.upcast());
+        }
+        if let Ok(button) = widget.clone().downcast::<gtk::MenuButton>()
+            && button.is_active()
+            && let Some(popover) = button.popover()
+            && popover.is_visible()
+        {
+            return Some(popover);
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    menu_popover
+}
+
+fn activate_menu_action(anchor: &gtk::Widget, action: &str) {
+    let mut current = Some(anchor.clone());
+    while let Some(widget) = current {
+        if gtk::prelude::WidgetExt::activate_action(&widget, action, None).is_ok() {
+            return;
+        }
+        current = widget.parent();
+    }
+}
+
+fn find_visible_popover(root: &gtk::Widget) -> Option<gtk::Popover> {
+    let mut stack = vec![root.clone()];
+    let mut found = None;
+    while let Some(widget) = stack.pop() {
+        if let Ok(popover) = widget.clone().downcast::<gtk::Popover>()
+            && popover.is_visible()
+        {
+            found = Some(popover);
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    found
+}
+
+fn find_parent_popover(widget: &gtk::Widget) -> Option<gtk::Popover> {
+    let mut parent = widget.parent();
+    while let Some(w) = parent {
+        if let Ok(popover) = w.clone().downcast::<gtk::Popover>() {
+            return Some(popover);
+        }
+        parent = w.parent();
+    }
+    None
+}
+
+fn find_parent_dropdown(widget: &gtk::Widget) -> Option<gtk::DropDown> {
+    let mut parent = widget.parent();
+    while let Some(w) = parent {
+        if let Ok(dropdown) = w.clone().downcast::<gtk::DropDown>() {
+            return Some(dropdown);
+        }
+        parent = w.parent();
+    }
+    None
+}
+
+fn find_parent_combo_row(widget: &gtk::Widget) -> Option<adw::ComboRow> {
+    let mut parent = widget.parent();
+    while let Some(w) = parent {
+        if let Ok(row) = w.clone().downcast::<adw::ComboRow>() {
+            return Some(row);
+        }
+        parent = w.parent();
+    }
+    None
+}
+
+fn menu_anchor(popover: &gtk::Popover) -> gtk::Widget {
+    popover
+        .parent()
+        .unwrap_or_else(|| popover.upcast_ref::<gtk::Widget>().clone())
+}
+
+fn append_menu_entries(model: &gio::MenuModel, entries: &mut Vec<FlatMenuEntry>) {
+    for i in 0..model.n_items() {
+        if let Some(submodel) = model.item_link(i, gio::MENU_LINK_SECTION) {
+            append_menu_entries(&submodel, entries);
+            continue;
+        }
+        if let Some(submodel) = model.item_link(i, gio::MENU_LINK_SUBMENU) {
+            append_menu_entries(&submodel, entries);
+            continue;
+        }
+        let Some(action) = model
+            .item_attribute_value(i, gio::MENU_ATTRIBUTE_ACTION, Some(glib::VariantTy::STRING))
+            .and_then(|value| value.get::<String>())
+            .filter(|action| !action.is_empty())
+        else {
+            continue;
+        };
+        entries.push(FlatMenuEntry {
+            action: action.into(),
+        });
+    }
+}
+
+fn collect_menu_entries(model: &gio::MenuModel) -> Vec<FlatMenuEntry> {
+    let mut entries = Vec::new();
+    append_menu_entries(model, &mut entries);
+    entries
+}
+
+fn sync_menu_listview(popover: &gtk::Popover, index: u32) {
+    let content = popover
+        .child()
+        .unwrap_or_else(|| popover.upcast_ref::<gtk::Widget>().clone());
+    let Some(listview) = find_popover_listview(&content) else {
+        return;
+    };
+    if let Some(selection) = listview
+        .model()
+        .and_then(|model| model.downcast::<gtk::SingleSelection>().ok())
+    {
+        selection.set_selected(index);
+        listview.scroll_to(index, gtk::ListScrollFlags::NONE, None);
+    }
+    highlight_listview_row(&listview, index);
+}
+
+fn highlight_listview_row(listview: &gtk::ListView, index: u32) {
+    clear_listview_tv_focus(listview);
+    let mut pos = 0u32;
+    let mut child = listview.first_child();
+    while let Some(widget) = child {
+        if pos == index {
+            set_tv_focused(&widget, true);
+            return;
+        }
+        pos += 1;
+        child = widget.next_sibling();
+    }
+}
+
+fn clear_listview_tv_focus(listview: &gtk::ListView) {
+    let mut child = listview.first_child();
+    while let Some(widget) = child {
+        set_tv_focused(&widget, false);
+        child = widget.next_sibling();
+    }
+}
+
+fn handle_gmenu_popover(
+    popover: &gtk::PopoverMenu, action: InputAction, on_back: impl FnOnce(),
+) -> bool {
+    let Some(model) = popover.menu_model() else {
+        return false;
+    };
+    let anchor = menu_anchor(popover.upcast_ref());
+    let entries = collect_menu_entries(&model);
+    if entries.is_empty() {
+        return false;
+    }
+
+    let popover_id = popover.as_ptr() as usize;
+    if MENU_POPOVER.get() != popover_id {
+        MENU_POPOVER.set(popover_id);
+        MENU_INDEX.set(0);
+    }
+
+    let count = entries.len() as u32;
+    let mut index = MENU_INDEX.get().min(count.saturating_sub(1));
+    sync_menu_listview(popover.upcast_ref(), index);
+
+    match action {
+        InputAction::NavigateDown | InputAction::NavigateRight => {
+            index = (index + 1).min(count - 1);
+            MENU_INDEX.set(index);
+            sync_menu_listview(popover.upcast_ref(), index);
+            true
+        }
+        InputAction::NavigateUp | InputAction::NavigateLeft => {
+            index = index.saturating_sub(1);
+            MENU_INDEX.set(index);
+            sync_menu_listview(popover.upcast_ref(), index);
+            true
+        }
+        InputAction::Activate => {
+            if let Some(entry) = entries.get(index as usize) {
+                activate_menu_action(&anchor, &entry.action);
+            }
+            popover.popdown();
+            true
+        }
+        InputAction::Back => {
+            on_back();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_popover(popover: &gtk::Popover, action: InputAction) -> bool {
+    if let Ok(menu_popover) = popover.clone().downcast::<gtk::PopoverMenu>()
+        && menu_popover.menu_model().is_some()
+    {
+        return handle_gmenu_popover(&menu_popover, action, || popover.popdown());
+    }
+
+    let content = popover
+        .child()
+        .unwrap_or_else(|| popover.upcast_ref::<gtk::Widget>().clone());
+
+    if let Some(listview) = find_popover_listview(&content) {
+        return handle_listview(listview, action, || popover.popdown());
+    }
+
+    if let Some(listbox) = find_popover_listbox(&content) {
+        return handle_listbox(&listbox, action, || popover.popdown());
+    }
+
+    let widgets = super::dialog_navigator::collect_focusable_widgets(&content);
+    super::settings_navigator::SettingsNavigator::default()
+        .handle_widgets(&widgets, action, || popover.popdown())
+}
+
+fn find_popover_listview(root: &gtk::Widget) -> Option<gtk::ListView> {
+    let mut stack = vec![root.clone()];
+    let mut found = None;
+    while let Some(widget) = stack.pop() {
+        if let Ok(listview) = widget.clone().downcast::<gtk::ListView>()
+            && listview
+                .model()
+                .and_then(|model| model.downcast::<gtk::SingleSelection>().ok())
+                .is_some_and(|sel| sel.n_items() > 0)
+        {
+            found = Some(listview);
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    found
+}
+
+fn find_popover_listbox(root: &gtk::Widget) -> Option<gtk::ListBox> {
+    let mut stack = vec![root.clone()];
+    let mut found = None;
+    while let Some(widget) = stack.pop() {
+        if let Ok(listbox) = widget.clone().downcast::<gtk::ListBox>()
+            && !listbox_rows(&listbox).is_empty()
+        {
+            found = Some(listbox);
+        }
+        let mut child = widget.first_child();
+        while let Some(next) = child {
+            stack.push(next.clone());
+            child = next.next_sibling();
+        }
+    }
+    found
+}
+
+fn listbox_rows(listbox: &gtk::ListBox) -> Vec<gtk::ListBoxRow> {
+    let mut rows = Vec::new();
+    let mut child = listbox.first_child();
+    while let Some(widget) = child {
+        let next = widget.next_sibling();
+        if let Ok(row) = widget.downcast::<gtk::ListBoxRow>()
+            && row.is_visible()
+            && row.is_sensitive()
+            && row.parent().as_ref() == Some(listbox.upcast_ref())
+        {
+            rows.push(row);
+        }
+        child = next;
+    }
+    rows
+}
+
+fn handle_listbox(listbox: &gtk::ListBox, action: InputAction, on_back: impl FnOnce()) -> bool {
+    let rows = listbox_rows(listbox);
+    if rows.is_empty() {
+        return false;
+    }
+
+    let mut current = listbox
+        .selected_row()
+        .and_then(|row| rows.iter().position(|r| r == &row))
+        .unwrap_or(0) as i32;
+
+    if listbox.selected_row().is_none() {
+        select_listbox_row(listbox, &rows, 0);
+        current = 0;
+    }
+
+    match action {
+        InputAction::NavigateDown | InputAction::NavigateRight => {
+            let next = (current + 1).min(rows.len() as i32 - 1) as usize;
+            select_listbox_row(listbox, &rows, next);
+            true
+        }
+        InputAction::NavigateUp | InputAction::NavigateLeft => {
+            let next = current.saturating_sub(1) as usize;
+            select_listbox_row(listbox, &rows, next);
+            true
+        }
+        InputAction::Activate => {
+            let index = current.clamp(0, rows.len() as i32 - 1) as usize;
+            if let Some(row) = rows.get(index) {
+                listbox.select_row(Some(row));
+                row.activate();
+            }
+            if let Some(popover) = find_parent_popover(listbox.upcast_ref()) {
+                popover.popdown();
+            }
+            true
+        }
+        InputAction::Back => {
+            on_back();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn select_listbox_row(listbox: &gtk::ListBox, rows: &[gtk::ListBoxRow], index: usize) {
+    let Some(row) = rows.get(index) else {
+        return;
+    };
+    for row in rows {
+        set_tv_focused(row, false);
+    }
+    listbox.select_row(Some(row));
+    set_tv_focused(row, true);
+}
+
+fn handle_listview(listview: gtk::ListView, action: InputAction, on_back: impl FnOnce()) -> bool {
+    let Some(selection) = listview
+        .model()
+        .and_then(|model| model.downcast::<gtk::SingleSelection>().ok())
+    else {
+        return false;
+    };
+    let count = selection.n_items() as i32;
+    if count == 0 {
+        return false;
+    }
+    let current = if selection.selected() == gtk::INVALID_LIST_POSITION {
+        0
+    } else {
+        selection.selected() as i32
+    };
+    if selection.selected() == gtk::INVALID_LIST_POSITION {
+        selection.set_selected(0);
+        listview.scroll_to(0, gtk::ListScrollFlags::NONE, None);
+    }
+
+    match action {
+        InputAction::NavigateDown | InputAction::NavigateRight => {
+            let next = (current + 1).clamp(0, count - 1) as u32;
+            selection.set_selected(next);
+            listview.scroll_to(next, gtk::ListScrollFlags::NONE, None);
+            highlight_listview_row(&listview, next);
+            true
+        }
+        InputAction::NavigateUp | InputAction::NavigateLeft => {
+            let next = (current - 1).clamp(0, count - 1) as u32;
+            selection.set_selected(next);
+            listview.scroll_to(next, gtk::ListScrollFlags::NONE, None);
+            highlight_listview_row(&listview, next);
+            true
+        }
+        InputAction::Activate => {
+            let index = selection.selected();
+            let widget = listview.upcast_ref::<gtk::Widget>();
+            if let Some(combo) = find_parent_combo_row(widget) {
+                if index != gtk::INVALID_LIST_POSITION {
+                    combo.set_selected(index);
+                }
+                if let Some(popover) = find_parent_popover(widget) {
+                    popover.popdown();
+                }
+            } else if let Some(dropdown) = find_parent_dropdown(widget) {
+                if index != gtk::INVALID_LIST_POSITION {
+                    dropdown.set_selected(index);
+                }
+                if let Some(popover) = find_parent_popover(widget) {
+                    popover.popdown();
+                }
+            } else {
+                listview.activate();
+            }
+            true
+        }
+        InputAction::Back => {
+            on_back();
+            true
+        }
+        _ => false,
+    }
+}

--- a/src/ui/input/pushed_navigator.rs
+++ b/src/ui/input/pushed_navigator.rs
@@ -1,0 +1,565 @@
+use gtk::{
+    glib::subclass::types::ObjectSubclassIsExt,
+    prelude::*,
+};
+
+use super::{
+    actions::InputAction,
+    focus_manager::FocusManager,
+    grid_navigator::GridNavigator,
+};
+use crate::{
+    Window,
+    tv::set_tv_focused,
+    ui::widgets::{
+        list::ListPage,
+        media_viewer::MediaViewer,
+        music_album::AlbumPage,
+        other::OtherPage,
+        server_panel::ServerPanel,
+    },
+};
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ListZone {
+    Tabs,
+    Toolbar,
+    Grid,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AlbumZone {
+    Actions,
+    Songs,
+    Rows,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OtherZone {
+    Actions,
+    Carousel,
+    Rows,
+    Episodes,
+}
+
+pub struct PushedNavigator {
+    album_focus: FocusManager,
+    other_focus: FocusManager,
+    grid_navigator: GridNavigator,
+    list_zone: std::cell::Cell<ListZone>,
+    list_toolbar_index: std::cell::Cell<usize>,
+    album_zone: std::cell::RefCell<AlbumZone>,
+    other_zone: std::cell::RefCell<OtherZone>,
+    server_group_index: std::cell::RefCell<usize>,
+    server_row_index: std::cell::RefCell<usize>,
+}
+
+impl Default for PushedNavigator {
+    fn default() -> Self {
+        Self {
+            album_focus: FocusManager::default(),
+            other_focus: FocusManager::default(),
+            grid_navigator: GridNavigator,
+            list_zone: std::cell::Cell::new(ListZone::Grid),
+            list_toolbar_index: std::cell::Cell::new(0),
+            album_zone: std::cell::RefCell::new(AlbumZone::Actions),
+            other_zone: std::cell::RefCell::new(OtherZone::Actions),
+            server_group_index: std::cell::RefCell::new(0),
+            server_row_index: std::cell::RefCell::new(0),
+        }
+    }
+}
+
+impl PushedNavigator {
+    pub fn handle(&self, window: &Window, action: InputAction) -> bool {
+        let Some(page) = window.imp().mainview.visible_page() else {
+            return self.handle_back(window, action);
+        };
+
+        if let Some(album) = page.downcast_ref::<AlbumPage>() {
+            return self.handle_album(window, album, action);
+        }
+        if let Some(list) = page.downcast_ref::<ListPage>() {
+            return self.handle_list(window, list, action);
+        }
+        if let Some(other) = page.downcast_ref::<OtherPage>() {
+            return self.handle_other(window, other, action);
+        }
+        if let Some(server) = page.downcast_ref::<ServerPanel>() {
+            return self.handle_server(window, server, action);
+        }
+
+        self.handle_back(window, action)
+    }
+
+    fn handle_back(&self, window: &Window, action: InputAction) -> bool {
+        match action {
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_album(&self, window: &Window, page: &AlbumPage, action: InputAction) -> bool {
+        self.album_focus.register_rows(page.focus_hortu_rows());
+
+        match action {
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::Menu => {
+                window.set_sidebar_panel_visible(
+                    !window.tv_sidebar_collapsed()
+                        || !window.imp().split_view.get().shows_sidebar(),
+                );
+                true
+            }
+            InputAction::NavigateDown => self.navigate_album_zone(page, 1),
+            InputAction::NavigateUp => self.navigate_album_zone(page, -1),
+            InputAction::NavigateLeft => self.navigate_album_horizontal(window, page, -1),
+            InputAction::NavigateRight => self.navigate_album_horizontal(window, page, 1),
+            InputAction::Activate => self.activate_album(window, page),
+            _ => false,
+        }
+    }
+
+    fn visible_album_zones(&self, page: &AlbumPage) -> Vec<AlbumZone> {
+        let mut zones = vec![AlbumZone::Actions];
+        if !page.song_widgets().is_empty() {
+            zones.push(AlbumZone::Songs);
+        }
+        if page
+            .focus_hortu_rows()
+            .iter()
+            .any(|row| row.is_visible() && row.item_count() > 0)
+        {
+            zones.push(AlbumZone::Rows);
+        }
+        zones
+    }
+
+    fn navigate_album_zone(&self, page: &AlbumPage, delta: i32) -> bool {
+        let zones = self.visible_album_zones(page);
+        let current = *self.album_zone.borrow();
+        let pos = zones.iter().position(|z| *z == current).unwrap_or(0) as i32;
+        let next = (pos + delta).clamp(0, zones.len() as i32 - 1) as usize;
+        self.clear_album_focus(page);
+        *self.album_zone.borrow_mut() = zones[next];
+        self.apply_album_focus(page);
+        true
+    }
+
+    fn navigate_album_horizontal(&self, window: &Window, page: &AlbumPage, delta: i32) -> bool {
+        match *self.album_zone.borrow() {
+            AlbumZone::Actions => {
+                page.navigate_actions(delta);
+                true
+            }
+            AlbumZone::Songs => {
+                page.navigate_songs(delta);
+                true
+            }
+            AlbumZone::Rows => self.album_focus.handle_rows_only(
+                window,
+                if delta < 0 {
+                    InputAction::NavigateLeft
+                } else {
+                    InputAction::NavigateRight
+                },
+            ),
+        }
+    }
+
+    fn activate_album(&self, window: &Window, page: &AlbumPage) -> bool {
+        match *self.album_zone.borrow() {
+            AlbumZone::Actions => {
+                page.activate_focused_action();
+                true
+            }
+            AlbumZone::Songs => {
+                page.activate_focused_song();
+                true
+            }
+            AlbumZone::Rows => self
+                .album_focus
+                .handle_rows_only(window, InputAction::Activate),
+        }
+    }
+
+    fn clear_album_focus(&self, page: &AlbumPage) {
+        page.clear_action_focus();
+        page.clear_song_focus();
+        self.album_focus.clear_all_row_selections();
+    }
+
+    fn apply_album_focus(&self, page: &AlbumPage) {
+        match *self.album_zone.borrow() {
+            AlbumZone::Actions => page.focus_default_action(),
+            AlbumZone::Songs => page.focus_default_song(),
+            AlbumZone::Rows => self.album_focus.register_rows(page.focus_hortu_rows()),
+        }
+    }
+
+    fn handle_list(&self, window: &Window, page: &ListPage, action: InputAction) -> bool {
+        if self.list_zone.get() == ListZone::Grid
+            && let Some(grid) = page.visible_grid()
+        {
+            grid.tuview_scrolled().ensure_selection();
+        }
+
+        match action {
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::Menu => {
+                window.set_sidebar_panel_visible(
+                    !window.tv_sidebar_collapsed()
+                        || !window.imp().split_view.get().shows_sidebar(),
+                );
+                true
+            }
+            InputAction::NavigateUp => {
+                if self.list_zone.get() == ListZone::Grid
+                    && let Some(grid) = page.visible_grid()
+                {
+                    if grid.tuview_scrolled().is_at_top_row() {
+                        return self.navigate_list_zone(page, -1);
+                    }
+                    return self.grid_navigator.handle(window, &grid, action);
+                }
+                self.navigate_list_zone(page, -1)
+            }
+            InputAction::NavigateDown => {
+                let zone = self.list_zone.get();
+                match zone {
+                    ListZone::Grid => {
+                        if let Some(grid) = page.visible_grid() {
+                            self.grid_navigator.handle(window, &grid, action)
+                        } else {
+                            false
+                        }
+                    }
+                    _ => self.navigate_list_zone(page, 1),
+                }
+            }
+            InputAction::NavigateLeft => self.navigate_list_horizontal(page, window, -1),
+            InputAction::NavigateRight => self.navigate_list_horizontal(page, window, 1),
+            InputAction::Activate => self.activate_list(window, page),
+            _ => false,
+        }
+    }
+
+    fn list_zones(&self, page: &ListPage) -> Vec<ListZone> {
+        let has_tabs = page.tab_count() > 1;
+        if has_tabs {
+            vec![ListZone::Tabs, ListZone::Toolbar, ListZone::Grid]
+        } else {
+            vec![ListZone::Toolbar, ListZone::Grid]
+        }
+    }
+
+    fn navigate_list_zone(&self, page: &ListPage, delta: i32) -> bool {
+        let zones = self.list_zones(page);
+        let current = self.list_zone.get();
+        let pos = zones.iter().position(|z| *z == current).unwrap_or(0) as i32;
+        let next = (pos + delta).clamp(0, zones.len() as i32 - 1) as usize;
+        self.list_zone.set(zones[next]);
+        if zones[next] == ListZone::Toolbar {
+            self.list_toolbar_index.set(0);
+        }
+        self.apply_list_focus(page);
+        true
+    }
+
+    fn navigate_list_horizontal(&self, page: &ListPage, window: &Window, delta: i32) -> bool {
+        match self.list_zone.get() {
+            ListZone::Tabs => {
+                page.switch_tab(delta);
+                true
+            }
+            ListZone::Toolbar => {
+                if let Some(grid) = page.visible_grid() {
+                    let count = grid.toolbar_widget_count();
+                    if count == 0 {
+                        return false;
+                    }
+                    let current = self.list_toolbar_index.get() as i32;
+                    let next = (current + delta).clamp(0, count as i32 - 1) as usize;
+                    self.list_toolbar_index.set(next);
+                    grid.focus_toolbar_index(next);
+                    true
+                } else {
+                    false
+                }
+            }
+            ListZone::Grid => {
+                if let Some(grid) = page.visible_grid() {
+                    self.grid_navigator.handle(
+                        window,
+                        &grid,
+                        if delta < 0 {
+                            InputAction::NavigateLeft
+                        } else {
+                            InputAction::NavigateRight
+                        },
+                    )
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn activate_list(&self, window: &Window, page: &ListPage) -> bool {
+        match self.list_zone.get() {
+            ListZone::Tabs => {
+                self.list_zone.set(ListZone::Toolbar);
+                self.list_toolbar_index.set(0);
+                self.apply_list_focus(page);
+                true
+            }
+            ListZone::Toolbar => page
+                .visible_grid()
+                .is_some_and(|grid| grid.activate_toolbar_index(self.list_toolbar_index.get())),
+            ListZone::Grid => page.visible_grid().is_some_and(|grid| {
+                self.grid_navigator
+                    .handle(window, &grid, InputAction::Activate)
+            }),
+        }
+    }
+
+    fn apply_list_focus(&self, page: &ListPage) {
+        match self.list_zone.get() {
+            ListZone::Tabs => {
+                page.focus_current_tab();
+                if let Some(grid) = page.visible_grid() {
+                    grid.tuview_scrolled().clear_selection();
+                    grid.clear_toolbar_focus();
+                }
+            }
+            ListZone::Toolbar => {
+                if let Some(grid) = page.visible_grid() {
+                    grid.tuview_scrolled().clear_selection();
+                    grid.focus_toolbar_index(self.list_toolbar_index.get());
+                }
+            }
+            ListZone::Grid => {
+                if let Some(grid) = page.visible_grid() {
+                    grid.clear_toolbar_focus();
+                    grid.tuview_scrolled().ensure_selection();
+                }
+            }
+        }
+    }
+
+    fn handle_other(&self, window: &Window, page: &OtherPage, action: InputAction) -> bool {
+        self.other_focus.register_rows(page.focus_hortu_rows());
+
+        match action {
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::Menu => {
+                window.set_sidebar_panel_visible(
+                    !window.tv_sidebar_collapsed()
+                        || !window.imp().split_view.get().shows_sidebar(),
+                );
+                true
+            }
+            InputAction::NavigateDown => self.navigate_other_zone(page, 1),
+            InputAction::NavigateUp => self.navigate_other_zone(page, -1),
+            InputAction::NavigateLeft => self.navigate_other_horizontal(page, window, -1),
+            InputAction::NavigateRight => self.navigate_other_horizontal(page, window, 1),
+            InputAction::Activate => self.activate_other(window, page),
+            _ => false,
+        }
+    }
+
+    fn visible_other_zones(&self, page: &OtherPage) -> Vec<OtherZone> {
+        let mut zones = vec![OtherZone::Actions];
+        if page.carousel_page_count() > 1 {
+            zones.push(OtherZone::Carousel);
+        }
+        if page
+            .focus_hortu_rows()
+            .iter()
+            .any(|row| row.is_visible() && row.item_count() > 0)
+        {
+            zones.push(OtherZone::Rows);
+        }
+        if page.has_episode_list() {
+            zones.push(OtherZone::Episodes);
+        }
+        zones
+    }
+
+    fn navigate_other_zone(&self, page: &OtherPage, delta: i32) -> bool {
+        let zones = self.visible_other_zones(page);
+        let current = *self.other_zone.borrow();
+        let pos = zones.iter().position(|z| *z == current).unwrap_or(0) as i32;
+        let next = (pos + delta).clamp(0, zones.len() as i32 - 1) as usize;
+        self.clear_other_focus(page);
+        *self.other_zone.borrow_mut() = zones[next];
+        self.apply_other_focus(page);
+        true
+    }
+
+    fn navigate_other_horizontal(&self, page: &OtherPage, window: &Window, delta: i32) -> bool {
+        match *self.other_zone.borrow() {
+            OtherZone::Actions => {
+                page.navigate_actions(delta);
+                true
+            }
+            OtherZone::Carousel => {
+                page.navigate_carousel(delta);
+                true
+            }
+            OtherZone::Rows => self.other_focus.handle_rows_only(
+                window,
+                if delta < 0 {
+                    InputAction::NavigateLeft
+                } else {
+                    InputAction::NavigateRight
+                },
+            ),
+            OtherZone::Episodes => {
+                page.navigate_episodes(delta);
+                true
+            }
+        }
+    }
+
+    fn activate_other(&self, window: &Window, page: &OtherPage) -> bool {
+        match *self.other_zone.borrow() {
+            OtherZone::Actions => {
+                page.activate_focused_action();
+                true
+            }
+            OtherZone::Carousel => {
+                if page.has_episode_list() {
+                    self.clear_other_focus(page);
+                    *self.other_zone.borrow_mut() = OtherZone::Episodes;
+                    self.apply_other_focus(page);
+                }
+                true
+            }
+            OtherZone::Rows => self
+                .other_focus
+                .handle_rows_only(window, InputAction::Activate),
+            OtherZone::Episodes => {
+                page.activate_focused_episode();
+                true
+            }
+        }
+    }
+
+    fn clear_other_focus(&self, page: &OtherPage) {
+        page.clear_action_focus();
+        self.other_focus.clear_all_row_selections();
+        page.clear_episode_focus();
+    }
+
+    fn apply_other_focus(&self, page: &OtherPage) {
+        match *self.other_zone.borrow() {
+            OtherZone::Actions => page.focus_default_action(),
+            OtherZone::Carousel => {}
+            OtherZone::Rows => self.other_focus.register_rows(page.focus_hortu_rows()),
+            OtherZone::Episodes => page.focus_default_episode(),
+        }
+    }
+
+    fn handle_server(&self, window: &Window, page: &ServerPanel, action: InputAction) -> bool {
+        let groups = page.focus_groups();
+        if groups.is_empty() {
+            return self.handle_back(window, action);
+        }
+
+        match action {
+            InputAction::Back => {
+                window.on_pop();
+                true
+            }
+            InputAction::NavigateDown => self.navigate_server(&groups, 1),
+            InputAction::NavigateUp => self.navigate_server(&groups, -1),
+            InputAction::Activate => page.activate_focused_row(
+                &groups,
+                *self.server_group_index.borrow(),
+                *self.server_row_index.borrow(),
+            ),
+            _ => false,
+        }
+    }
+
+    fn navigate_server(
+        &self, groups: &[crate::ui::widgets::server_panel::ServerFocusGroup], delta: i32,
+    ) -> bool {
+        let group_idx = *self.server_group_index.borrow();
+        let row_idx = *self.server_row_index.borrow();
+        let Some(group) = groups.get(group_idx) else {
+            return false;
+        };
+
+        if delta > 0 {
+            if row_idx + 1 < group.rows.len() {
+                *self.server_row_index.borrow_mut() = row_idx + 1;
+            } else if group_idx + 1 < groups.len() {
+                *self.server_group_index.borrow_mut() = group_idx + 1;
+                *self.server_row_index.borrow_mut() = 0;
+            }
+        } else if row_idx > 0 {
+            *self.server_row_index.borrow_mut() = row_idx - 1;
+        } else if group_idx > 0 {
+            let prev = group_idx - 1;
+            *self.server_group_index.borrow_mut() = prev;
+            *self.server_row_index.borrow_mut() = groups[prev].rows.len().saturating_sub(1);
+        }
+
+        self.apply_server_focus(groups);
+        true
+    }
+
+    fn apply_server_focus(&self, groups: &[crate::ui::widgets::server_panel::ServerFocusGroup]) {
+        for (gidx, group) in groups.iter().enumerate() {
+            for (ridx, row) in group.rows.iter().enumerate() {
+                let focused = gidx == *self.server_group_index.borrow()
+                    && ridx == *self.server_row_index.borrow();
+                set_tv_focused(row, focused);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct MediaViewerNavigator;
+
+impl MediaViewerNavigator {
+    pub fn handle(&self, _window: &Window, viewer: &MediaViewer, action: InputAction) -> bool {
+        match action {
+            InputAction::Back => {
+                viewer.dismiss();
+                true
+            }
+            InputAction::Activate => {
+                viewer.activate_action("media-viewer.close", None).ok();
+                true
+            }
+            InputAction::Menu => {
+                viewer.focus_menu();
+                true
+            }
+            InputAction::NavigateUp => {
+                viewer.reveal_header_for_tv(true);
+                true
+            }
+            InputAction::NavigateDown => {
+                viewer.reveal_header_for_tv(false);
+                true
+            }
+            _ => false,
+        }
+    }
+}

--- a/src/ui/input/router.rs
+++ b/src/ui/input/router.rs
@@ -1,0 +1,27 @@
+use gtk::{
+    gdk::Key,
+    glib::translate::FromGlib,
+};
+
+use super::actions::InputAction;
+
+pub fn key_to_action(keyval: u32) -> Option<InputAction> {
+    let key = unsafe { Key::from_glib(keyval) };
+    use InputAction::*;
+    match key {
+        Key::Left | Key::KP_Left => Some(NavigateLeft),
+        Key::Right | Key::KP_Right => Some(NavigateRight),
+        Key::Up | Key::KP_Up => Some(NavigateUp),
+        Key::Down | Key::KP_Down => Some(NavigateDown),
+        Key::Return | Key::KP_Enter | Key::space => Some(Activate),
+        Key::Escape | Key::BackSpace => Some(Back),
+        Key::Home => Some(Home),
+        Key::Menu | Key::F10 => Some(Menu),
+        Key::question | Key::f | Key::F => Some(Search),
+        Key::Page_Up | Key::KP_Page_Up => Some(PageScrollLeft),
+        Key::Page_Down | Key::KP_Page_Down => Some(PageScrollRight),
+        Key::AudioPlay | Key::AudioPause | Key::Pause => Some(PlayPause),
+        k if Key::from_name("Guide") == Some(k) => Some(ToggleHints),
+        _ => None,
+    }
+}

--- a/src/ui/input/search_navigator.rs
+++ b/src/ui/input/search_navigator.rs
@@ -1,0 +1,156 @@
+use gtk::{
+    glib::subclass::types::ObjectSubclassIsExt,
+    prelude::*,
+};
+
+use super::actions::InputAction;
+use crate::{
+    Window,
+    tv::set_tv_focused,
+    ui::widgets::search::SearchPage,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SearchZone {
+    Entry,
+    Filters,
+    Results,
+}
+
+pub struct SearchNavigator {
+    zone: std::cell::RefCell<SearchZone>,
+    filter_index: std::cell::RefCell<usize>,
+}
+
+impl Default for SearchNavigator {
+    fn default() -> Self {
+        Self {
+            zone: std::cell::RefCell::new(SearchZone::Results),
+            filter_index: std::cell::RefCell::new(0),
+        }
+    }
+}
+
+impl SearchNavigator {
+    pub fn handle(&self, window: &Window, page: &SearchPage, action: InputAction) -> bool {
+        match action {
+            InputAction::Search => {
+                *self.zone.borrow_mut() = SearchZone::Entry;
+                page.search_entry().grab_focus();
+                true
+            }
+            InputAction::Menu => {
+                window.set_sidebar_panel_visible(
+                    !window.tv_sidebar_collapsed()
+                        || !window.imp().split_view.get().shows_sidebar(),
+                );
+                true
+            }
+            InputAction::Back => {
+                window.homepage();
+                true
+            }
+            InputAction::NavigateDown => self.navigate(page, 1),
+            InputAction::NavigateUp => self.navigate(page, -1),
+            InputAction::NavigateLeft => self.navigate_horizontal(page, -1),
+            InputAction::NavigateRight => self.navigate_horizontal(page, 1),
+            InputAction::Activate => self.activate(window, page),
+            _ => false,
+        }
+    }
+
+    fn navigate(&self, page: &SearchPage, delta: i32) -> bool {
+        let zones = self.visible_zones(page);
+        if zones.is_empty() {
+            return false;
+        }
+        let current = *self.zone.borrow();
+        let pos = zones.iter().position(|z| *z == current).unwrap_or(0) as i32;
+        let next = (pos + delta).clamp(0, zones.len() as i32 - 1) as usize;
+        *self.zone.borrow_mut() = zones[next];
+        self.apply_zone_focus(page);
+        true
+    }
+
+    fn navigate_results(&self, page: &SearchPage, delta: i32) -> bool {
+        if *self.zone.borrow() != SearchZone::Results {
+            return false;
+        }
+        page.search_scrolled().move_selection(delta);
+        true
+    }
+
+    fn navigate_filters(&self, page: &SearchPage, delta: i32) -> bool {
+        let rows = page.filter_rows();
+        if rows.is_empty() {
+            return false;
+        }
+        let current = *self.filter_index.borrow() as i32;
+        let next = (current + delta).clamp(0, rows.len() as i32 - 1) as usize;
+        *self.filter_index.borrow_mut() = next;
+        for row in &rows {
+            set_tv_focused(row, false);
+        }
+        if let Some(row) = rows.get(next) {
+            set_tv_focused(row, true);
+        }
+        true
+    }
+
+    fn navigate_horizontal(&self, page: &SearchPage, delta: i32) -> bool {
+        match *self.zone.borrow() {
+            SearchZone::Filters => self.navigate_filters(page, delta),
+            SearchZone::Results => self.navigate_results(page, delta),
+            _ => false,
+        }
+    }
+
+    fn activate(&self, window: &Window, page: &SearchPage) -> bool {
+        match *self.zone.borrow() {
+            SearchZone::Entry => {
+                page.trigger_search();
+                true
+            }
+            SearchZone::Filters => {
+                let rows = page.filter_rows();
+                let idx = *self.filter_index.borrow();
+                if let Some(row) = rows.get(idx) {
+                    row.set_active(!row.is_active());
+                }
+                true
+            }
+            SearchZone::Results => {
+                page.search_scrolled().activate_selected(window);
+                true
+            }
+        }
+    }
+
+    fn visible_zones(&self, page: &SearchPage) -> Vec<SearchZone> {
+        let mut zones = vec![SearchZone::Entry, SearchZone::Filters];
+        if page.search_scrolled().n_items() > 0 {
+            zones.push(SearchZone::Results);
+        }
+        zones
+    }
+
+    fn apply_zone_focus(&self, page: &SearchPage) {
+        let entry = page.search_entry();
+        set_tv_focused(&entry, false);
+        for row in page.filter_rows() {
+            set_tv_focused(&row, false);
+        }
+        page.search_scrolled().clear_tv_focus();
+
+        match *self.zone.borrow() {
+            SearchZone::Entry => set_tv_focused(&entry, true),
+            SearchZone::Filters => {
+                let idx = *self.filter_index.borrow();
+                if let Some(row) = page.filter_rows().get(idx) {
+                    set_tv_focused(row, true);
+                }
+            }
+            SearchZone::Results => page.search_scrolled().ensure_selection(),
+        }
+    }
+}

--- a/src/ui/input/settings_navigator.rs
+++ b/src/ui/input/settings_navigator.rs
@@ -1,0 +1,441 @@
+#![allow(deprecated)]
+
+use adw::prelude::*;
+
+use super::{
+    actions::InputAction,
+    popover_navigator,
+};
+use crate::{
+    tv::{
+        osk,
+        set_tv_focused,
+    },
+    ui::widgets::{
+        account_add::AccountWindow,
+        account_settings::AccountSettings,
+    },
+};
+
+pub struct SettingsNavigator {
+    row_index: std::cell::Cell<u32>,
+    tab_index: std::cell::Cell<u32>,
+    row_child_index: std::cell::Cell<Option<u32>>,
+}
+
+impl Default for SettingsNavigator {
+    fn default() -> Self {
+        Self {
+            row_index: std::cell::Cell::new(0),
+            tab_index: std::cell::Cell::new(0),
+            row_child_index: std::cell::Cell::new(None),
+        }
+    }
+}
+
+impl SettingsNavigator {
+    pub fn reset_for_preferences(&self, settings: &AccountSettings) {
+        self.row_index.set(0);
+        self.row_child_index.set(None);
+        let pages = settings.preference_pages();
+        let tab_index = pages
+            .iter()
+            .position(|page| {
+                settings
+                    .visible_page()
+                    .is_some_and(|visible| visible.as_ptr() == page.as_ptr())
+            })
+            .unwrap_or(0) as u32;
+        self.tab_index.set(tab_index);
+        let rows = rows_for_page(settings.upcast_ref(), &pages, tab_index);
+        if !rows.is_empty() {
+            self.apply_focus(&rows, 0);
+        }
+    }
+
+    pub fn handle_window(&self, settings: &AccountSettings, action: InputAction) -> bool {
+        if popover_navigator::handle_widget_tree(settings.upcast_ref(), action) {
+            return true;
+        }
+
+        let pages = settings.preference_pages();
+        if pages.is_empty() {
+            return self.handle_window_inner(settings.upcast_ref(), action);
+        }
+        self.handle_preferences(settings.upcast_ref(), &pages, action)
+    }
+
+    fn handle_window_inner(&self, window: &adw::Window, action: InputAction) -> bool {
+        let rows = collect_focusable_rows_from_root(&window.clone().upcast::<gtk::Widget>());
+        self.handle_rows_only(&rows, action, false, || window.close())
+    }
+
+    fn handle_preferences(
+        &self, prefs: &adw::PreferencesWindow, pages: &[adw::PreferencesPage], action: InputAction,
+    ) -> bool {
+        let prefs_widget = prefs.clone().upcast::<gtk::Widget>();
+        let tab_count = pages.len() as u32;
+        let mut tab_index = self.tab_index.get().min(tab_count.saturating_sub(1));
+
+        if let Some(page) = pages.get(tab_index as usize) {
+            prefs.set_visible_page(page);
+        }
+
+        let rows = rows_for_page(prefs, pages, tab_index);
+
+        if self.handle_row_child_navigation(&rows, action) {
+            return true;
+        }
+
+        match action {
+            InputAction::NavigateLeft => {
+                tab_index = tab_index.saturating_sub(1);
+                self.switch_tab(prefs, pages, tab_index);
+                true
+            }
+            InputAction::NavigateRight => {
+                tab_index = (tab_index + 1).min(tab_count - 1);
+                self.switch_tab(prefs, pages, tab_index);
+                true
+            }
+            InputAction::NavigateDown => {
+                if rows.is_empty() {
+                    return true;
+                }
+                let count = rows.len() as u32;
+                let index = (self.row_index.get() + 1).min(count - 1);
+                self.row_index.set(index);
+                self.apply_focus(&rows, index);
+                true
+            }
+            InputAction::NavigateUp => {
+                if rows.is_empty() {
+                    return true;
+                }
+                let index = self.row_index.get().saturating_sub(1);
+                self.row_index.set(index);
+                self.apply_focus(&rows, index);
+                true
+            }
+            InputAction::Activate => {
+                if let Some(row) = rows.get(self.row_index.get() as usize) {
+                    self.activate_row_widget(row);
+                }
+                true
+            }
+            InputAction::Back => {
+                if self.row_child_index.get().is_some() {
+                    self.row_child_index.set(None);
+                    self.apply_focus(&rows, self.row_index.get());
+                    true
+                } else if popover_navigator::popdown_visible_popover(&prefs_widget) {
+                    true
+                } else {
+                    prefs.close();
+                    true
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn switch_tab(
+        &self, prefs: &adw::PreferencesWindow, pages: &[adw::PreferencesPage], tab_index: u32,
+    ) {
+        popover_navigator::popdown_visible_popover(&prefs.clone().upcast::<gtk::Widget>());
+        self.tab_index.set(tab_index);
+        self.row_index.set(0);
+        self.row_child_index.set(None);
+        if let Some(page) = pages.get(tab_index as usize) {
+            prefs.set_visible_page(page);
+        }
+        let rows = rows_for_page(prefs, pages, tab_index);
+        if rows.is_empty() {
+            return;
+        }
+        self.apply_focus(&rows, 0);
+    }
+
+    fn handle_rows_only(
+        &self, rows: &[gtk::Widget], action: InputAction, allow_tab_switch: bool,
+        on_back: impl FnOnce(),
+    ) -> bool {
+        if rows.is_empty() {
+            return false;
+        }
+        let count = rows.len() as u32;
+        let mut index = self.row_index.get().min(count - 1);
+
+        if self.handle_row_child_navigation(rows, action) {
+            return true;
+        }
+
+        match action {
+            InputAction::NavigateDown => {
+                index = (index + 1).min(count - 1);
+                self.row_index.set(index);
+                self.apply_focus(rows, index);
+                true
+            }
+            InputAction::NavigateUp => {
+                index = index.saturating_sub(1);
+                self.row_index.set(index);
+                self.apply_focus(rows, index);
+                true
+            }
+            InputAction::NavigateLeft | InputAction::NavigateRight if allow_tab_switch => false,
+            InputAction::Activate => {
+                if let Some(row) = rows.get(index as usize) {
+                    self.activate_row_widget(row);
+                }
+                true
+            }
+            InputAction::Back => {
+                if self.row_child_index.get().is_some() {
+                    self.row_child_index.set(None);
+                    self.apply_focus(rows, index);
+                    true
+                } else {
+                    on_back();
+                    true
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_row_child_navigation(&self, rows: &[gtk::Widget], action: InputAction) -> bool {
+        let Some(child_index) = self.row_child_index.get() else {
+            return false;
+        };
+        let row_index = self.row_index.get();
+        let Some(row) = rows.get(row_index as usize) else {
+            return false;
+        };
+        let buttons = row_suffix_buttons(row);
+        if buttons.is_empty() {
+            self.row_child_index.set(None);
+            return false;
+        }
+
+        match action {
+            InputAction::NavigateLeft => {
+                let next = child_index.saturating_sub(1);
+                self.row_child_index.set(Some(next));
+                self.apply_child_focus(row, next, &buttons);
+                true
+            }
+            InputAction::NavigateRight => {
+                let next = (child_index + 1).min(buttons.len() as u32 - 1);
+                self.row_child_index.set(Some(next));
+                self.apply_child_focus(row, next, &buttons);
+                true
+            }
+            InputAction::Activate => {
+                if let Some(button) = buttons.get(child_index as usize) {
+                    button.emit_clicked();
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn handle_account_window(&self, account: &AccountWindow, action: InputAction) -> bool {
+        if popover_navigator::handle_widget_tree(account.upcast_ref(), action) {
+            return true;
+        }
+        let widgets = account.focus_widgets();
+        let count = widgets.len() as u32;
+        if matches!(action, InputAction::Activate) {
+            let index = self.row_index.get().min(count.saturating_sub(1));
+            if index == count.saturating_sub(1) {
+                let account = account.clone();
+                crate::utils::spawn(async move {
+                    account.add().await;
+                });
+                return true;
+            }
+        }
+        self.handle_widgets(&widgets, action, || {
+            adw::prelude::AdwDialogExt::close(account);
+        })
+    }
+
+    pub fn handle_widgets(
+        &self, widgets: &[gtk::Widget], action: InputAction, on_back: impl FnOnce(),
+    ) -> bool {
+        self.handle_rows_only(widgets, action, false, on_back)
+    }
+
+    fn activate_row_widget(&self, row: &gtk::Widget) {
+        if self.row_child_index.get().is_some() {
+            let buttons = row_suffix_buttons(row);
+            if let Some(child_index) = self.row_child_index.get()
+                && let Some(button) = buttons.get(child_index as usize)
+            {
+                button.emit_clicked();
+            }
+            return;
+        }
+
+        let buttons = row_suffix_buttons(row);
+        if buttons.len() == 1 {
+            buttons[0].emit_clicked();
+            return;
+        }
+        if buttons.len() > 1 {
+            self.row_child_index.set(Some(0));
+            self.apply_child_focus(row, 0, &buttons);
+            return;
+        }
+
+        if let Ok(switch) = row.clone().downcast::<adw::SwitchRow>() {
+            switch.set_active(!switch.is_active());
+        } else if let Ok(switch) = row.clone().downcast::<gtk::Switch>() {
+            switch.set_active(!switch.is_active());
+        } else if let Ok(spin) = row.clone().downcast::<adw::SpinRow>() {
+            let adjustment = spin.adjustment();
+            adjustment.set_value(adjustment.value() + adjustment.step_increment());
+        } else if let Ok(row) = row.clone().downcast::<adw::ComboRow>() {
+            adw::prelude::ActionRowExt::activate(&row);
+        } else if let Ok(row) = row.clone().downcast::<adw::PasswordEntryRow>() {
+            row.grab_focus();
+            osk::show_for_widget(&row);
+        } else if let Ok(row) = row.clone().downcast::<adw::EntryRow>() {
+            row.grab_focus();
+            osk::show_for_widget(&row);
+        } else if let Ok(row) = row.clone().downcast::<adw::ActionRow>() {
+            adw::prelude::ActionRowExt::activate(&row);
+        } else if let Ok(button) = row.clone().downcast::<gtk::Button>() {
+            button.emit_clicked();
+        } else {
+            row.activate();
+        }
+    }
+
+    fn apply_focus(&self, rows: &[gtk::Widget], index: u32) {
+        self.row_child_index.set(None);
+        for row in rows {
+            set_tv_focused(row, false);
+            clear_child_focus(row);
+        }
+        if let Some(row) = rows.get(index as usize) {
+            set_tv_focused(row, true);
+            if should_grab_row_focus(row) {
+                row.grab_focus();
+            }
+        }
+    }
+
+    fn apply_child_focus(&self, row: &gtk::Widget, child_index: u32, buttons: &[gtk::Button]) {
+        set_tv_focused(row, true);
+        clear_child_focus(row);
+        if let Some(button) = buttons.get(child_index as usize) {
+            set_tv_focused(button, true);
+        }
+    }
+}
+
+fn should_grab_row_focus(row: &gtk::Widget) -> bool {
+    !row.is::<adw::EntryRow>() && !row.is::<adw::PasswordEntryRow>() && !row.is::<adw::SpinRow>()
+}
+
+fn row_suffix_buttons(row: &gtk::Widget) -> Vec<gtk::Button> {
+    let mut buttons = Vec::new();
+    collect_buttons(row, &mut buttons);
+    buttons
+}
+
+fn collect_buttons(widget: &gtk::Widget, buttons: &mut Vec<gtk::Button>) {
+    if let Ok(button) = widget.clone().downcast::<gtk::Button>()
+        && button.is_visible()
+        && button.is_sensitive()
+    {
+        buttons.push(button);
+    }
+    let mut child = widget.first_child();
+    while let Some(next) = child {
+        collect_buttons(&next, buttons);
+        child = next.next_sibling();
+    }
+}
+
+fn clear_child_focus(row: &gtk::Widget) {
+    for button in row_suffix_buttons(row) {
+        set_tv_focused(&button, false);
+    }
+}
+
+pub fn find_view_stack_pages(prefs: &adw::PreferencesWindow) -> Vec<adw::PreferencesPage> {
+    let Some(stack) = find_view_stack(&prefs.clone().upcast::<gtk::Widget>()) else {
+        return Vec::new();
+    };
+    let mut pages = Vec::new();
+    let mut child = stack.first_child();
+    while let Some(page_widget) = child {
+        if let Ok(page) = page_widget.clone().downcast::<adw::PreferencesPage>() {
+            pages.push(page);
+        }
+        child = page_widget.next_sibling();
+    }
+    pages
+}
+
+fn find_view_stack(widget: &gtk::Widget) -> Option<adw::ViewStack> {
+    if let Ok(stack) = widget.clone().downcast::<adw::ViewStack>() {
+        return Some(stack);
+    }
+    let mut child = widget.first_child();
+    while let Some(next) = child {
+        if let Some(stack) = find_view_stack(&next) {
+            return Some(stack);
+        }
+        child = next.next_sibling();
+    }
+    None
+}
+
+fn rows_for_page(
+    prefs: &adw::PreferencesWindow, pages: &[adw::PreferencesPage], tab_index: u32,
+) -> Vec<gtk::Widget> {
+    let page = prefs
+        .visible_page()
+        .or_else(|| pages.get(tab_index as usize).cloned());
+    let Some(page) = page else {
+        return Vec::new();
+    };
+    collect_focusable_rows_from_root(&page.upcast::<gtk::Widget>())
+}
+
+fn collect_focusable_rows_from_root(root: &gtk::Widget) -> Vec<gtk::Widget> {
+    let mut rows = Vec::new();
+    collect_focusable_rows_in_order(root, &mut rows);
+    rows
+}
+
+fn collect_focusable_rows_in_order(widget: &gtk::Widget, rows: &mut Vec<gtk::Widget>) {
+    if is_focusable_preferences_row(widget) {
+        if widget.is_visible() && widget.is_sensitive() {
+            rows.push(widget.clone());
+        }
+        return;
+    }
+    let mut child = widget.first_child();
+    while let Some(next) = child {
+        collect_focusable_rows_in_order(&next, rows);
+        child = next.next_sibling();
+    }
+}
+
+fn is_focusable_preferences_row(widget: &gtk::Widget) -> bool {
+    widget.downcast_ref::<adw::PreferencesRow>().is_some()
+        || widget.downcast_ref::<adw::ActionRow>().is_some()
+        || widget.downcast_ref::<adw::ButtonRow>().is_some()
+        || widget.downcast_ref::<adw::ComboRow>().is_some()
+        || widget.downcast_ref::<adw::EntryRow>().is_some()
+        || widget.downcast_ref::<adw::PasswordEntryRow>().is_some()
+        || widget.downcast_ref::<adw::SpinRow>().is_some()
+        || widget.downcast_ref::<adw::SwitchRow>().is_some()
+        || widget.downcast_ref::<gtk::Button>().is_some()
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod input;
 mod models;
 mod mpv;
 pub mod provider;

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -76,6 +76,16 @@ impl Settings {
     const KEY_WINDOW_HEIGHT: &'static str = "window-height"; // i32
     const KEY_IS_MAXIMIZED: &'static str = "is-maximized"; // bool
     const KEY_IS_FULLSCREEN: &'static str = "is-fullscreen"; // bool
+    const KEY_GAMEPAD_ENABLED: &'static str = "gamepad-enabled";
+    const KEY_TV_MODE: &'static str = "tv-mode";
+    const KEY_TV_UI_SCALE: &'static str = "tv-ui-scale";
+    const KEY_TV_START_FULLSCREEN: &'static str = "tv-start-fullscreen";
+    const KEY_TV_HIDE_SIDEBAR: &'static str = "tv-hide-sidebar";
+    const KEY_TV_SHOW_BUTTON_HINTS: &'static str = "tv-show-button-hints";
+    const KEY_PLAYBACK_CONDITIONAL_RULES: &'static str = "playback-conditional-rules";
+    const KEY_OPENSUBTITLES_API_KEY: &'static str = "opensubtitles-api-key";
+    const KEY_SUBDL_API_KEY: &'static str = "subdl-api-key";
+    const KEY_SUBTITLE_PROVIDERS_ENABLED: &'static str = "subtitle-providers-enabled";
 
     pub fn is_overlay(&self) -> bool {
         self.boolean(Self::KEY_IS_OVERLAY)
@@ -361,6 +371,22 @@ impl Settings {
         self.int(Self::KEY_MPV_SUBTITLE_PREFERRED_LANG)
     }
 
+    pub fn mpv_audio_preferred_lang_str(&self) -> String {
+        match self.mpv_audio_preferred_lang() {
+            1 => "eng",
+            2 => "chs",
+            3 => "jpn",
+            4 => "chi",
+            5 => "ara",
+            6 => "nob",
+            7 => "por",
+            8 => "fre",
+            9 => "rus",
+            _ => "",
+        }
+        .to_string()
+    }
+
     pub fn mpv_subtitle_preferred_lang_str(&self) -> String {
         match self.mpv_subtitle_preferred_lang() {
             1 => "eng",
@@ -509,6 +535,90 @@ impl Settings {
 
     pub fn background_enabled(&self) -> bool {
         self.boolean(Self::KEY_IS_BACKGROUND_ENABLED)
+    }
+
+    pub fn gamepad_enabled(&self) -> bool {
+        self.boolean(Self::KEY_GAMEPAD_ENABLED)
+    }
+
+    pub fn set_gamepad_enabled(&self, enabled: bool) -> Result<(), glib::BoolError> {
+        self.set_boolean(Self::KEY_GAMEPAD_ENABLED, enabled)
+    }
+
+    pub fn tv_mode(&self) -> bool {
+        self.boolean(Self::KEY_TV_MODE)
+    }
+
+    pub fn set_tv_mode(&self, enabled: bool) -> Result<(), glib::BoolError> {
+        self.set_boolean(Self::KEY_TV_MODE, enabled)
+    }
+
+    pub fn tv_ui_scale(&self) -> f64 {
+        let scale = self.double(Self::KEY_TV_UI_SCALE);
+        if scale < 1.0 { 1.0 } else { scale }
+    }
+
+    pub fn set_tv_ui_scale(&self, scale: f64) -> Result<(), glib::BoolError> {
+        self.set_double(Self::KEY_TV_UI_SCALE, scale)
+    }
+
+    pub fn tv_start_fullscreen(&self) -> bool {
+        self.boolean(Self::KEY_TV_START_FULLSCREEN)
+    }
+
+    pub fn set_tv_start_fullscreen(&self, enabled: bool) -> Result<(), glib::BoolError> {
+        self.set_boolean(Self::KEY_TV_START_FULLSCREEN, enabled)
+    }
+
+    pub fn tv_hide_sidebar(&self) -> bool {
+        self.boolean(Self::KEY_TV_HIDE_SIDEBAR)
+    }
+
+    pub fn set_tv_hide_sidebar(&self, enabled: bool) -> Result<(), glib::BoolError> {
+        self.set_boolean(Self::KEY_TV_HIDE_SIDEBAR, enabled)
+    }
+
+    pub fn tv_show_button_hints(&self) -> bool {
+        self.boolean(Self::KEY_TV_SHOW_BUTTON_HINTS)
+    }
+
+    pub fn playback_conditional_rules(&self) -> crate::playback::rules::PlaybackRulesConfig {
+        let raw = self.string(Self::KEY_PLAYBACK_CONDITIONAL_RULES);
+        serde_json::from_str(&raw).unwrap_or_default()
+    }
+
+    pub fn set_playback_conditional_rules(
+        &self, config: &crate::playback::rules::PlaybackRulesConfig,
+    ) -> Result<(), glib::BoolError> {
+        let raw = serde_json::to_string(config)
+            .map_err(|_| glib::bool_error!("Failed to serialize playback rules"))?;
+        self.set_string(Self::KEY_PLAYBACK_CONDITIONAL_RULES, &raw)
+    }
+
+    pub fn opensubtitles_api_key(&self) -> String {
+        self.string(Self::KEY_OPENSUBTITLES_API_KEY).to_string()
+    }
+
+    pub fn set_opensubtitles_api_key(&self, key: &str) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_OPENSUBTITLES_API_KEY, key)
+    }
+
+    pub fn subdl_api_key(&self) -> String {
+        self.string(Self::KEY_SUBDL_API_KEY).to_string()
+    }
+
+    pub fn set_subdl_api_key(&self, key: &str) -> Result<(), glib::BoolError> {
+        self.set_string(Self::KEY_SUBDL_API_KEY, key)
+    }
+
+    pub fn subtitle_provider_enabled(&self, id: &str) -> bool {
+        self.string(Self::KEY_SUBTITLE_PROVIDERS_ENABLED)
+            .split(',')
+            .any(|entry| entry.trim() == id)
+    }
+
+    pub fn set_tv_show_button_hints(&self, enabled: bool) -> Result<(), glib::BoolError> {
+        self.set_boolean(Self::KEY_TV_SHOW_BUTTON_HINTS, enabled)
     }
 }
 

--- a/src/ui/mpv/mod.rs
+++ b/src/ui/mpv/mod.rs
@@ -5,6 +5,7 @@ pub mod mpris;
 pub mod mpvglarea;
 pub mod options_matcher;
 pub mod page;
+pub mod trickplay;
 pub mod tsukimi_mpv;
 pub mod video_scale;
 pub mod volume_bar;

--- a/src/ui/mpv/mpvglarea.rs
+++ b/src/ui/mpv/mpvglarea.rs
@@ -300,6 +300,10 @@ impl MPVGLArea {
         self.imp().mpv().set_slang(value)
     }
 
+    pub fn set_alang(&self, value: String) {
+        self.set_property("alang", value);
+    }
+
     pub fn set_property<V>(&self, property: &str, value: V)
     where
         V: SetData + Send + 'static,

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -43,6 +43,13 @@ use crate::{
         },
     },
     close_on_error,
+    playback::resolver::{
+        detect_default_audio_language,
+        pick_subtitle_stream,
+        resolve_alang,
+        resolve_playback_tracks,
+        resolve_slang,
+    },
     ui::{
         GlobalToast,
         models::SETTINGS,
@@ -199,6 +206,8 @@ mod imp {
         #[template_child]
         pub network_speed_label: TemplateChild<gtk::Label>,
         #[template_child]
+        pub finishes_at_label: TemplateChild<gtk::Label>,
+        #[template_child]
         pub network_speed_label_2: TemplateChild<gtk::Button>,
         #[template_child]
         pub playback_speed_indicator: TemplateChild<gtk::Button>,
@@ -225,6 +234,8 @@ mod imp {
         pub y: RefCell<f64>,
         pub last_motion_time: RefCell<i64>,
         pub suburl: RefCell<Option<String>>,
+        pub external_sub_override: RefCell<Option<String>>,
+        pub imdb_id: RefCell<Option<String>>,
         pub skippable_segments: RefCell<Option<Vec<MediaSegment>>>,
         pub current_segment_end: Cell<Option<f64>>,
         pub popover: RefCell<Option<PopoverMenu>>,
@@ -257,8 +268,13 @@ mod imp {
         pub fallback_context: RefCell<Option<super::FallbackContext>>,
         pub playback_direct_mode: RefCell<super::PlaybackDirectMode>,
         pub queued_playback_direct_mode: RefCell<Option<super::PlaybackDirectMode>>,
+        pub trickplay_manifest: RefCell<Option<crate::ui::mpv::trickplay::TrickplayManifest>>,
+        pub trickplay_cache: RefCell<crate::ui::mpv::trickplay::TrickplayCache>,
+        pub trickplay_preview: RefCell<Option<gtk::Popover>>,
+        pub trickplay_picture: RefCell<Option<gtk::Picture>>,
         pub retrying_playback: Cell<bool>,
         pub allow_fallback: Cell<bool>,
+        pub was_fullscreen_before_play: Cell<bool>,
         pub last_nonzero_volume: Cell<i64>,
 
         #[property(get, set, default_value = true)]
@@ -349,6 +365,23 @@ mod imp {
                 .build();
 
             self.video_scale.set_player(Some(&self.video.get()));
+            self.video_scale
+                .connect_scrub_position_changed(glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    move |position| {
+                        imp.obj().update_trickplay_preview(position);
+                    }
+                ));
+            self.video_scale.connect_scrub_finished(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move || {
+                    if let Some(popover) = imp.trickplay_preview.borrow().as_ref() {
+                        popover.popdown();
+                    }
+                }
+            ));
 
             let obj = self.obj();
 
@@ -499,6 +532,10 @@ impl MPVPage {
         true
     }
 
+    pub fn set_external_sub_override(&self, path: Option<String>) {
+        self.imp().external_sub_override.replace(path);
+    }
+
     pub fn play(
         &self, selected: Option<SelectedVideoSubInfo>, item: TuItem, episode_list: Vec<TuItem>,
         video_matcher: Option<String>, start_seconds: f64,
@@ -528,6 +565,7 @@ impl MPVPage {
         self.mpv().set_property("force-media-title", media_title);
 
         let id = item.id();
+        let id_for_info = id.clone();
         let series_id = item.series_id();
         self.imp().video_scale.reset_scale();
         self.imp().last_playback_position.set(start_seconds);
@@ -543,8 +581,24 @@ impl MPVPage {
         #[cfg(target_os = "linux")]
         let track_list_changed = self.mpris_track_list_changed(&episode_list);
 
-        self.set_current_video(Some(item));
+        self.set_current_video(Some(item.clone()));
         self.imp().current_episode_list.replace(episode_list);
+        self.imp().imdb_id.replace(None);
+        spawn(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            async move {
+                if let Ok(info) = crate::utils::spawn_tokio(async move {
+                    JELLYFIN_CLIENT.get_item_info(&id_for_info).await
+                })
+                .await
+                {
+                    obj.imp()
+                        .imdb_id
+                        .replace(info.provider_ids.and_then(|ids| ids.imdb));
+                }
+            }
+        ));
 
         #[cfg(target_os = "linux")]
         {
@@ -568,6 +622,12 @@ impl MPVPage {
         self.imp().retrying_playback.set(false);
         self.imp().allow_fallback.set(true);
 
+        if let Some(window) = self.root().and_downcast::<Window>() {
+            self.imp()
+                .was_fullscreen_before_play
+                .set(window.is_fullscreen());
+        }
+
         self.load_skippable_segments(id.to_owned());
 
         spawn_g_timeout(glib::clone!(
@@ -580,7 +640,12 @@ impl MPVPage {
                 imp.network_speed_label
                     .set_text(&gettext("Initializing..."));
 
-                let sub_stream_index = selected.as_ref().map(|s| s.sub_index);
+                let rules_active = crate::playback::rules::PlaybackRules::load().enabled;
+                let sub_stream_index = if rules_active {
+                    None
+                } else {
+                    selected.as_ref().map(|s| s.sub_index)
+                };
                 let media_source_id = selected.as_ref().map(|s| s.media_source_id.clone());
                 let id_clone = id.to_owned();
                 let playback_info = match spawn_tokio(async move {
@@ -643,32 +708,58 @@ impl MPVPage {
 
                 imp.back.replace(Some(back));
 
-                let media_stream =
-                    if let Some(sub_stream_index) = selected.as_ref().map(|s| s.sub_index) {
-                        media_source.media_streams.get(sub_stream_index as usize)
-                    } else {
-                        let sub_version_list: Vec<_> = media_source
-                            .media_streams
-                            .iter()
-                            .filter(|stream| stream.stream_type == "Subtitle")
-                            .map(|stream| {
-                                (
-                                    stream.index,
-                                    stream.display_title.to_owned().unwrap_or_default(),
-                                )
-                            })
-                            .collect();
-
-                        make_subtitle_version_choice(sub_version_list)
-                            .and_then(|index| media_source.media_streams.get(index.0 as usize))
-                    };
-
-                if let Some(slang) = selected.map(|s| s.sub_lang) {
-                    imp.video.set_slang(slang);
+                if let Some(manifest) = super::trickplay::manifest_from_media_source(media_source) {
+                    imp.trickplay_manifest.replace(Some(manifest));
                 } else {
-                    imp.video
-                        .set_slang(SETTINGS.mpv_subtitle_preferred_lang_str());
+                    imp.trickplay_manifest.take();
                 }
+                imp.trickplay_cache.borrow_mut().clear();
+
+                let audio_lang = detect_default_audio_language(&media_source.media_streams);
+                let resolved = resolve_playback_tracks(audio_lang.as_deref());
+
+                let media_stream = if resolved.subtitles_off {
+                    None
+                } else if !rules_active
+                    && let Some(sub_stream_index) = selected.as_ref().map(|s| s.sub_index)
+                {
+                    media_source.media_streams.get(sub_stream_index as usize)
+                } else if let Some(stream) =
+                    pick_subtitle_stream(&media_source.media_streams, &resolved)
+                {
+                    Some(stream)
+                } else if !rules_active {
+                    let sub_version_list: Vec<_> = media_source
+                        .media_streams
+                        .iter()
+                        .filter(|stream| stream.stream_type == "Subtitle")
+                        .map(|stream| {
+                            (
+                                stream.index,
+                                stream.display_title.to_owned().unwrap_or_default(),
+                            )
+                        })
+                        .collect();
+
+                    make_subtitle_version_choice(sub_version_list)
+                        .and_then(|index| media_source.media_streams.get(index.0 as usize))
+                } else {
+                    None
+                };
+
+                if resolved.subtitles_off {
+                    imp.video.set_slang(String::new());
+                    imp.video
+                        .set_sid(crate::ui::mpv::tsukimi_mpv::TrackSelection::None);
+                } else if !rules_active
+                    && let Some(selected) = selected.as_ref()
+                    && !selected.sub_lang.is_empty()
+                {
+                    imp.video.set_slang(selected.sub_lang.clone());
+                } else {
+                    imp.video.set_slang(resolve_slang(&resolved));
+                }
+                imp.video.set_alang(resolve_alang(&resolved));
 
                 let sub_url = match media_stream {
                     Some(stream) if stream.is_external => match &stream.delivery_url {
@@ -1043,6 +1134,7 @@ impl MPVPage {
         imp.progress_time_label.set_width_chars(width_chars);
         imp.duration_label.set_width_chars(width_chars);
         imp.duration_label.set_text(&duration);
+        self.update_finishes_at();
     }
 
     fn speed_cb(&self, value: f64) {
@@ -1074,6 +1166,26 @@ impl MPVPage {
             self.imp().video_scale.set_value(value as f64);
         }
         self.update_skip_segment_button(value as f64);
+        self.update_finishes_at();
+    }
+
+    fn update_finishes_at(&self) {
+        let imp = self.imp();
+        let scale = imp.video_scale.get();
+        let duration = scale.adjustment().upper();
+        if duration <= 0.0 {
+            imp.finishes_at_label.set_visible(false);
+            return;
+        }
+        let position = scale.value();
+        let remaining = (duration - position).max(0.0) as i64;
+        let finish = chrono::Local::now() + chrono::Duration::seconds(remaining);
+        imp.finishes_at_label.set_text(&format!(
+            "{} {}",
+            gettext("Finishes at"),
+            finish.format("%-I:%M %p")
+        ));
+        imp.finishes_at_label.set_visible(true);
     }
 
     #[template_callback]
@@ -1356,9 +1468,111 @@ impl MPVPage {
     }
 
     #[template_callback]
-    fn on_play_pause_clicked(&self) {
+    pub fn on_play_pause_clicked(&self) {
         let video = &self.imp().video;
         video.pause();
+    }
+
+    pub fn seek_relative(&self, seconds: f64) {
+        let video = &self.imp().video;
+        if seconds < 0.0 {
+            video.seek_backward((-seconds).round() as i64);
+        } else {
+            video.seek_forward(seconds.round() as i64);
+        }
+    }
+
+    pub fn adjust_volume(&self, delta: i32) {
+        let imp = self.imp();
+        let vol = (imp.volume_adj.value() as i64 + i64::from(delta)).clamp(0, 100);
+        imp.video.set_volume(vol);
+    }
+
+    pub fn open_subtitle_search(&self) {
+        use crate::subtitles::{
+            SubtitleSearchDialog,
+            preferred_subtitle_language_code,
+        };
+
+        let title = self
+            .current_video()
+            .map(|item| item.name())
+            .unwrap_or_default();
+        let imdb_id = self.imp().imdb_id.borrow().clone();
+        let dialog = SubtitleSearchDialog::new(
+            &title,
+            &preferred_subtitle_language_code(),
+            imdb_id.as_deref(),
+        );
+        dialog.connect_subtitle_downloaded(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |path| {
+                let path = path.display().to_string();
+                obj.imp().video.add_sub(&path);
+                obj.toast(gettext("Subtitle loaded"));
+            }
+        ));
+        dialog.present(self.root().as_ref());
+    }
+
+    fn update_trickplay_preview(&self, seconds: f64) {
+        let imp = self.imp();
+        let Some(manifest) = imp.trickplay_manifest.borrow().clone() else {
+            return;
+        };
+
+        if let Some(bytes) = imp.trickplay_cache.borrow().cached_tile(&manifest, seconds) {
+            self.show_trickplay_preview(bytes, &manifest);
+            return;
+        }
+
+        let url_path = imp.trickplay_cache.borrow().preview_url(&manifest, seconds);
+        spawn(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            async move {
+                let bytes = match super::trickplay::fetch_trickplay_tile(&url_path).await {
+                    Ok(bytes) => bytes,
+                    Err(_) => return,
+                };
+                obj.imp().trickplay_cache.borrow_mut().store_tile(
+                    &manifest,
+                    seconds,
+                    bytes.clone(),
+                );
+                obj.show_trickplay_preview(&bytes, &manifest);
+            }
+        ));
+    }
+
+    fn show_trickplay_preview(&self, bytes: &[u8], manifest: &super::trickplay::TrickplayManifest) {
+        let imp = self.imp();
+        let loader = gtk::gdk_pixbuf::PixbufLoader::new();
+        if loader.write(bytes).is_err() || loader.close().is_err() {
+            return;
+        }
+        let Some(pixbuf) = loader.pixbuf() else {
+            return;
+        };
+
+        let popover = imp.trickplay_preview.borrow().clone().unwrap_or_else(|| {
+            let popover = gtk::Popover::new();
+            popover.set_has_arrow(true);
+            let picture = gtk::Picture::new();
+            popover.set_child(Some(&picture));
+            imp.trickplay_picture.replace(Some(picture));
+            imp.trickplay_preview.replace(Some(popover.clone()));
+            popover
+        });
+
+        if let Some(picture) = imp.trickplay_picture.borrow().as_ref() {
+            picture.set_pixbuf(Some(&pixbuf));
+            picture.set_size_request(manifest.tile_width as i32, manifest.tile_height as i32);
+        }
+
+        popover.set_parent(&imp.video_scale.get());
+        popover.popup();
     }
 
     #[template_callback]
@@ -1377,7 +1591,17 @@ impl MPVPage {
             .and_downcast_ref::<crate::ui::widgets::window::Window>()
             .unwrap();
         window.imp().stack.set_visible_child_name("main");
+        window.sync_tv_button_hints();
         window.allow_suspend();
+
+        let global_fullscreen = SETTINGS.is_fullscreen() || SETTINGS.tv_start_fullscreen();
+        if window.is_fullscreen()
+            && !global_fullscreen
+            && !self.imp().was_fullscreen_before_play.get()
+        {
+            window.unfullscreen();
+        }
+
         window.refresh_homepage_if_needed();
 
         spawn_g_timeout(glib::clone!(

--- a/src/ui/mpv/trickplay.rs
+++ b/src/ui/mpv/trickplay.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+
+use crate::{
+    client::{
+        jellyfin_client::JELLYFIN_CLIENT,
+        structs::MediaSource,
+    },
+    utils::spawn_tokio,
+};
+
+#[derive(Clone)]
+pub struct TrickplayManifest {
+    pub tile_width: u32,
+    pub tile_height: u32,
+    pub interval_seconds: f64,
+    pub url_template: String,
+}
+
+#[derive(Default)]
+pub struct TrickplayCache {
+    tiles: HashMap<u32, Vec<u8>>,
+}
+
+impl TrickplayCache {
+    pub fn tile_index_for_time(&self, manifest: &TrickplayManifest, seconds: f64) -> u32 {
+        (seconds / manifest.interval_seconds).floor() as u32
+    }
+
+    pub fn preview_url(&self, manifest: &TrickplayManifest, seconds: f64) -> String {
+        let index = self.tile_index_for_time(manifest, seconds);
+        manifest.url_template.replace("{index}", &index.to_string())
+    }
+
+    pub fn cached_tile(&self, manifest: &TrickplayManifest, seconds: f64) -> Option<&[u8]> {
+        let index = self.tile_index_for_time(manifest, seconds);
+        self.tiles.get(&index).map(|data| data.as_slice())
+    }
+
+    pub fn store_tile(&mut self, manifest: &TrickplayManifest, seconds: f64, data: Vec<u8>) {
+        let index = self.tile_index_for_time(manifest, seconds);
+        self.tiles.insert(index, data);
+    }
+
+    pub fn clear(&mut self) {
+        self.tiles.clear();
+    }
+}
+
+pub fn manifest_from_media_source(source: &MediaSource) -> Option<TrickplayManifest> {
+    let trickplay = source.trickplay.as_ref()?;
+    let first = trickplay.first()?;
+    let url_template = first.url_template.clone()?;
+    if url_template.is_empty() {
+        return None;
+    }
+    Some(TrickplayManifest {
+        tile_width: first.width.unwrap_or(160),
+        tile_height: first.height.unwrap_or(90),
+        interval_seconds: first.interval.unwrap_or(10) as f64,
+        url_template,
+    })
+}
+
+pub async fn fetch_trickplay_tile(url_path: &str) -> anyhow::Result<Vec<u8>> {
+    let url_path = url_path.to_owned();
+    spawn_tokio(async move { JELLYFIN_CLIENT.fetch_bytes(&url_path).await })
+        .await
+        .map_err(|err| anyhow::anyhow!(err.to_string()))
+}

--- a/src/ui/mpv/tsukimi_mpv.rs
+++ b/src/ui/mpv/tsukimi_mpv.rs
@@ -344,6 +344,10 @@ impl TsukimiMPV {
         self.set_property("slang", value);
     }
 
+    pub fn set_alang(&self, value: String) {
+        self.set_property("alang", value);
+    }
+
     pub fn set_property<V>(&self, property: &str, value: V)
     where
         V: SetData + Send + 'static,

--- a/src/ui/mpv/video_scale.rs
+++ b/src/ui/mpv/video_scale.rs
@@ -7,7 +7,10 @@ use gtk::{
 use super::tsukimi_mpv::ChapterList;
 
 mod imp {
-    use std::cell::Cell;
+    use std::cell::{
+        Cell,
+        RefCell,
+    };
 
     use gtk::{
         glib,
@@ -17,6 +20,8 @@ mod imp {
 
     use crate::ui::mpv::mpvglarea::MPVGLArea;
 
+    type ScrubCallback = Box<dyn Fn(f64)>;
+
     #[derive(Default, glib::Properties)]
     #[properties(wrapper_type = super::VideoScale)]
     pub struct VideoScale {
@@ -24,6 +29,8 @@ mod imp {
         pub player: glib::WeakRef<MPVGLArea>,
 
         pub is_dragging: Cell<bool>,
+        pub scrub_callback: RefCell<Option<ScrubCallback>>,
+        pub scrub_finished_callback: RefCell<Option<Box<dyn Fn()>>>,
     }
 
     #[glib::object_subclass]
@@ -38,10 +45,6 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
-            // new GestureClick with add_controller is doesn't work for connect_released
-            //
-            // so we need to iterate through the controllers to get the GestureClick
-            // and then connect the signals
             let mut gesture = gtk::GestureClick::new();
             self.obj()
                 .observe_controllers()
@@ -69,6 +72,18 @@ mod imp {
                     imp.on_click_released();
                 }
             ));
+
+            self.obj().connect_value_changed(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |scale| {
+                    if imp.is_dragging.get()
+                        && let Some(callback) = imp.scrub_callback.borrow().as_ref()
+                    {
+                        callback(scale.value());
+                    }
+                }
+            ));
         }
     }
     impl WidgetImpl for VideoScale {}
@@ -85,12 +100,19 @@ mod imp {
 
         fn on_click_pressed(&self) {
             self.is_dragging.set(true);
+            let value = self.obj().value();
+            if let Some(callback) = self.scrub_callback.borrow().as_ref() {
+                callback(value);
+            }
         }
 
         fn on_click_released(&self) {
             let obj = self.obj();
             self.on_seek_finished(obj.value());
             self.is_dragging.set(false);
+            if let Some(callback) = self.scrub_finished_callback.borrow().as_ref() {
+                callback();
+            }
         }
 
         fn on_seek_finished(&self, value: f64) {
@@ -113,6 +135,20 @@ impl Default for VideoScale {
 impl VideoScale {
     pub fn new() -> Self {
         glib::Object::builder().build()
+    }
+
+    pub fn connect_scrub_position_changed<F>(&self, callback: F)
+    where
+        F: Fn(f64) + 'static,
+    {
+        *self.imp().scrub_callback.borrow_mut() = Some(Box::new(callback));
+    }
+
+    pub fn connect_scrub_finished<F>(&self, callback: F)
+    where
+        F: Fn() + 'static,
+    {
+        *self.imp().scrub_finished_callback.borrow_mut() = Some(Box::new(callback));
     }
 
     pub fn update_position_callback(&self) -> glib::ControlFlow {

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -461,7 +461,7 @@ impl TuItem {
             #[weak]
             window,
             async move {
-                window.play_media(None, item, vec![], None, 0.0);
+                window.play_media(None, item, vec![], None, 0.0, None);
             }
         ));
     }
@@ -528,6 +528,7 @@ impl TuItem {
                 episode_list,
                 None,
                 self.playback_position_ticks() as f64 / 10_000_000.0,
+                None,
             )
         }
     }
@@ -720,17 +721,17 @@ impl TuItem {
 
     pub fn size_hint(&self) -> (i32, i32) {
         match self.prefer_size() {
-            PreferSize::Video => return TU_ITEM_VIDEO_SIZE,
-            PreferSize::Post => return TU_ITEM_POST_SIZE,
+            PreferSize::Video => return tu_item_video_size(),
+            PreferSize::Post => return tu_item_post_size(),
             _ => (),
         }
 
         match self.item_type().as_str() {
             MOVIE | SERIES | BOX_SET | ACTOR | PERSON | DIRECTOR | WRITER | PRODUCER
-            | GUEST_STAR | SEASON => TU_ITEM_POST_SIZE,
+            | GUEST_STAR | SEASON => tu_item_post_size(),
             VIDEO | MUSIC_VIDEO | ADULT_VIDEO | TV_CHANNEL | COLLECTION_FOLDER | EPISODE
-            | USER_VIEW => TU_ITEM_VIDEO_SIZE,
-            _ => TU_ITEM_SQUARE_SIZE,
+            | USER_VIEW => tu_item_video_size(),
+            _ => tu_item_square_size(),
         }
     }
 

--- a/src/ui/widgets/account_add.rs
+++ b/src/ui/widgets/account_add.rs
@@ -103,6 +103,13 @@ pub mod imp {
     impl ObjectImpl for AccountWindow {
         fn constructed(&self) {
             self.parent_constructed();
+            let obj = self.obj();
+            let imp = obj.imp();
+            crate::tv::osk::attach_on_screen_keyboard(&imp.servername_entry.get());
+            crate::tv::osk::attach_on_screen_keyboard(&imp.server_entry.get());
+            crate::tv::osk::attach_on_screen_keyboard(&imp.username_entry.get());
+            crate::tv::osk::attach_on_screen_keyboard(&imp.password_entry.get());
+            crate::tv::osk::attach_on_screen_keyboard(&imp.port_entry.get());
         }
     }
 
@@ -125,6 +132,18 @@ impl Default for AccountWindow {
 impl AccountWindow {
     pub fn new() -> Self {
         Object::builder().build()
+    }
+
+    pub fn focus_widgets(&self) -> Vec<gtk::Widget> {
+        let imp = self.imp();
+        vec![
+            imp.servername_entry.get().upcast(),
+            imp.server_entry.get().upcast(),
+            imp.port_entry.get().upcast(),
+            imp.username_entry.get().upcast(),
+            imp.password_entry.get().upcast(),
+            imp.nav.get().upcast(),
+        ]
     }
 
     #[template_callback]

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -23,6 +23,7 @@ use adw::{
     subclass::prelude::*,
 };
 use gettextrs::gettext;
+use glib::translate::IntoGlib;
 use gtk::{
     CompositeTemplate,
     gdk::{
@@ -141,6 +142,8 @@ mod imp {
 
         pub descriptor_grab_x: Cell<f64>,
         pub descriptor_grab_y: Cell<f64>,
+
+        pub preference_pages: RefCell<Vec<adw::PreferencesPage>>,
     }
 
     #[glib::object_subclass]
@@ -205,7 +208,12 @@ mod imp {
             obj.set_pic();
             obj.set_color();
             obj.bind_settings();
+            obj.setup_htpc_settings();
+            obj.setup_playback_and_subtitle_settings();
+            obj.setup_osk_entries();
             obj.refersh_descriptors();
+            obj.cache_preference_pages();
+            obj.setup_tv_controller_navigation();
         }
     }
 
@@ -227,6 +235,56 @@ glib::wrapper! {
 impl AccountSettings {
     pub fn new(window: crate::Window) -> Self {
         glib::Object::builder().property("window", window).build()
+    }
+
+    pub fn preference_pages(&self) -> Vec<adw::PreferencesPage> {
+        self.imp().preference_pages.borrow().clone()
+    }
+
+    fn cache_preference_pages(&self) {
+        *self.imp().preference_pages.borrow_mut() =
+            crate::ui::input::settings_navigator::find_view_stack_pages(
+                self.upcast_ref::<adw::PreferencesWindow>(),
+            );
+    }
+
+    fn setup_tv_controller_navigation(&self) {
+        if !crate::tv::focus::tv_focus_enabled() {
+            return;
+        }
+        let settings = self.clone();
+        let parent = self.window();
+        let keys = gtk::EventControllerKey::new();
+        keys.connect_key_pressed(move |_, keyval, _, _| {
+            if !crate::tv::controller_navigation_enabled() {
+                return glib::Propagation::Proceed;
+            }
+            let Some(action) = crate::ui::input::key_to_action(keyval.into_glib()) else {
+                return glib::Propagation::Proceed;
+            };
+            if parent
+                .imp()
+                .settings_navigator
+                .borrow()
+                .handle_window(&settings, action)
+            {
+                return glib::Propagation::Stop;
+            }
+            glib::Propagation::Proceed
+        });
+        self.add_controller(keys);
+
+        let pointer = gtk::EventControllerLegacy::new();
+        pointer.connect_event(move |_, event| {
+            if event.event_type() == gtk::gdk::EventType::ButtonPress
+                || event.event_type() == gtk::gdk::EventType::ButtonRelease
+                || event.event_type() == gtk::gdk::EventType::MotionNotify
+            {
+                crate::tv::osk::mark_pointer_input();
+            }
+            glib::Propagation::Proceed
+        });
+        self.add_controller(pointer);
     }
 
     #[template_callback]
@@ -252,6 +310,443 @@ impl AccountSettings {
                 self.toast(format!("{}: {}", gettext("Failed to change password"), e));
             }
         };
+    }
+
+    pub fn setup_osk_entries(&self) {
+        let imp = self.imp();
+        crate::tv::osk::attach_on_screen_keyboard(&imp.password_entry.get());
+        crate::tv::osk::attach_on_screen_keyboard(&imp.password_second_entry.get());
+    }
+
+    pub fn setup_htpc_settings(&self) {
+        let page = adw::PreferencesPage::new();
+        page.set_title(&gettext("TV / HTPC"));
+        page.set_name(Some("tv-htpc"));
+        page.set_icon_name(Some("preferences-desktop-remote-desktop-symbolic"));
+
+        let controls = adw::PreferencesGroup::new();
+        controls.set_title(&gettext("Controls"));
+
+        let gamepad_row = adw::SwitchRow::new();
+        gamepad_row.set_title(&gettext("Enable Gamepad"));
+        gamepad_row.set_subtitle(&gettext(
+            "Xbox, PlayStation, Steam Deck, and other controllers",
+        ));
+        gamepad_row.set_active(SETTINGS.gamepad_enabled());
+        gamepad_row.connect_active_notify(|row| {
+            let _ = SETTINGS.set_gamepad_enabled(row.is_active());
+            if !row.is_active() {
+                crate::tv::cursor::restore();
+            }
+        });
+        controls.add(&gamepad_row);
+
+        let tv_group = adw::PreferencesGroup::new();
+        tv_group.set_title(&gettext("TV / HTPC"));
+
+        let tv_mode_row = adw::SwitchRow::new();
+        tv_mode_row.set_title(&gettext("TV Mode"));
+        tv_mode_row.set_subtitle(&gettext("Larger UI scaled for couch viewing"));
+        tv_mode_row.set_active(SETTINGS.tv_mode());
+        tv_mode_row.connect_active_notify(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |row| {
+                let active = row.is_active();
+                let _ = SETTINGS.set_tv_mode(active);
+                crate::tv::set_tv_mode_active(active);
+                let window = obj.window();
+                if active {
+                    crate::tv::apply_to_window(&window, false);
+                } else {
+                    crate::tv::remove_from_window(&window);
+                }
+            }
+        ));
+        tv_group.add(&tv_mode_row);
+
+        let tv_scale_adjustment =
+            gtk::Adjustment::new(SETTINGS.tv_ui_scale(), 1.0, 2.0, 0.05, 0.1, 0.0);
+        let tv_scale_row = adw::SpinRow::new(Some(&tv_scale_adjustment), 0.05, 2);
+        tv_scale_row.set_title(&gettext("TV UI Scale"));
+        tv_scale_row.set_subtitle(&gettext("Multiplier for poster and control sizes"));
+        tv_scale_row.set_range(1.0, 2.0);
+        tv_scale_row.set_value(SETTINGS.tv_ui_scale());
+        tv_scale_row.connect_value_notify(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |row| {
+                let _ = SETTINGS.set_tv_ui_scale(row.value());
+                if crate::tv::is_tv_mode_active() {
+                    crate::tv::sync_tv_style();
+                    let window = obj.window();
+                    window.enable_tv_mode_ui(false);
+                }
+            }
+        ));
+        tv_group.add(&tv_scale_row);
+
+        let tv_fullscreen_row = adw::SwitchRow::new();
+        tv_fullscreen_row.set_title(&gettext("Start Fullscreen in TV Mode"));
+        tv_fullscreen_row.set_active(SETTINGS.tv_start_fullscreen());
+        tv_fullscreen_row.connect_active_notify(|row| {
+            let _ = SETTINGS.set_tv_start_fullscreen(row.is_active());
+        });
+        tv_group.add(&tv_fullscreen_row);
+
+        let tv_sidebar_row = adw::SwitchRow::new();
+        tv_sidebar_row.set_title(&gettext("Hide Sidebar in TV Mode"));
+        tv_sidebar_row.set_active(SETTINGS.tv_hide_sidebar());
+        tv_sidebar_row.connect_active_notify(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |row| {
+                let _ = SETTINGS.set_tv_hide_sidebar(row.is_active());
+                if crate::tv::is_tv_mode_active() {
+                    let window = obj.window();
+                    if row.is_active() {
+                        window.set_sidebar_panel_visible(false);
+                    } else {
+                        window.overlay_sidebar(SETTINGS.overlay());
+                        window.imp().split_view.set_show_sidebar(true);
+                    }
+                }
+            }
+        ));
+        tv_group.add(&tv_sidebar_row);
+
+        let tv_hints_row = adw::SwitchRow::new();
+        tv_hints_row.set_title(&gettext("Show Controller Hints"));
+        tv_hints_row.set_active(SETTINGS.tv_show_button_hints());
+        tv_hints_row.connect_active_notify(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |row| {
+                let _ = SETTINGS.set_tv_show_button_hints(row.is_active());
+                obj.window().sync_tv_button_hints();
+            }
+        ));
+        tv_group.add(&tv_hints_row);
+
+        let steam_group = adw::PreferencesGroup::new();
+        steam_group.set_title(&gettext("Steam"));
+
+        let steam_row = adw::ActionRow::new();
+        steam_row.set_title(&gettext("Add to Steam"));
+        steam_row.set_subtitle(&gettext(
+            "Add Tsukimi to your Steam library for Big Picture launch",
+        ));
+        let steam_button = gtk::Button::with_label(&gettext("Add"));
+        steam_button.set_valign(gtk::Align::Center);
+        steam_row.add_suffix(&steam_button);
+        steam_button.connect_clicked(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |_| {
+                let window = obj.window();
+                match crate::steam::shortcuts::add_tsukimi_to_steam(&window) {
+                    Ok(()) => {}
+                    Err(e) => obj.toast(e),
+                }
+            }
+        ));
+        steam_group.add(&steam_row);
+
+        page.add(&controls);
+        page.add(&tv_group);
+        page.add(&steam_group);
+        self.add(&page);
+    }
+
+    pub fn setup_playback_and_subtitle_settings(&self) {
+        use crate::{
+            playback::{
+                PlaybackRuleEditor,
+                rules::{
+                    LanguageCondition,
+                    PlaybackRule,
+                    PlaybackRulesConfig,
+                    SubtitleOutcome,
+                },
+            },
+            tv::osk,
+        };
+
+        fn rule_summary(rule: &PlaybackRule) -> String {
+            let subtitles = match &rule.then.subtitles {
+                SubtitleOutcome::Off => gettext("Subs: off"),
+                SubtitleOutcome::Forced { language } if language.is_empty() => {
+                    gettext("Subs: forced")
+                }
+                SubtitleOutcome::Forced { language } => {
+                    format!("{} {language}", gettext("Subs: forced"))
+                }
+                SubtitleOutcome::Full { language } if language.is_empty() => gettext("Subs: full"),
+                SubtitleOutcome::Full { language } => {
+                    format!("{} {language}", gettext("Subs: full"))
+                }
+                SubtitleOutcome::PreferLanguage { language } => {
+                    format!("{} {language}", gettext("Subs:"))
+                }
+            };
+            let when = match &rule.when.audio_language {
+                LanguageCondition::Any => gettext("When audio: any"),
+                LanguageCondition::Equals(language) => {
+                    format!("{} = {language}", gettext("When audio"))
+                }
+                LanguageCondition::NotEquals(language) => {
+                    format!("{} ≠ {language}", gettext("When audio"))
+                }
+            };
+            format!("{when} → {subtitles}")
+        }
+
+        let page = adw::PreferencesPage::new();
+        page.set_title(&gettext("Playback Rules"));
+        page.set_name(Some("playback-rules"));
+        page.set_icon_name(Some("media-playlist-repeat-symbolic"));
+
+        let rules_group = adw::PreferencesGroup::new();
+        rules_group.set_title(&gettext("Conditional Tracks"));
+
+        let enable_row = adw::SwitchRow::new();
+        enable_row.set_title(&gettext("Enable Playback Rules"));
+        enable_row.set_subtitle(&gettext(
+            "Choose subtitle tracks based on the audio language",
+        ));
+
+        let rules_list = gtk::ListBox::new();
+        rules_list.set_selection_mode(gtk::SelectionMode::None);
+        rules_list.add_css_class("boxed-list");
+
+        let config = SETTINGS.playback_conditional_rules();
+        enable_row.set_active(config.enabled);
+
+        let settings = self.clone();
+        let refresh_rules_for_init = std::rc::Rc::new(std::cell::RefCell::new(
+            None::<std::rc::Rc<dyn Fn(&PlaybackRulesConfig)>>,
+        ));
+        let rebuild = {
+            let rules_list = rules_list.clone();
+            let enable_row = enable_row.clone();
+            let refresh_rules_for_init = refresh_rules_for_init.clone();
+            let settings = settings.clone();
+            std::rc::Rc::new(move |config: &PlaybackRulesConfig| {
+                while let Some(child) = rules_list.first_child() {
+                    rules_list.remove(&child);
+                }
+                let mut rules = config.rules.clone();
+                rules.sort_by_key(|rule| rule.priority);
+                for rule in rules {
+                    let row = adw::ActionRow::new();
+                    row.set_title(&rule_summary(&rule));
+                    row.set_subtitle(&format!("{} {}", gettext("Priority"), rule.priority));
+                    row.set_activatable(true);
+
+                    let edit_button = gtk::Button::from_icon_name("document-edit-symbolic");
+                    edit_button.set_valign(gtk::Align::Center);
+                    edit_button.add_css_class("flat");
+                    edit_button.set_tooltip_text(Some(&gettext("Edit")));
+
+                    let remove_button = gtk::Button::from_icon_name("user-trash-symbolic");
+                    remove_button.set_valign(gtk::Align::Center);
+                    remove_button.add_css_class("flat");
+                    remove_button.set_tooltip_text(Some(&gettext("Remove")));
+                    row.add_suffix(&edit_button);
+                    row.add_suffix(&remove_button);
+                    rules_list.append(&row);
+
+                    let priority = rule.priority;
+                    let rule_snapshot = rule.clone();
+                    let enable_row_for_edit = enable_row.clone();
+                    let rebuild_for_edit = refresh_rules_for_init.borrow().clone();
+                    edit_button.connect_clicked(glib::clone!(
+                        #[weak]
+                        settings,
+                        #[strong]
+                        rule_snapshot,
+                        move |_| {
+                            let editor = PlaybackRuleEditor::edit_rule_dialog(&rule_snapshot);
+                            editor.present(Some(&settings));
+                            let priority = rule_snapshot.priority;
+                            let enable_row = enable_row_for_edit.clone();
+                            let rebuild = rebuild_for_edit.clone();
+                            editor.connect_save(move |updated| {
+                                let mut config = SETTINGS.playback_conditional_rules();
+                                if let Some(entry) = config
+                                    .rules
+                                    .iter_mut()
+                                    .find(|entry| entry.priority == priority)
+                                {
+                                    *entry = updated;
+                                }
+                                let _ = SETTINGS.set_playback_conditional_rules(&config);
+                                enable_row.set_active(config.enabled);
+                                if let Some(rebuild) = rebuild.as_ref() {
+                                    rebuild(&config);
+                                }
+                            });
+                        }
+                    ));
+
+                    let enable_row_for_remove = enable_row.clone();
+                    let rebuild_for_remove = refresh_rules_for_init.borrow().clone();
+                    remove_button.connect_clicked(move |_| {
+                        let mut updated = SETTINGS.playback_conditional_rules();
+                        updated.rules.retain(|entry| entry.priority != priority);
+                        let _ = SETTINGS.set_playback_conditional_rules(&updated);
+                        enable_row_for_remove.set_active(updated.enabled);
+                        if let Some(rebuild) = rebuild_for_remove.as_ref() {
+                            rebuild(&updated);
+                        }
+                    });
+                }
+            })
+        };
+        *refresh_rules_for_init.borrow_mut() = Some(rebuild.clone());
+        rebuild(&config);
+
+        rules_group.add(&enable_row);
+        rules_group.add(&rules_list);
+
+        let add_row = adw::ButtonRow::new();
+        add_row.set_title(&gettext("Add Rule"));
+        let rebuild_for_add = rebuild.clone();
+        let settings_for_add = self.clone();
+        let settings_weak = settings_for_add.downgrade();
+        let enable_weak = enable_row.downgrade();
+        add_row.connect_activated(move |_| {
+            let Some(settings) = settings_weak.upgrade() else {
+                return;
+            };
+            let updated = SETTINGS.playback_conditional_rules();
+            let next_priority = updated
+                .rules
+                .iter()
+                .map(|rule| rule.priority)
+                .max()
+                .unwrap_or(0)
+                + 1;
+            let editor = PlaybackRuleEditor::new_rule_dialog(next_priority);
+            editor.present(Some(&settings));
+            let rebuild_for_add = rebuild_for_add.clone();
+            let enable_weak = enable_weak.clone();
+            editor.connect_save(move |rule| {
+                let mut config = SETTINGS.playback_conditional_rules();
+                config.rules.push(rule);
+                let _ = SETTINGS.set_playback_conditional_rules(&config);
+                if let Some(enable_row) = enable_weak.upgrade() {
+                    enable_row.set_active(config.enabled);
+                }
+                rebuild_for_add(&config);
+            });
+        });
+        rules_group.add(&add_row);
+
+        let default_row = adw::ActionRow::new();
+        default_row.set_title(&gettext("Edit Default Outcome"));
+        default_row.set_subtitle(&gettext("Used when no rule matches"));
+        default_row.set_activatable(true);
+        let rebuild_for_default = rebuild.clone();
+        let settings_for_default = self.clone();
+        let settings_weak = settings_for_default.downgrade();
+        default_row.connect_activated(move |_| {
+            let Some(settings) = settings_weak.upgrade() else {
+                return;
+            };
+            let config = SETTINGS.playback_conditional_rules();
+            let editor = PlaybackRuleEditor::default_outcome_dialog(&config);
+            editor.present(Some(&settings));
+            let rebuild_for_default = rebuild_for_default.clone();
+            editor.connect_save(move |rule| {
+                let mut config = SETTINGS.playback_conditional_rules();
+                config.default = rule.then;
+                let _ = SETTINGS.set_playback_conditional_rules(&config);
+                rebuild_for_default(&config);
+            });
+        });
+        rules_group.add(&default_row);
+
+        enable_row.connect_active_notify(|row| {
+            let mut updated = SETTINGS.playback_conditional_rules();
+            updated.enabled = row.is_active();
+            let _ = SETTINGS.set_playback_conditional_rules(&updated);
+        });
+
+        let subtitle_page = adw::PreferencesPage::new();
+        subtitle_page.set_title(&gettext("Subtitle Providers"));
+        subtitle_page.set_name(Some("subtitle-providers"));
+        subtitle_page.set_icon_name(Some("text-x-generic-symbolic"));
+
+        let provider_group = adw::PreferencesGroup::new();
+        provider_group.set_title(&gettext("Online Subtitles"));
+
+        let opensubtitles_row = adw::PasswordEntryRow::new();
+        opensubtitles_row.set_title(&gettext("OpenSubtitles API Key"));
+        opensubtitles_row.set_text(&SETTINGS.opensubtitles_api_key());
+        osk::attach_on_screen_keyboard(&opensubtitles_row);
+        opensubtitles_row.connect_changed(|row| {
+            let _ = SETTINGS.set_opensubtitles_api_key(row.text().as_ref());
+        });
+        provider_group.add(&opensubtitles_row);
+
+        let subdl_row = adw::PasswordEntryRow::new();
+        subdl_row.set_title(&gettext("SubDL API Key"));
+        subdl_row.set_text(&SETTINGS.subdl_api_key());
+        osk::attach_on_screen_keyboard(&subdl_row);
+        subdl_row.connect_changed(|row| {
+            let _ = SETTINGS.set_subdl_api_key(row.text().as_ref());
+        });
+        provider_group.add(&subdl_row);
+
+        let opensubtitles_switch = adw::SwitchRow::new();
+        opensubtitles_switch.set_title(&gettext("Enable OpenSubtitles"));
+        opensubtitles_switch.set_active(SETTINGS.subtitle_provider_enabled("opensubtitles"));
+        opensubtitles_switch.connect_active_notify(|row| {
+            let mut providers = SETTINGS
+                .string("subtitle-providers-enabled")
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            if row.is_active() {
+                if !providers.iter().any(|entry| entry == "opensubtitles") {
+                    providers.push("opensubtitles".into());
+                }
+            } else {
+                providers.retain(|entry| entry != "opensubtitles");
+            }
+            let _ = SETTINGS.set_string("subtitle-providers-enabled", &providers.join(","));
+        });
+        provider_group.add(&opensubtitles_switch);
+
+        let subdl_switch = adw::SwitchRow::new();
+        subdl_switch.set_title(&gettext("Enable SubDL"));
+        subdl_switch.set_active(SETTINGS.subtitle_provider_enabled("subdl"));
+        subdl_switch.connect_active_notify(|row| {
+            let mut providers = SETTINGS
+                .string("subtitle-providers-enabled")
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            if row.is_active() {
+                if !providers.iter().any(|entry| entry == "subdl") {
+                    providers.push("subdl".into());
+                }
+            } else {
+                providers.retain(|entry| entry != "subdl");
+            }
+            let _ = SETTINGS.set_string("subtitle-providers-enabled", &providers.join(","));
+        });
+        provider_group.add(&subdl_switch);
+
+        page.add(&rules_group);
+        subtitle_page.add(&provider_group);
+        self.add(&page);
+        self.add(&subtitle_page);
     }
 
     pub fn set_sidebar(&self) {

--- a/src/ui/widgets/fix.rs
+++ b/src/ui/widgets/fix.rs
@@ -1,10 +1,155 @@
 use gtk::{
+    PolicyType,
     ScrolledWindow,
+    graphene::Point,
     prelude::*,
 };
 
+use serde_json;
+
 pub trait ScrolledWindowFixExt {
     fn fix(&self) -> &Self;
+}
+
+/// Scroll a child widget so it sits near the vertical center of the nearest
+/// ancestor `ScrolledWindow` with a vertical scrollbar.
+pub fn scroll_widget_to_row_center(widget: &impl IsA<gtk::Widget>) {
+    let Some(scrolled) = widget
+        .ancestor(ScrolledWindow::static_type())
+        .and_downcast::<ScrolledWindow>()
+    else {
+        return;
+    };
+    if scrolled.vscrollbar_policy() == PolicyType::Never {
+        return;
+    }
+    scroll_widget_centered_in(&scrolled, widget);
+}
+
+fn scroll_widget_centered_in(scrolled: &ScrolledWindow, widget: &impl IsA<gtk::Widget>) {
+    let Some(content) = scrolled.child() else {
+        return;
+    };
+    let point = Point::new(0.0, 0.0);
+    let Some(translated) = widget.compute_point(&content, &point) else {
+        return;
+    };
+    let y = f64::from(translated.y());
+    let height = widget.height().max(1);
+    let adj = scrolled.vadjustment();
+    let page = adj.page_size();
+    if page <= 0.0 {
+        return;
+    }
+    let max = (adj.upper() - page).max(0.0);
+    let center_target = y + f64::from(height) * 0.5 - page * 0.5;
+    let target = center_target.clamp(0.0, max);
+    // #region agent log
+    {
+        use std::io::Write;
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let line = serde_json::json!({
+            "sessionId": "ef5d72",
+            "hypothesisId": "A",
+            "location": "fix.rs:scroll_widget_centered_in",
+            "message": "scroll clamp",
+            "data": {
+                "y": y,
+                "height": height,
+                "centerTarget": center_target,
+                "target": target,
+                "max": max,
+                "adjValue": adj.value(),
+                "adjUpper": adj.upper(),
+                "clamped": center_target > max
+            },
+            "timestamp": ts,
+            "runId": "post-fix"
+        });
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("/var/mnt/SSD/Atlas Commons/technitiumdns-api/.cursor/debug-ef5d72.log")
+        {
+            let _ = writeln!(f, "{line}");
+        }
+    }
+    // #endregion
+    adj.set_value(target);
+}
+
+/// Keep a widget fully visible inside the nearest vertical `ScrolledWindow`.
+#[allow(dead_code)]
+pub fn scroll_widget_into_viewport(widget: &impl IsA<gtk::Widget>) {
+    let Some(scrolled) = widget
+        .ancestor(ScrolledWindow::static_type())
+        .and_downcast::<ScrolledWindow>()
+    else {
+        return;
+    };
+    if scrolled.vscrollbar_policy() == PolicyType::Never {
+        return;
+    }
+    let Some(content) = scrolled.child() else {
+        return;
+    };
+    let point = Point::new(0.0, 0.0);
+    let Some(translated) = widget.compute_point(&content, &point) else {
+        return;
+    };
+    let y = f64::from(translated.y());
+    let height = f64::from(widget.height().max(1));
+    let adj = scrolled.vadjustment();
+    let page = adj.page_size();
+    if page <= 0.0 {
+        return;
+    }
+    let max = (adj.upper() - page).max(0.0);
+    let margin = 56.0;
+    let top = y;
+    let bottom = y + height;
+    let view_top = adj.value();
+    let view_bottom = view_top + page;
+
+    if bottom > view_bottom - margin {
+        adj.set_value((bottom - page + margin).clamp(0.0, max));
+    } else if top < view_top + margin {
+        adj.set_value((top - margin).clamp(0.0, max));
+    }
+}
+
+/// Scroll a child widget so it sits near the horizontal center of the nearest
+/// ancestor `ScrolledWindow` with a horizontal scrollbar.
+pub fn scroll_widget_to_column_center(widget: &impl IsA<gtk::Widget>) {
+    let Some(scrolled) = widget
+        .ancestor(ScrolledWindow::static_type())
+        .and_downcast::<ScrolledWindow>()
+    else {
+        return;
+    };
+    if scrolled.hscrollbar_policy() == PolicyType::Never {
+        return;
+    }
+    let Some(content) = scrolled.child() else {
+        return;
+    };
+    let point = Point::new(0.0, 0.0);
+    let Some(translated) = widget.compute_point(&content, &point) else {
+        return;
+    };
+    let x = f64::from(translated.x());
+    let width = f64::from(widget.width().max(1));
+    let adj = scrolled.hadjustment();
+    let page = adj.page_size();
+    if page <= 0.0 {
+        return;
+    }
+    let max = (adj.upper() - page).max(0.0);
+    let target = (x + width * 0.5 - page * 0.5).clamp(0.0, max);
+    adj.set_value(target);
 }
 
 /// fix scrolledwindow fucking up the vscroll event

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -145,6 +145,24 @@ impl HomePage {
         Object::builder().build()
     }
 
+    pub fn focus_hortu_rows(&self) -> Vec<HortuScrolled> {
+        let imp = self.imp();
+        let mut rows = vec![
+            imp.libhortu.get(),
+            imp.hishortu.get(),
+            imp.nextuphortu.get(),
+        ];
+        // Preserve visual order from libsbox — HashMap iteration order is arbitrary.
+        let mut child = imp.libsbox.first_child();
+        while let Some(widget) = child {
+            if let Some(hortu) = widget.downcast_ref::<HortuScrolled>() {
+                rows.push(hortu.clone());
+            }
+            child = widget.next_sibling();
+        }
+        rows
+    }
+
     pub fn init_load(&self) {
         spawn(glib::clone!(
             #[weak(rename_to = obj)]
@@ -179,6 +197,9 @@ impl HomePage {
             self.setup_library(enable_cache)
         );
         fraction!(self);
+        if let Some(window) = self.root().and_downcast::<crate::Window>() {
+            window.refresh_focus_manager();
+        }
     }
 
     pub async fn setup_history(&self, enable_cache: bool, force_cache_emit: bool) {

--- a/src/ui/widgets/horbu_scrolled.rs
+++ b/src/ui/widgets/horbu_scrolled.rs
@@ -13,11 +13,15 @@ use crate::{
         SGTitem,
         Urls,
     },
+    ui::widgets::fix::scroll_widget_to_row_center,
     utils::spawn,
 };
 
 mod imp {
-    use std::cell::RefCell;
+    use std::cell::{
+        Cell,
+        RefCell,
+    };
 
     use glib::subclass::InitializingObject;
 
@@ -38,6 +42,7 @@ mod imp {
         pub title: RefCell<String>,
 
         pub selection: gtk::SingleSelection,
+        pub selected_index: Cell<Option<usize>>,
     }
 
     #[glib::object_subclass]
@@ -176,5 +181,85 @@ impl HorbuScrolled {
                 }
             }
         ));
+    }
+
+    fn wrapbox_buttons(&self) -> Vec<gtk::Button> {
+        let wrapbox = self.imp().wrapbox.get();
+        let mut buttons = Vec::new();
+        let mut child = wrapbox.first_child();
+        while let Some(widget) = child {
+            if let Ok(button) = widget.clone().downcast::<gtk::Button>() {
+                buttons.push(button);
+            }
+            child = widget.next_sibling();
+        }
+        buttons
+    }
+
+    pub fn button_count(&self) -> usize {
+        self.wrapbox_buttons().len()
+    }
+
+    pub fn ensure_selection(&self) {
+        if self.button_count() == 0 {
+            return;
+        }
+        if self.imp().selected_index.get().is_none() {
+            self.set_selection_index(0);
+        }
+    }
+
+    pub fn clear_selection(&self) {
+        let buttons = self.wrapbox_buttons();
+        if let Some(index) = self.imp().selected_index.get()
+            && let Some(button) = buttons.get(index)
+        {
+            crate::tv::set_tv_focused(button, false);
+        }
+        self.imp().selected_index.set(None);
+    }
+
+    pub fn move_selection(&self, delta: i32) {
+        let count = self.button_count();
+        if count == 0 {
+            return;
+        }
+        let current = self.imp().selected_index.get().unwrap_or(0);
+        let next = (current as i32 + delta).clamp(0, count as i32 - 1) as usize;
+        self.set_selection_index(next);
+    }
+
+    fn set_selection_index(&self, index: usize) {
+        let buttons = self.wrapbox_buttons();
+        if buttons.is_empty() {
+            return;
+        }
+        let index = index.min(buttons.len() - 1);
+        let prev = self.imp().selected_index.get();
+        if prev == Some(index) {
+            return;
+        }
+        if let Some(prev_index) = prev
+            && let Some(button) = buttons.get(prev_index)
+        {
+            crate::tv::set_tv_focused(button, false);
+        }
+        if let Some(button) = buttons.get(index) {
+            crate::tv::set_tv_focused(button, true);
+        }
+        self.imp().selected_index.set(Some(index));
+    }
+
+    pub fn activate_selected(&self) {
+        let buttons = self.wrapbox_buttons();
+        if let Some(index) = self.imp().selected_index.get()
+            && let Some(button) = buttons.get(index)
+        {
+            button.emit_clicked();
+        }
+    }
+
+    pub fn scroll_into_parent_viewport(&self) {
+        scroll_widget_to_row_center(self);
     }
 }

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -19,7 +19,10 @@ use crate::{
             tu_object::TuObject,
         },
         widgets::{
-            fix::ScrolledWindowFixExt,
+            fix::{
+                ScrolledWindowFixExt,
+                scroll_widget_to_row_center,
+            },
             hor_controls::HorControlsExt,
             lazy_diff_view::LazyDiffView,
             tu_list_item::{
@@ -116,6 +119,9 @@ mod imp {
         pub show_right_animation: OnceCell<adw::TimedAnimation>,
         pub hide_right_animation: OnceCell<adw::TimedAnimation>,
         pub is_hovering: Cell<bool>,
+        pub keyboard_focused: Cell<bool>,
+        pub header_focused: Cell<bool>,
+        pub selected_index: Cell<Option<usize>>,
         pub item_cache: RefCell<HashMap<String, TuObject>>,
     }
 
@@ -166,12 +172,27 @@ mod imp {
 
                     tu_item.upcast::<gtk::Widget>()
                 },
-                |widget, tu_obj: &TuObject| {
-                    let tu_item = widget
-                        .downcast_ref::<TuListItem>()
-                        .expect("LazyDiffView row must be a TuListItem");
-                    tu_item.set_item(tu_obj.item());
-                },
+                glib::clone!(
+                    #[weak(rename_to = obj)]
+                    self.obj(),
+                    move |widget, tu_obj: &TuObject| {
+                        let tu_item = widget
+                            .downcast_ref::<TuListItem>()
+                            .expect("LazyDiffView row must be a TuListItem");
+                        let key = tu_obj.item().key();
+                        let selected = obj
+                            .imp()
+                            .selected_index
+                            .get()
+                            .and_then(|index| obj.imp().diffview.key_at(index))
+                            .as_deref()
+                            == Some(key.as_str());
+                        if tu_item.item().key() != key {
+                            tu_item.set_item(tu_obj.item());
+                        }
+                        tu_item.set_poster_focused(selected);
+                    }
+                ),
             );
 
             self.obj().connect_scroll_controls();
@@ -263,6 +284,9 @@ impl HortuScrolled {
 
     #[template_callback]
     fn on_leave_focus(&self) {
+        if self.imp().keyboard_focused.get() {
+            return;
+        }
         self.on_leave_scroll_controls();
     }
 
@@ -276,6 +300,169 @@ impl HortuScrolled {
         F: Fn(&gtk::Button) + 'static,
     {
         self.imp().morebutton.connect_clicked(cb);
+    }
+
+    pub fn item_count(&self) -> usize {
+        self.imp().diffview.len()
+    }
+
+    pub fn ensure_selection(&self) {
+        if self.item_count() == 0 {
+            return;
+        }
+        if self.imp().selected_index.get().is_none() {
+            self.set_selection_index(0);
+        }
+    }
+
+    pub fn clear_selection(&self) {
+        let prev_key = self
+            .imp()
+            .selected_index
+            .get()
+            .and_then(|index| self.imp().diffview.key_at(index));
+        self.imp().selected_index.set(None);
+        self.imp().header_focused.set(false);
+        self.clear_keyboard_focus();
+        crate::tv::set_tv_focused(&self.imp().morebutton.get(), false);
+        if let Some(key) = prev_key {
+            self.set_focus_for_key(&key, false);
+        }
+    }
+
+    pub fn clear_keyboard_focus(&self) {
+        self.imp().keyboard_focused.set(false);
+        self.on_leave_scroll_controls();
+    }
+
+    pub fn move_selection(&self, delta: i32) {
+        let count = self.item_count();
+        if count == 0 {
+            return;
+        }
+        if self.imp().header_focused.get() {
+            if delta > 0 {
+                self.leave_header_focus();
+            }
+            return;
+        }
+        let current = self.imp().selected_index.get().unwrap_or(0);
+        if delta < 0 && current == 0 && self.imp().morebutton.is_visible() {
+            self.focus_header();
+            return;
+        }
+        let next = (current as i32 + delta).clamp(0, count as i32 - 1) as usize;
+        self.set_selection_index(next);
+    }
+
+    pub fn is_header_focused(&self) -> bool {
+        self.imp().header_focused.get()
+    }
+
+    pub fn focus_header(&self) {
+        if !self.imp().morebutton.is_visible() {
+            return;
+        }
+        let prev_key = self
+            .imp()
+            .selected_index
+            .get()
+            .and_then(|index| self.imp().diffview.key_at(index));
+        self.imp().selected_index.set(None);
+        self.imp().header_focused.set(true);
+        if let Some(key) = prev_key {
+            self.set_focus_for_key(&key, false);
+        }
+        self.clear_keyboard_focus();
+        crate::tv::set_tv_focused(&self.imp().morebutton.get(), true);
+        self.imp().morebutton.grab_focus();
+    }
+
+    fn leave_header_focus(&self) {
+        self.imp().header_focused.set(false);
+        crate::tv::set_tv_focused(&self.imp().morebutton.get(), false);
+        self.ensure_selection();
+    }
+
+    pub fn selection_at_start(&self) -> bool {
+        self.imp().selected_index.get().unwrap_or(0) == 0
+    }
+
+    fn set_selection_index(&self, index: usize) {
+        let count = self.item_count();
+        if count == 0 {
+            return;
+        }
+        let index = index.min(count - 1);
+        let prev_key = self
+            .imp()
+            .selected_index
+            .get()
+            .and_then(|idx| self.imp().diffview.key_at(idx));
+        let new_key = self.imp().diffview.key_at(index);
+        self.imp().selected_index.set(Some(index));
+        self.imp().diffview.scroll_to_index(index);
+        self.update_selection_focus(prev_key.as_deref(), new_key.as_deref());
+        self.show_scroll_controls_for_focus();
+    }
+
+    fn update_selection_focus(&self, prev_key: Option<&str>, new_key: Option<&str>) {
+        if let Some(key) = prev_key.filter(|k| Some(*k) != new_key) {
+            self.set_focus_for_key(key, false);
+        }
+        if let Some(key) = new_key {
+            self.set_focus_for_key(key, true);
+        }
+    }
+
+    fn set_focus_for_key(&self, key: &str, focused: bool) {
+        if let Some(widget) = self.imp().diffview.row_widget_for_key(key)
+            && let Some(item) = widget.downcast_ref::<TuListItem>()
+        {
+            item.set_poster_focused(focused);
+        }
+    }
+
+    pub fn activate_selected(&self, window: &crate::Window) {
+        let imp = self.imp();
+        if imp.header_focused.get() {
+            imp.morebutton.emit_clicked();
+            return;
+        }
+        let Some(index) = imp.selected_index.get() else {
+            return;
+        };
+        let items = imp.diffview.len();
+        if index >= items {
+            return;
+        }
+        if let Some(key) = imp
+            .selected_index
+            .get()
+            .and_then(|idx| imp.diffview.key_at(idx))
+            && let Some(obj) = imp.item_cache.borrow().get(&key)
+        {
+            obj.item().activate(window);
+        }
+    }
+
+    pub fn show_scroll_controls_for_focus(&self) {
+        self.imp().header_focused.set(false);
+        crate::tv::set_tv_focused(&self.imp().morebutton.get(), false);
+        self.imp().keyboard_focused.set(true);
+        self.on_enter_scroll_controls();
+    }
+
+    pub fn scroll_into_parent_viewport(&self) {
+        scroll_widget_to_row_center(self);
+    }
+
+    pub fn scroll_page_left(&self) {
+        self.scroll_controls_anime::<false>();
+    }
+
+    pub fn scroll_page_right(&self) {
+        self.scroll_controls_anime::<true>();
     }
 }
 

--- a/src/ui/widgets/hover_scale.rs
+++ b/src/ui/widgets/hover_scale.rs
@@ -5,9 +5,68 @@ use adw::{
 use gtk::{
     gdk,
     glib,
+    glib::WeakRef,
     graphene,
     gsk,
 };
+
+use std::{
+    cell::RefCell,
+    sync::atomic::{
+        AtomicBool,
+        Ordering,
+    },
+};
+
+thread_local! {
+    static HOVER_SCALES: RefCell<Vec<WeakRef<HoverScale>>> = const { RefCell::new(Vec::new()) };
+}
+
+static PENDING_POINTER_TARGETING_SYNC: AtomicBool = AtomicBool::new(false);
+
+fn register_hover_scale(scale: &HoverScale) {
+    HOVER_SCALES.with(|scales| {
+        let mut scales = scales.borrow_mut();
+        scales.retain(|weak| weak.upgrade().is_some());
+        scales.push(scale.downgrade());
+    });
+    apply_pointer_targeting(scale);
+}
+
+fn apply_pointer_targeting(scale: &HoverScale) {
+    let enabled = pointer_hover_enabled();
+    scale.set_can_target(enabled);
+    if !enabled {
+        scale.clear_pointer_hover();
+    }
+}
+
+pub fn sync_all_pointer_targeting() {
+    HOVER_SCALES.with(|scales| {
+        scales.borrow_mut().retain(|weak| {
+            if let Some(scale) = weak.upgrade() {
+                apply_pointer_targeting(&scale);
+                true
+            } else {
+                false
+            }
+        });
+    });
+}
+
+pub fn request_pointer_targeting_sync() {
+    if PENDING_POINTER_TARGETING_SYNC.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    glib::idle_add_local_once(|| {
+        PENDING_POINTER_TARGETING_SYNC.store(false, Ordering::Relaxed);
+        sync_all_pointer_targeting();
+    });
+}
+
+fn pointer_hover_enabled() -> bool {
+    !crate::tv::cursor::suppress_pointer_hover()
+}
 
 pub const MAX_SCALE: f32 = 1.10;
 const ANIMATION_DURATION: u32 = 250;
@@ -42,6 +101,7 @@ mod imp {
 
         pub cursor_nx: Cell<f32>,
         pub cursor_ny: Cell<f32>,
+        pub focus_highlighted: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -57,6 +117,7 @@ mod imp {
             self.parent_constructed();
 
             let obj = self.obj();
+            register_hover_scale(&obj);
 
             obj.set_halign(gtk::Align::Center);
             obj.set_overflow(gtk::Overflow::Visible);
@@ -79,6 +140,9 @@ mod imp {
                 #[weak]
                 obj,
                 move |_, x, y| {
+                    if !pointer_hover_enabled() {
+                        return;
+                    }
                     let imp = obj.imp();
                     let w = obj.width() as f64;
                     let h = obj.height() as f64;
@@ -100,6 +164,9 @@ mod imp {
                 #[weak]
                 obj,
                 move |_, x, y| {
+                    if !pointer_hover_enabled() {
+                        return;
+                    }
                     let imp = obj.imp();
                     let w = obj.width() as f64;
                     let h = obj.height() as f64;
@@ -115,6 +182,9 @@ mod imp {
                 #[weak]
                 obj,
                 move |_| {
+                    if !pointer_hover_enabled() {
+                        return;
+                    }
                     let Some(animation) = obj.imp().animation() else {
                         return;
                     };
@@ -273,6 +343,49 @@ impl HoverScale {
 
     pub fn set_underlay(&self, f: impl Fn(&gtk::Snapshot) + 'static) {
         self.imp().underlay.replace(Some(Box::new(f)));
+    }
+
+    /// Gamepad/TV focus ring — same scale animation as pointer hover, without tilt.
+    pub fn set_highlighted(&self, highlighted: bool) {
+        let imp = self.imp();
+        imp.focus_highlighted.set(highlighted);
+        let Some(animation) = imp.animation.get() else {
+            return;
+        };
+        let at_target = if highlighted {
+            animation.value() >= 1.0
+        } else {
+            animation.value() <= 0.0
+        };
+        if at_target {
+            return;
+        }
+        if highlighted {
+            imp.cursor_nx.set(0.0);
+            imp.cursor_ny.set(0.0);
+        }
+        animation.set_value_from(animation.value());
+        animation.set_value_to(if highlighted { 1.0 } else { 0.0 });
+        animation.play();
+    }
+
+    /// Drop pointer-driven hover without clearing gamepad focus highlight.
+    pub fn clear_pointer_hover(&self) {
+        if self.imp().focus_highlighted.get() {
+            return;
+        }
+        let imp = self.imp();
+        let Some(animation) = imp.animation.get() else {
+            return;
+        };
+        if animation.value() <= 0.0 {
+            return;
+        }
+        imp.cursor_nx.set(0.0);
+        imp.cursor_ny.set(0.0);
+        animation.set_value_from(animation.value());
+        animation.set_value_to(0.0);
+        animation.play();
     }
 }
 

--- a/src/ui/widgets/identify/dialog.rs
+++ b/src/ui/widgets/identify/dialog.rs
@@ -143,8 +143,12 @@ impl IdentifyDialog {
     }
 
     fn load_data(&self, data: Vec<ExternalIdInfo>) {
+        let imp = self.imp();
+        crate::tv::osk::attach_on_screen_keyboard(&imp.name_entry.get());
+        crate::tv::osk::attach_on_screen_keyboard(&imp.year_entry.get());
         for info in data {
             let entry = adw::EntryRow::builder().title(&info.name).build();
+            crate::tv::osk::attach_on_screen_keyboard(&entry);
 
             if let Some(url) = &info.website {
                 let button = gtk::Button::builder()

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -21,6 +21,7 @@ use crate::{
         structs::*,
     },
     ui::{
+        SETTINGS,
         mpv::page::{
             PlaybackDirectMode,
             media_source_stream_url,
@@ -136,6 +137,8 @@ pub(crate) mod imp {
         pub logobox: TemplateChild<gtk::Box>,
         #[template_child]
         pub seasonlist: TemplateChild<gtk::DropDown>,
+        #[template_child]
+        pub season_view_more: TemplateChild<gtk::Button>,
 
         #[template_child]
         pub mediainfobox: TemplateChild<gtk::Box>,
@@ -228,6 +231,11 @@ pub(crate) mod imp {
         pub episode_list_vec: RefCell<Vec<SimpleListItem>>,
 
         pub video_version_matcher: RefCell<Option<String>>,
+        pub pending_external_sub: RefCell<Option<String>>,
+        pub imdb_id: RefCell<Option<String>>,
+        pub tv_subtitle_btn: RefCell<Option<gtk::Button>>,
+        pub mediainfo_selected: Cell<Option<usize>>,
+        pub episode_subzone: Cell<u8>,
     }
 
     #[glib::object_subclass]
@@ -977,6 +985,9 @@ impl ItemPage {
                         if let Some(genres) = item.genres {
                             obj.set_flowbuttons(genres, "Genres");
                         }
+                        if let Some(provider_ids) = item.provider_ids {
+                            obj.imp().imdb_id.replace(provider_ids.imdb);
+                        }
                         if let Some(image_tags) = item.backdrop_image_tags {
                             obj.add_backdrops(image_tags, &item.id).await;
                         }
@@ -1282,9 +1293,16 @@ impl ItemPage {
             .collect();
 
         let matcher = self.imp().video_version_matcher.borrow().to_owned();
+        let external_sub = self.imp().pending_external_sub.borrow_mut().take();
 
-        self.window()
-            .play_media(Some(info), item, episode_list, matcher, start_seconds);
+        self.window().play_media(
+            Some(info),
+            item,
+            episode_list,
+            matcher,
+            start_seconds,
+            external_sub,
+        );
     }
 
     #[template_callback]
@@ -1326,6 +1344,695 @@ impl ItemPage {
 
         let item = TuItem::from_simple(season.to_owned());
         item.activate(self);
+    }
+
+    pub fn focus_hortu_rows(&self) -> Vec<super::hortu_scrolled::HortuScrolled> {
+        let imp = self.imp();
+        vec![
+            imp.includehortu.get(),
+            imp.additionalhortu.get(),
+            imp.seasonshortu.get(),
+            imp.actorhortu.get(),
+            imp.recommendhortu.get(),
+        ]
+    }
+
+    pub fn focus_horbu_rows(&self) -> Vec<super::horbu_scrolled::HorbuScrolled> {
+        let imp = self.imp();
+        vec![
+            imp.linkshorbu.get(),
+            imp.studioshorbu.get(),
+            imp.genreshorbu.get(),
+            imp.tagshorbu.get(),
+        ]
+    }
+
+    pub fn scroll_to_hero_page(&self) {
+        let carousel = self.imp().main_carousel.get();
+        if carousel.n_pages() > 0 {
+            carousel.scroll_to(&carousel.nth_page(0), true);
+        }
+    }
+
+    pub fn scroll_to_details_page(&self) {
+        let carousel = self.imp().main_carousel.get();
+        if carousel.n_pages() > 1 {
+            carousel.scroll_to(&carousel.nth_page(1), true);
+        }
+    }
+
+    pub fn focus_details_row(&self, focus: impl FnOnce() + 'static) {
+        self.scroll_to_details_page();
+        glib::idle_add_local_once(focus);
+    }
+
+    pub fn has_dropdowns(&self) -> bool {
+        let imp = self.imp();
+        imp.namedropdown.get().is_visible() || imp.subdropdown.get().is_visible()
+    }
+
+    pub fn has_episode_toolbar(&self) -> bool {
+        self.imp().toolbar.get().is_visible()
+    }
+
+    pub fn episode_toolbar_widgets(&self) -> Vec<gtk::Widget> {
+        let imp = self.imp();
+        if !imp.toolbar.get().is_visible() {
+            return Vec::new();
+        }
+        vec![
+            imp.seasonlist.get().upcast(),
+            imp.season_view_more.get().upcast(),
+        ]
+    }
+
+    pub fn clear_episode_toolbar_focus(&self) {
+        for widget in self.episode_toolbar_widgets() {
+            crate::tv::set_tv_focused(&widget, false);
+        }
+    }
+
+    pub fn focus_episode_toolbar(&self, index: usize) {
+        self.clear_episode_toolbar_focus();
+        self.clear_episode_focus();
+        if let Some(widget) = self.episode_toolbar_widgets().get(index) {
+            crate::tv::set_tv_focused(widget, true);
+        }
+        self.imp().episode_subzone.set(0);
+    }
+
+    pub fn focus_episode_list(&self) {
+        self.clear_episode_toolbar_focus();
+        self.focus_default_episode();
+        self.imp().episode_subzone.set(1);
+    }
+
+    pub fn is_episode_toolbar_focused(&self) -> bool {
+        self.imp().episode_subzone.get() == 0
+    }
+
+    pub fn navigate_episode_toolbar(&self, delta: i32) {
+        let widgets = self.episode_toolbar_widgets();
+        if widgets.is_empty() {
+            return;
+        }
+        let current = widgets
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, widgets.len() as i32 - 1) as usize;
+        self.focus_episode_toolbar(next);
+    }
+
+    pub fn activate_episode_toolbar(&self) {
+        let widgets = self.episode_toolbar_widgets();
+        let index = widgets
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0);
+        let imp = self.imp();
+        if index == 0 {
+            let dropdown = imp.seasonlist.get();
+            dropdown.grab_focus();
+            gtk::prelude::WidgetExt::activate(&dropdown);
+        } else if index == 1 {
+            imp.season_view_more.get().emit_clicked();
+        }
+    }
+
+    pub fn has_episode_list(&self) -> bool {
+        let imp = self.imp();
+        imp.episode_list_bin.get().is_visible()
+            && imp.episode_stack.visible_child_name().as_deref() == Some("view")
+            && imp.selection.n_items() > 0
+    }
+
+    pub fn focus_default_action(&self) {
+        self.set_action_focus(0);
+    }
+
+    pub fn clear_action_focus(&self) {
+        for widget in self.action_focus_widgets() {
+            crate::tv::set_tv_focused(&widget, false);
+        }
+    }
+
+    pub fn action_focus_widgets(&self) -> Vec<gtk::Widget> {
+        let imp = self.imp();
+        vec![
+            imp.playbutton.get().upcast(),
+            imp.actionbox.favourite_button().upcast(),
+            imp.actionbox.menu_button().upcast(),
+        ]
+    }
+
+    pub fn top_bar_action_widgets(&self) -> Vec<gtk::Widget> {
+        let mut widgets = self.action_focus_widgets();
+        if let Some(btn) = self.ensure_tv_subtitle_button() {
+            widgets.push(btn.upcast());
+        }
+        widgets
+    }
+
+    pub fn media_focus_widgets(&self) -> Vec<gtk::Widget> {
+        let imp = self.imp();
+        let mut widgets = Vec::new();
+        if imp.namedropdown.get().is_visible() {
+            widgets.push(imp.namedropdown.get().upcast());
+        }
+        if imp.subdropdown.get().is_visible() {
+            widgets.push(imp.subdropdown.get().upcast());
+        }
+        widgets
+    }
+
+    pub fn clear_media_focus(&self) {
+        for widget in self.media_focus_widgets() {
+            crate::tv::set_tv_focused(&widget, false);
+        }
+    }
+
+    pub fn set_media_focus(&self, index: usize) {
+        self.clear_media_focus();
+        if let Some(widget) = self.media_focus_widgets().get(index) {
+            crate::tv::set_tv_focused(widget, true);
+        }
+    }
+
+    pub fn top_bar_spatial_widgets(&self) -> Vec<gtk::Widget> {
+        self.top_bar_focus_widgets()
+    }
+
+    pub fn focused_top_bar_widget(&self) -> Option<gtk::Widget> {
+        self.top_bar_spatial_widgets()
+            .into_iter()
+            .find(|widget| widget.has_css_class("tv-focused"))
+    }
+
+    pub fn set_top_bar_widget_focus(&self, widget: &gtk::Widget) {
+        self.clear_top_bar_focus();
+        crate::tv::set_tv_focused(widget, true);
+    }
+
+    pub fn navigate_top_bar_spatial(&self, dx: i32, dy: i32) -> bool {
+        let actions = self.top_bar_action_widgets();
+        let media = self.media_focus_widgets();
+        if actions.is_empty() && media.is_empty() {
+            return false;
+        }
+
+        let current = self.focused_top_bar_widget().unwrap_or_else(|| {
+            actions
+                .first()
+                .or_else(|| media.first())
+                .cloned()
+                .expect("top bar widgets exist")
+        });
+
+        let in_actions = actions.iter().any(|widget| widget == &current);
+        let in_media = media.iter().any(|widget| widget == &current);
+
+        if dy != 0 {
+            if in_media {
+                let imp = self.imp();
+                let video = imp.namedropdown.get().upcast::<gtk::Widget>();
+                let sub = imp.subdropdown.get().upcast::<gtk::Widget>();
+                if current == video && dy > 0 && sub.is_visible() {
+                    self.set_top_bar_widget_focus(&sub);
+                    return true;
+                }
+                if current == sub && dy < 0 && video.is_visible() {
+                    self.set_top_bar_widget_focus(&video);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if dx == 0 {
+            return false;
+        }
+
+        if in_media {
+            let pos = media.iter().position(|widget| widget == &current);
+            if let Some(index) = pos {
+                let next = (index as i32 + dx).clamp(0, media.len() as i32 - 1) as usize;
+                if next != index {
+                    self.set_top_bar_widget_focus(&media[next]);
+                    return true;
+                }
+            }
+            if dx < 0
+                && let Some(widget) = actions.last()
+            {
+                self.set_top_bar_widget_focus(widget);
+                return true;
+            }
+            return false;
+        }
+
+        if in_actions {
+            let pos = actions.iter().position(|widget| widget == &current);
+            if let Some(index) = pos {
+                let next = (index as i32 + dx).clamp(0, actions.len() as i32 - 1) as usize;
+                if next != index {
+                    self.set_top_bar_widget_focus(&actions[next]);
+                    return true;
+                }
+            }
+            if dx > 0
+                && let Some(widget) = media.first()
+            {
+                self.set_top_bar_widget_focus(widget);
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn activate_focused_top_bar(&self) {
+        let Some(widget) = self.focused_top_bar_widget() else {
+            return;
+        };
+        let imp = self.imp();
+        let play = imp.playbutton.get().upcast::<gtk::Widget>();
+        let fav = imp.actionbox.favourite_button().upcast::<gtk::Widget>();
+        let menu = imp.actionbox.menu_button().upcast::<gtk::Widget>();
+        let video = imp.namedropdown.get().upcast::<gtk::Widget>();
+        let sub = imp.subdropdown.get().upcast::<gtk::Widget>();
+        if widget == play {
+            imp.playbutton.emit_clicked();
+        } else if widget == fav {
+            imp.actionbox.favourite_button().emit_clicked();
+        } else if widget == menu {
+            let btn = imp.actionbox.menu_button();
+            btn.grab_focus();
+            btn.popup();
+        } else if imp
+            .tv_subtitle_btn
+            .borrow()
+            .as_ref()
+            .is_some_and(|btn| widget == btn.clone().upcast::<gtk::Widget>())
+        {
+            self.open_subtitle_search();
+        } else if widget == video || widget == sub {
+            widget.grab_focus();
+            gtk::prelude::WidgetExt::activate(&widget);
+        }
+    }
+
+    pub fn focus_default_top_bar_spatial(&self) {
+        if let Some(widget) = self.top_bar_spatial_widgets().first() {
+            self.set_top_bar_widget_focus(widget);
+        }
+    }
+
+    pub fn top_bar_focus_widgets(&self) -> Vec<gtk::Widget> {
+        let mut widgets = self.top_bar_action_widgets();
+        widgets.extend(self.media_focus_widgets());
+        widgets
+    }
+
+    pub fn subtitle_search_available(&self) -> bool {
+        if !crate::tv::is_tv_mode_active() {
+            return false;
+        }
+        if !(SETTINGS.subtitle_provider_enabled("opensubtitles")
+            || SETTINGS.subtitle_provider_enabled("subdl"))
+        {
+            return false;
+        }
+        let item = self.item();
+        matches!(
+            item.item_type().as_str(),
+            "Movie" | "Episode" | "Video" | "Series"
+        )
+    }
+
+    pub fn ensure_tv_subtitle_button(&self) -> Option<gtk::Button> {
+        if !self.subtitle_search_available() {
+            return None;
+        }
+        let imp = self.imp();
+        if let Some(btn) = imp.tv_subtitle_btn.borrow().clone() {
+            btn.set_visible(true);
+            return Some(btn);
+        }
+        let btn = gtk::Button::with_label(&gettext("Find Subtitles"));
+        btn.add_css_class("pill");
+        btn.set_valign(gtk::Align::Center);
+        let obj = self.clone();
+        btn.connect_clicked(move |_| obj.open_subtitle_search());
+        if let Some(parent) = imp
+            .playbutton
+            .get()
+            .parent()
+            .and_then(|widget| widget.downcast::<gtk::Box>().ok())
+        {
+            parent.insert_child_after(&btn, Some(&imp.actionbox.get()));
+        }
+        *imp.tv_subtitle_btn.borrow_mut() = Some(btn.clone());
+        Some(btn)
+    }
+
+    pub fn clear_top_bar_focus(&self) {
+        for widget in self.top_bar_focus_widgets() {
+            crate::tv::set_tv_focused(&widget, false);
+        }
+    }
+
+    pub fn set_top_bar_focus(&self, index: usize) {
+        self.clear_top_bar_focus();
+        if let Some(widget) = self.top_bar_focus_widgets().get(index) {
+            crate::tv::set_tv_focused(widget, true);
+        }
+    }
+
+    pub fn focus_default_top_bar(&self) {
+        self.set_top_bar_focus(0);
+    }
+
+    pub fn navigate_top_bar(&self, delta: i32) {
+        let count = self.top_bar_focus_widgets().len() as i32;
+        if count == 0 {
+            return;
+        }
+        let current = self
+            .top_bar_focus_widgets()
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, count - 1) as usize;
+        self.set_top_bar_focus(next);
+    }
+
+    pub fn activate_top_bar_action_at(&self, index: usize) {
+        let imp = self.imp();
+        let widgets = self.top_bar_action_widgets();
+        let Some(widget) = widgets.get(index) else {
+            return;
+        };
+        if widget == &imp.playbutton.get().upcast::<gtk::Widget>() {
+            imp.playbutton.emit_clicked();
+        } else if widget == &imp.actionbox.favourite_button().upcast::<gtk::Widget>() {
+            imp.actionbox.favourite_button().emit_clicked();
+        } else if widget == &imp.actionbox.menu_button().upcast::<gtk::Widget>() {
+            imp.actionbox.menu_button().popup();
+        } else if imp
+            .tv_subtitle_btn
+            .borrow()
+            .as_ref()
+            .is_some_and(|btn| widget == &btn.clone().upcast::<gtk::Widget>())
+        {
+            self.open_subtitle_search();
+        }
+    }
+
+    pub fn activate_media_at(&self, index: usize) {
+        let widgets = self.media_focus_widgets();
+        let Some(widget) = widgets.get(index) else {
+            return;
+        };
+        widget.grab_focus();
+        gtk::prelude::WidgetExt::activate(widget);
+    }
+
+    pub fn activate_top_bar_at(&self, index: usize) {
+        let imp = self.imp();
+        let widgets = self.top_bar_focus_widgets();
+        let Some(widget) = widgets.get(index) else {
+            return;
+        };
+        if widget == &imp.playbutton.get().upcast::<gtk::Widget>() {
+            imp.playbutton.emit_clicked();
+        } else if widget == &imp.actionbox.favourite_button().upcast::<gtk::Widget>() {
+            imp.actionbox.favourite_button().emit_clicked();
+        } else if widget == &imp.actionbox.menu_button().upcast::<gtk::Widget>() {
+            imp.actionbox.menu_button().popup();
+        } else if imp
+            .tv_subtitle_btn
+            .borrow()
+            .as_ref()
+            .is_some_and(|btn| widget == &btn.clone().upcast::<gtk::Widget>())
+        {
+            self.open_subtitle_search();
+        } else if widget == &imp.namedropdown.get().upcast::<gtk::Widget>()
+            || widget == &imp.subdropdown.get().upcast::<gtk::Widget>()
+        {
+            widget.grab_focus();
+            gtk::prelude::WidgetExt::activate(widget);
+        }
+    }
+
+    pub fn set_action_focus(&self, index: usize) {
+        self.clear_action_focus();
+        if let Some(widget) = self.action_focus_widgets().get(index) {
+            crate::tv::set_tv_focused(widget, true);
+        }
+    }
+
+    pub fn navigate_actions(&self, delta: i32) {
+        let count = self.action_focus_widgets().len() as i32;
+        if count == 0 {
+            return;
+        }
+        let current = self
+            .action_focus_widgets()
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, count - 1) as usize;
+        self.set_action_focus(next);
+    }
+
+    pub fn activate_action_at(&self, index: usize) {
+        let imp = self.imp();
+        match index {
+            0 => imp.playbutton.emit_clicked(),
+            1 => imp.actionbox.favourite_button().emit_clicked(),
+            2 => imp.actionbox.menu_button().popup(),
+            _ => {}
+        }
+    }
+
+    pub fn activate_focused_action(&self) {
+        let index = self
+            .action_focus_widgets()
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0);
+        self.activate_action_at(index);
+    }
+
+    pub fn open_subtitle_search(&self) {
+        use crate::subtitles::{
+            SubtitleSearchDialog,
+            preferred_subtitle_language_code,
+        };
+
+        let title = self
+            .current_item()
+            .map(|item| item.name())
+            .or_else(|| self.name())
+            .unwrap_or_default();
+        let imdb_id = self.imp().imdb_id.borrow().clone();
+        let dialog = SubtitleSearchDialog::new(
+            &title,
+            &preferred_subtitle_language_code(),
+            imdb_id.as_deref(),
+        );
+        dialog.connect_subtitle_downloaded(glib::clone!(
+            #[weak(rename_to = obj)]
+            self,
+            move |path| {
+                obj.imp()
+                    .pending_external_sub
+                    .replace(Some(path.display().to_string()));
+                obj.toast(gettext("Subtitle will load on play"));
+            }
+        ));
+        dialog.present(self.root().as_ref());
+    }
+
+    pub fn focus_default_dropdown(&self) {
+        let imp = self.imp();
+        if imp.namedropdown.get().is_visible() {
+            crate::tv::set_tv_focused(&imp.namedropdown.get(), true);
+        } else if imp.subdropdown.get().is_visible() {
+            crate::tv::set_tv_focused(&imp.subdropdown.get(), true);
+        }
+    }
+
+    pub fn clear_dropdown_focus(&self) {
+        let imp = self.imp();
+        crate::tv::set_tv_focused(&imp.namedropdown.get(), false);
+        crate::tv::set_tv_focused(&imp.subdropdown.get(), false);
+    }
+
+    pub fn navigate_dropdowns(&self, delta: i32) {
+        let imp = self.imp();
+        if delta > 0 && imp.namedropdown.get().is_visible() && imp.subdropdown.get().is_visible() {
+            self.clear_dropdown_focus();
+            crate::tv::set_tv_focused(&imp.subdropdown.get(), true);
+        } else if delta < 0 && imp.subdropdown.get().is_visible() {
+            self.clear_dropdown_focus();
+            crate::tv::set_tv_focused(&imp.namedropdown.get(), true);
+        } else {
+            self.focus_default_dropdown();
+        }
+    }
+
+    pub fn activate_focused_dropdown(&self) {
+        let imp = self.imp();
+        let dropdown = if imp.subdropdown.get().has_css_class("tv-focused") {
+            imp.subdropdown.get()
+        } else {
+            imp.namedropdown.get()
+        };
+        dropdown.grab_focus();
+        gtk::prelude::WidgetExt::activate(&dropdown);
+    }
+
+    pub fn focus_default_episode(&self) {
+        let imp = self.imp();
+        if imp.selection.n_items() > 0 {
+            imp.selection.set_selected(0);
+            imp.itemlist.get().scroll_to(0, ListScrollFlags::NONE, None);
+        }
+        self.scroll_episode_list_into_view();
+    }
+
+    pub fn scroll_episode_list_into_view(&self) {
+        let imp = self.imp();
+        if !imp.episode_list_bin.get().is_visible() {
+            return;
+        }
+        self.scroll_to_hero_page();
+        super::fix::scroll_widget_to_row_center(&imp.episode_list_bin.get());
+    }
+
+    pub fn mediainfo_card_widgets(&self) -> Vec<gtk::Widget> {
+        let imp = self.imp();
+        if !imp.mediainforevealer.reveals_child() {
+            return Vec::new();
+        }
+        let mut cards = Vec::new();
+        let mut source = imp.mediainfobox.first_child();
+        while let Some(singlebox) = source {
+            let mut child = singlebox.first_child();
+            while let Some(widget) = child {
+                if widget.is::<gtk::ScrolledWindow>()
+                    && let Some(row) = widget.first_child()
+                {
+                    let mut card = row.first_child();
+                    while let Some(card_widget) = card {
+                        if card_widget.has_css_class("card") {
+                            cards.push(card_widget.clone());
+                        }
+                        card = card_widget.next_sibling();
+                    }
+                }
+                child = widget.next_sibling();
+            }
+            source = singlebox.next_sibling();
+        }
+        cards
+    }
+
+    pub fn mediainfo_card_count(&self) -> usize {
+        self.mediainfo_card_widgets().len()
+    }
+
+    pub fn clear_mediainfo_focus(&self) {
+        for widget in self.mediainfo_card_widgets() {
+            crate::tv::set_tv_focused(&widget, false);
+        }
+        self.imp().mediainfo_selected.set(None);
+    }
+
+    pub fn ensure_mediainfo_selection(&self) {
+        if self.mediainfo_card_count() == 0 {
+            return;
+        }
+        if self.imp().mediainfo_selected.get().is_none() {
+            self.set_mediainfo_selection(0);
+        }
+    }
+
+    fn set_mediainfo_selection(&self, index: usize) {
+        let cards = self.mediainfo_card_widgets();
+        if cards.is_empty() {
+            return;
+        }
+        let index = index.min(cards.len() - 1);
+        let prev = self.imp().mediainfo_selected.get();
+        if prev == Some(index) {
+            return;
+        }
+        if let Some(prev_index) = prev
+            && let Some(widget) = cards.get(prev_index)
+        {
+            crate::tv::set_tv_focused(widget, false);
+        }
+        if let Some(widget) = cards.get(index) {
+            crate::tv::set_tv_focused(widget, true);
+            super::fix::scroll_widget_to_column_center(widget);
+        }
+        self.imp().mediainfo_selected.set(Some(index));
+    }
+
+    pub fn move_mediainfo_selection(&self, delta: i32) {
+        let count = self.mediainfo_card_count();
+        if count == 0 {
+            return;
+        }
+        let current = self.imp().mediainfo_selected.get().unwrap_or(0);
+        let next = (current as i32 + delta).clamp(0, count as i32 - 1) as usize;
+        self.set_mediainfo_selection(next);
+    }
+
+    pub fn scroll_mediainfo_into_view(&self) {
+        let obj = self.clone();
+        self.focus_details_row(move || {
+            super::fix::scroll_widget_to_row_center(&obj.imp().mediainforevealer.get());
+            obj.ensure_mediainfo_selection();
+        });
+    }
+
+    pub fn clear_episode_focus(&self) {
+        self.imp()
+            .selection
+            .set_selected(gtk::INVALID_LIST_POSITION);
+    }
+
+    pub fn navigate_episodes(&self, delta: i32) {
+        let imp = self.imp();
+        let count = imp.selection.n_items() as i32;
+        if count == 0 {
+            return;
+        }
+        let current = if imp.selection.selected() == gtk::INVALID_LIST_POSITION {
+            0
+        } else {
+            imp.selection.selected() as i32
+        };
+        let next = (current + delta).clamp(0, count - 1) as u32;
+        imp.selection.set_selected(next);
+        imp.itemlist
+            .get()
+            .scroll_to(next, ListScrollFlags::NONE, None);
+    }
+
+    pub fn activate_focused_episode(&self) {
+        let imp = self.imp();
+        let index = imp.selection.selected();
+        if index == gtk::INVALID_LIST_POSITION {
+            return;
+        }
+        if let Some(item) = imp.selection.item(index).and_downcast::<TuObject>() {
+            item.item().activate(self);
+        }
     }
 }
 

--- a/src/ui/widgets/item_actionbox.rs
+++ b/src/ui/widgets/item_actionbox.rs
@@ -37,6 +37,8 @@ mod imp {
     pub struct ItemActionsBox {
         #[template_child]
         pub favourite_button: TemplateChild<StarToggle>,
+        #[template_child]
+        pub menu_button: TemplateChild<gtk::MenuButton>,
         #[property(get, set, nullable)]
         pub id: RefCell<Option<String>>,
         #[property(get, set, nullable)]
@@ -160,6 +162,20 @@ impl ItemActionsBox {
             ))
             .build()]);
         if self.is_playable() {
+            action_group.add_action_entries([gio::ActionEntry::builder("subtitles")
+                .activate(glib::clone!(
+                    #[weak(rename_to = obj)]
+                    self,
+                    move |_, _, _| {
+                        if let Some(page) = obj
+                            .root()
+                            .and_downcast::<crate::ui::widgets::item::ItemPage>()
+                        {
+                            page.open_subtitle_search();
+                        }
+                    }
+                ))
+                .build()]);
             if self.played() {
                 action_group.add_action_entries([gio::ActionEntry::builder("unplayed")
                     .activate(glib::clone!(
@@ -237,5 +253,13 @@ impl ItemActionsBox {
 
     pub fn set_btn_active(&self, active: bool) {
         self.imp().favourite_button.set_active(active);
+    }
+
+    pub fn favourite_button(&self) -> StarToggle {
+        self.imp().favourite_button.get()
+    }
+
+    pub fn menu_button(&self) -> gtk::MenuButton {
+        self.imp().menu_button.get()
     }
 }

--- a/src/ui/widgets/lazy_diff_view/mod.rs
+++ b/src/ui/widgets/lazy_diff_view/mod.rs
@@ -30,6 +30,8 @@ use gtk::{
 mod animated_bin;
 mod virtual_viewport;
 
+use crate::ui::widgets::tu_list_item::TuListItem;
+
 use animated_bin::AnimatedBin;
 use virtual_viewport::VirtualViewport;
 
@@ -358,6 +360,50 @@ impl LazyDiffView {
 
     pub fn len(&self) -> usize {
         self.imp().items.borrow().len()
+    }
+
+    pub fn key_at(&self, index: usize) -> Option<String> {
+        self.imp()
+            .items
+            .borrow()
+            .get(index)
+            .map(|row| row.key.clone())
+    }
+
+    pub fn scroll_to_index(&self, index: usize) {
+        let len = self.len();
+        if len == 0 {
+            return;
+        }
+        let index = index.min(len - 1);
+        let adj = match self.orientation() {
+            Orientation::Horizontal => self.scroll().hadjustment(),
+            _ => self.scroll().vadjustment(),
+        };
+        let pitch = self.item_pitch() as f64;
+        let target = index as f64 * pitch;
+        let page = adj.page_size();
+        let upper = (adj.upper() - page).max(0.0);
+        let value = (target + pitch * 0.5 - page * 0.5).clamp(0.0, upper);
+        adj.set_value(value);
+    }
+
+    pub fn row_widget_for_key(&self, key: &str) -> Option<gtk::Widget> {
+        self.imp()
+            .rows
+            .borrow()
+            .get(key)
+            .map(|row| row.child.clone())
+    }
+
+    pub fn rebind_active_rows(&self) {
+        let binder = self.imp().widget_binder.borrow().clone();
+        let Some(binder) = binder else {
+            return;
+        };
+        for row in self.imp().rows.borrow().values() {
+            row.rebind(&binder);
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -940,6 +986,10 @@ impl VirtualRow {
         (self.widget_binder)(&self.child, self.item.borrow().as_ref());
     }
 
+    fn rebind(&self, binder: &WidgetBinder) {
+        binder(&self.child, self.item.borrow().as_ref());
+    }
+
     fn set_orientation(&self, orientation: Orientation) {
         self.orientation.set(orientation);
         self.apply_orientation();
@@ -969,6 +1019,9 @@ impl VirtualRow {
 
     fn reset_for_reuse(&self) {
         self.container.set_sensitive(true);
+        if let Ok(tu_item) = self.child.clone().downcast::<TuListItem>() {
+            tu_item.set_poster_focused(false);
+        }
         self.reset_animation_state();
     }
 

--- a/src/ui/widgets/liked.rs
+++ b/src/ui/widgets/liked.rs
@@ -1,9 +1,10 @@
+use gtk::prelude::*;
+
 use gettextrs::gettext;
 use glib::Object;
 use gtk::{
     gio,
     glib,
-    prelude::*,
     subclass::prelude::*,
 };
 
@@ -104,6 +105,22 @@ impl Default for LikedPage {
 impl LikedPage {
     pub fn new() -> Self {
         Object::builder().build()
+    }
+
+    pub fn focus_hortu_rows(&self) -> Vec<crate::ui::widgets::hortu_scrolled::HortuScrolled> {
+        let imp = self.imp();
+        vec![
+            imp.moviehortu.get(),
+            imp.serieshortu.get(),
+            imp.episodehortu.get(),
+            imp.peoplehortu.get(),
+            imp.albumhortu.get(),
+            imp.boxsethortu.get(),
+            imp.tvhortu.get(),
+        ]
+        .into_iter()
+        .filter(|row| row.is_visible() && row.item_count() > 0)
+        .collect()
     }
 
     pub fn update(&self) {

--- a/src/ui/widgets/list.rs
+++ b/src/ui/widgets/list.rs
@@ -3,6 +3,7 @@ use glib::Object;
 use gtk::{
     gio,
     glib,
+    prelude::*,
     subclass::prelude::*,
 };
 
@@ -46,6 +47,8 @@ mod imp {
         pub item: OnceCell<TuItem>,
         #[template_child]
         pub stack: TemplateChild<gtk::Stack>,
+        #[template_child]
+        pub stack_switcher: TemplateChild<gtk::StackSwitcher>,
     }
 
     #[glib::object_subclass]
@@ -212,6 +215,56 @@ impl ListPage {
             };
 
             stack.add_titled(&page, Some(name), title);
+        }
+    }
+
+    pub fn tab_count(&self) -> usize {
+        let stack = self.imp().stack.get();
+        let mut count = 0usize;
+        let mut child = stack.first_child();
+        while child.is_some() {
+            count += 1;
+            child = child.and_then(|widget| widget.next_sibling());
+        }
+        count
+    }
+
+    pub fn visible_grid(&self) -> Option<SingleGrid> {
+        self.imp()
+            .stack
+            .visible_child()
+            .and_downcast::<SingleGrid>()
+    }
+
+    pub fn switch_tab(&self, delta: i32) {
+        let stack = self.imp().stack.get();
+        let mut names = Vec::new();
+        let mut child = stack.first_child();
+        while let Some(widget) = child {
+            let page = stack.page(&widget);
+            if let Some(name) = page.name() {
+                names.push(name.to_string());
+            }
+            child = widget.next_sibling();
+        }
+        if names.is_empty() {
+            return;
+        }
+        let current = stack.visible_child_name().unwrap_or_default().to_string();
+        let pos = names.iter().position(|name| name == &current).unwrap_or(0) as i32;
+        let next = (pos + delta).clamp(0, names.len() as i32 - 1) as usize;
+        stack.set_visible_child_name(&names[next]);
+        self.focus_current_tab();
+    }
+
+    pub fn focus_current_tab(&self) {
+        let switcher = self.imp().stack_switcher.get();
+        let mut child = switcher.first_child();
+        while let Some(widget) = child {
+            if let Ok(button) = widget.clone().downcast::<gtk::ToggleButton>() {
+                crate::tv::set_tv_focused(&button, button.is_active());
+            }
+            child = widget.next_sibling();
         }
     }
 }

--- a/src/ui/widgets/media_viewer.rs
+++ b/src/ui/widgets/media_viewer.rs
@@ -299,6 +299,10 @@ impl MediaViewer {
         animation.play();
     }
 
+    pub fn dismiss(&self) {
+        self.close();
+    }
+
     fn close(&self) {
         if self.fullscreened() {
             self.activate_action("win.toggle-fullscreen", None).unwrap();
@@ -316,6 +320,18 @@ impl MediaViewer {
 
     pub fn view_image(&self, image: gtk::gdk::Paintable) {
         self.imp().media.view_image(&image);
+    }
+
+    pub fn is_revealed(&self) -> bool {
+        self.is_visible() && self.imp().revealer.get().reveal_child()
+    }
+
+    pub fn focus_menu(&self) {
+        self.imp().menu.grab_focus();
+    }
+
+    pub fn reveal_header_for_tv(&self, reveal: bool) {
+        self.reveal_headerbar(reveal);
     }
 
     fn reveal_headerbar(&self, reveal: bool) {

--- a/src/ui/widgets/music_album.rs
+++ b/src/ui/widgets/music_album.rs
@@ -97,7 +97,10 @@ pub(crate) mod imp {
         pub artisthortu: TemplateChild<HortuScrolled>,
         #[template_child]
         pub actionbox: TemplateChild<ItemActionsBox>,
+        #[template_child]
+        pub play_button: TemplateChild<gtk::Button>,
         pub signal_id: RefCell<Option<SignalHandlerId>>,
+        pub song_focus_index: RefCell<usize>,
     }
 
     #[glib::object_subclass]
@@ -406,5 +409,126 @@ impl AlbumPage {
         };
         let active_core_song = widget.downcast::<SongWidget>().unwrap().coresong();
         bing_song_model!(self, active_model, active_core_song);
+    }
+
+    pub fn focus_hortu_rows(&self) -> Vec<super::hortu_scrolled::HortuScrolled> {
+        let imp = self.imp();
+        [imp.recommendhortu.get(), imp.artisthortu.get()]
+            .into_iter()
+            .filter(|row| row.is_visible() && row.item_count() > 0)
+            .collect()
+    }
+
+    pub fn song_widgets(&self) -> Vec<SongWidget> {
+        let mut songs = Vec::new();
+        let listbox = self.imp().listbox.get();
+        let mut child = listbox.first_child();
+        while let Some(disc) = child {
+            if let Some(discbox) = disc.downcast_ref::<DiscBox>() {
+                let mut song_child = discbox.imp().listbox.first_child();
+                while let Some(widget) = song_child {
+                    if let Some(song) = widget.downcast_ref::<SongWidget>() {
+                        songs.push(song.clone());
+                    }
+                    song_child = widget.next_sibling();
+                }
+            }
+            child = disc.next_sibling();
+        }
+        songs
+    }
+
+    pub fn focus_default_action(&self) {
+        crate::tv::set_tv_focused(&self.imp().play_button.get(), true);
+    }
+
+    pub fn clear_action_focus(&self) {
+        crate::tv::set_tv_focused(&self.imp().play_button.get(), false);
+        crate::tv::set_tv_focused(
+            &self
+                .imp()
+                .actionbox
+                .favourite_button()
+                .upcast::<gtk::Widget>(),
+            false,
+        );
+        crate::tv::set_tv_focused(
+            &self.imp().actionbox.menu_button().upcast::<gtk::Widget>(),
+            false,
+        );
+    }
+
+    pub fn navigate_actions(&self, delta: i32) {
+        let widgets = [
+            self.imp().play_button.get().upcast::<gtk::Widget>(),
+            self.imp()
+                .actionbox
+                .favourite_button()
+                .upcast::<gtk::Widget>(),
+            self.imp().actionbox.menu_button().upcast::<gtk::Widget>(),
+        ];
+        let current = widgets
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, widgets.len() as i32 - 1) as usize;
+        self.clear_action_focus();
+        crate::tv::set_tv_focused(&widgets[next], true);
+    }
+
+    pub fn activate_focused_action(&self) {
+        let widgets = [
+            self.imp().play_button.get().upcast::<gtk::Widget>(),
+            self.imp()
+                .actionbox
+                .favourite_button()
+                .upcast::<gtk::Widget>(),
+            self.imp().actionbox.menu_button().upcast::<gtk::Widget>(),
+        ];
+        let index = widgets
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0);
+        match index {
+            0 => self.imp().play_button.emit_clicked(),
+            1 => self.imp().actionbox.favourite_button().emit_clicked(),
+            2 => self.imp().actionbox.menu_button().popup(),
+            _ => {}
+        }
+    }
+
+    pub fn focus_default_song(&self) {
+        if let Some(song) = self.song_widgets().first() {
+            crate::tv::set_tv_focused(song, true);
+            *self.imp().song_focus_index.borrow_mut() = 0;
+        }
+    }
+
+    pub fn clear_song_focus(&self) {
+        for song in self.song_widgets() {
+            crate::tv::set_tv_focused(&song, false);
+        }
+    }
+
+    pub fn navigate_songs(&self, delta: i32) {
+        let songs = self.song_widgets();
+        if songs.is_empty() {
+            return;
+        }
+        let current = *self.imp().song_focus_index.borrow() as i32;
+        let next = (current + delta).clamp(0, songs.len() as i32 - 1) as usize;
+        self.clear_song_focus();
+        *self.imp().song_focus_index.borrow_mut() = next;
+        if let Some(song) = songs.get(next) {
+            crate::tv::set_tv_focused(song, true);
+        }
+    }
+
+    pub fn activate_focused_song(&self) {
+        let songs = self.song_widgets();
+        let index = *self.imp().song_focus_index.borrow();
+        if let Some(song) = songs.get(index) {
+            self.song_activated(song.clone());
+        }
     }
 }

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -520,4 +520,152 @@ impl OtherPage {
             }
         }
     }
+
+    pub fn focus_hortu_rows(&self) -> Vec<super::hortu_scrolled::HortuScrolled> {
+        let imp = self.imp();
+        [
+            imp.actorhortu.get(),
+            imp.moviehortu.get(),
+            imp.serieshortu.get(),
+            imp.episodehortu.get(),
+            imp.videohortu.get(),
+        ]
+        .into_iter()
+        .filter(|row| row.is_visible() && row.item_count() > 0)
+        .collect()
+    }
+
+    pub fn carousel_page_count(&self) -> u32 {
+        self.imp().main_carousel.n_pages()
+    }
+
+    pub fn navigate_carousel(&self, delta: i32) {
+        let carousel = self.imp().main_carousel.get();
+        let count = carousel.n_pages() as i32;
+        if count <= 1 {
+            return;
+        }
+        let current = carousel.position() as i32;
+        let next = (current + delta).clamp(0, count - 1) as u32;
+        let page = carousel.nth_page(next);
+        carousel.scroll_to(&page, true);
+    }
+
+    pub fn has_episode_list(&self) -> bool {
+        self.imp().selection.n_items() > 0 && self.imp().episode_list_revealer.get().reveals_child()
+    }
+
+    pub fn focus_default_action(&self) {
+        if self.imp().play_button.is_visible() {
+            crate::tv::set_tv_focused(&self.imp().play_button.get(), true);
+        } else {
+            crate::tv::set_tv_focused(
+                &self
+                    .imp()
+                    .actionbox
+                    .favourite_button()
+                    .upcast::<gtk::Widget>(),
+                true,
+            );
+        }
+    }
+
+    pub fn clear_action_focus(&self) {
+        crate::tv::set_tv_focused(&self.imp().play_button.get(), false);
+        crate::tv::set_tv_focused(
+            &self
+                .imp()
+                .actionbox
+                .favourite_button()
+                .upcast::<gtk::Widget>(),
+            false,
+        );
+        crate::tv::set_tv_focused(
+            &self.imp().actionbox.menu_button().upcast::<gtk::Widget>(),
+            false,
+        );
+    }
+
+    pub fn navigate_actions(&self, delta: i32) {
+        let mut widgets = Vec::new();
+        if self.imp().play_button.is_visible() {
+            widgets.push(self.imp().play_button.get().upcast::<gtk::Widget>());
+        }
+        widgets.push(
+            self.imp()
+                .actionbox
+                .favourite_button()
+                .upcast::<gtk::Widget>(),
+        );
+        widgets.push(self.imp().actionbox.menu_button().upcast::<gtk::Widget>());
+        let current = widgets
+            .iter()
+            .position(|widget| widget.has_css_class("tv-focused"))
+            .unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, widgets.len() as i32 - 1) as usize;
+        self.clear_action_focus();
+        crate::tv::set_tv_focused(&widgets[next], true);
+    }
+
+    pub fn activate_focused_action(&self) {
+        if self.imp().play_button.is_visible() && self.imp().play_button.has_css_class("tv-focused")
+        {
+            self.imp().play_button.emit_clicked();
+            return;
+        }
+        if self
+            .imp()
+            .actionbox
+            .favourite_button()
+            .has_css_class("tv-focused")
+        {
+            self.imp().actionbox.favourite_button().emit_clicked();
+        } else if self
+            .imp()
+            .actionbox
+            .menu_button()
+            .has_css_class("tv-focused")
+        {
+            self.imp().actionbox.menu_button().popup();
+        }
+    }
+
+    pub fn focus_default_episode(&self) {
+        if self.imp().selection.n_items() > 0 {
+            self.imp().selection.set_selected(0);
+        }
+    }
+
+    pub fn clear_episode_focus(&self) {
+        self.imp()
+            .selection
+            .set_selected(gtk::INVALID_LIST_POSITION);
+    }
+
+    pub fn navigate_episodes(&self, delta: i32) {
+        let count = self.imp().selection.n_items() as i32;
+        if count == 0 {
+            return;
+        }
+        let current = if self.imp().selection.selected() == gtk::INVALID_LIST_POSITION {
+            0
+        } else {
+            self.imp().selection.selected() as i32
+        };
+        let next = (current + delta).clamp(0, count - 1) as u32;
+        self.imp().selection.set_selected(next);
+        self.imp()
+            .episode_list
+            .scroll_to(next, gtk::ListScrollFlags::NONE, None);
+    }
+
+    pub fn activate_focused_episode(&self) {
+        let index = self.imp().selection.selected();
+        if index == gtk::INVALID_LIST_POSITION {
+            return;
+        }
+        if let Some(tu_obj) = self.imp().selection.item(index).and_downcast::<TuObject>() {
+            tu_obj.item().activate(self);
+        }
+    }
 }

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -6,8 +6,8 @@ use std::{
 use super::{
     image_paintable::paintable_from_file,
     utils::{
-        TU_ITEM_POST_SIZE,
-        TU_ITEM_VIDEO_SIZE,
+        tu_item_post_size,
+        tu_item_video_size,
     },
 };
 use crate::{
@@ -34,14 +34,9 @@ use gtk::{
 };
 use tracing::warn;
 
-const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
-static IMAGE_LOAD_SEMAPHORE: LazyLock<tokio::sync::Semaphore> = LazyLock::new(|| {
-    tokio::sync::Semaphore::new(
-        std::thread::available_parallelism()
-            .map(|p| p.get())
-            .unwrap_or(4),
-    )
-});
+const IMAGE_LOAD_DELAY: std::time::Duration = std::time::Duration::from_millis(150);
+static IMAGE_LOAD_SEMAPHORE: LazyLock<tokio::sync::Semaphore> =
+    LazyLock::new(|| tokio::sync::Semaphore::new(4));
 
 #[derive(Clone)]
 struct LoadToken {
@@ -245,8 +240,8 @@ impl PictureLoader {
 
     fn configure_picture_size(&self, image_type: &str) {
         let size = match image_type {
-            "Primary" => &TU_ITEM_POST_SIZE,
-            _ => &TU_ITEM_VIDEO_SIZE,
+            "Primary" => tu_item_post_size(),
+            _ => tu_item_video_size(),
         };
         self.imp().picture.set_width_request(size.0);
         self.imp().picture.set_height_request(size.1);

--- a/src/ui/widgets/player_toolbar.rs
+++ b/src/ui/widgets/player_toolbar.rs
@@ -222,16 +222,19 @@ impl PlayerToolbarBox {
         imp.toolbar.set_revealed(false);
     }
 
+    pub fn toggle_playback(&self) {
+        self.on_play_button_clicked();
+    }
+
     #[template_callback]
     fn on_play_button_clicked(&self) {
         let player = &self.imp().player;
         let play_pause_image = &self.imp().play_pause_image.get();
+        player.imp().play_pause();
         if player.imp().state() == gst::State::Playing {
-            player.imp().pause();
-            play_pause_image.set_icon_name(Some("media-playback-start-symbolic"));
-        } else {
-            player.imp().unpause();
             play_pause_image.set_icon_name(Some("media-playback-pause-symbolic"));
+        } else {
+            play_pause_image.set_icon_name(Some("media-playback-start-symbolic"));
         }
     }
 

--- a/src/ui/widgets/search.rs
+++ b/src/ui/widgets/search.rs
@@ -109,6 +109,7 @@ mod imp {
         fn constructed(&self) {
             let obj = self.obj();
             self.parent_constructed();
+            crate::tv::osk::attach_on_screen_keyboard(&self.searchentry.get());
             self.searchscrolled
                 .get()
                 .set_unify_size(UnifySize::Majority);
@@ -245,6 +246,35 @@ impl SearchPage {
         imp.searchscrolled.set_store::<true>(search_results.items);
 
         imp.stack.set_visible_child_name("result");
+    }
+
+    pub fn trigger_search(&self) {
+        let this = self.clone();
+        crate::utils::spawn(async move {
+            this.on_search_activate().await;
+        });
+    }
+
+    pub fn search_scrolled(&self) -> crate::ui::widgets::tuview_scrolled::TuViewScrolled {
+        self.imp().searchscrolled.get()
+    }
+
+    pub fn search_entry(&self) -> gtk::SearchEntry {
+        self.imp().searchentry.get()
+    }
+
+    pub fn filter_rows(&self) -> Vec<adw::SwitchRow> {
+        let imp = self.imp();
+        vec![
+            imp.movie.get(),
+            imp.series.get(),
+            imp.boxset.get(),
+            imp.person.get(),
+            imp.music.get(),
+            imp.audio.get(),
+            imp.video.get(),
+            imp.episode.get(),
+        ]
     }
 
     pub async fn get_search_results<const F: bool>(&self) -> List {

--- a/src/ui/widgets/server_action_row.rs
+++ b/src/ui/widgets/server_action_row.rs
@@ -47,6 +47,10 @@ mod imp {
         pub item: OnceCell<AccountItem>,
         #[template_child]
         pub server_image: TemplateChild<gtk::Image>,
+        #[template_child]
+        pub edit_button: TemplateChild<gtk::Button>,
+        #[template_child]
+        pub delete_button: TemplateChild<gtk::Button>,
     }
 
     #[glib::object_subclass]
@@ -116,6 +120,38 @@ impl ServerActionRow {
         glib::Object::builder()
             .property("item", AccountItem::from_simple(&account))
             .build()
+    }
+
+    pub fn set_tv_focused(&self, focused: bool) {
+        crate::tv::set_tv_focused(self, focused);
+    }
+
+    pub fn tv_focus_widgets(&self) -> Vec<gtk::Widget> {
+        vec![
+            self.clone().upcast::<gtk::Widget>(),
+            self.imp().edit_button.get().upcast(),
+            self.imp().delete_button.get().upcast(),
+        ]
+    }
+
+    pub fn set_tv_column_focus(&self, column: usize) {
+        for (index, widget) in self.tv_focus_widgets().into_iter().enumerate() {
+            crate::tv::set_tv_focused(&widget, index == column);
+        }
+    }
+
+    pub fn clear_tv_column_focus(&self) {
+        for widget in self.tv_focus_widgets() {
+            crate::tv::set_tv_focused(&widget, false);
+        }
+    }
+
+    pub fn activate_column(&self, column: u32) {
+        match column {
+            1 => self.imp().edit_button.get().emit_clicked(),
+            2 => self.imp().delete_button.get().emit_clicked(),
+            _ => adw::prelude::ActionRowExt::activate(self),
+        }
     }
 
     #[template_callback]

--- a/src/ui/widgets/server_panel.rs
+++ b/src/ui/widgets/server_panel.rs
@@ -32,6 +32,11 @@ use crate::{
 
 use super::utils::GlobalToast;
 
+#[derive(Clone)]
+pub struct ServerFocusGroup {
+    pub rows: Vec<gtk::Widget>,
+}
+
 pub(crate) mod imp {
     use glib::subclass::InitializingObject;
 
@@ -345,6 +350,48 @@ impl ServerPanel {
         };
 
         self.toast(gettext("Task started"));
+    }
+
+    pub fn focus_groups(&self) -> Vec<ServerFocusGroup> {
+        let imp = self.imp();
+        [
+            imp.system_log_group.get(),
+            imp.activity_log_group.get(),
+            imp.task_group.get(),
+        ]
+        .into_iter()
+        .map(|group| {
+            let mut rows = Vec::new();
+            let mut child = group.first_child();
+            while let Some(row) = child {
+                let next = row.next_sibling();
+                rows.push(row.upcast());
+                child = next;
+            }
+            ServerFocusGroup { rows }
+        })
+        .filter(|group| !group.rows.is_empty())
+        .collect()
+    }
+
+    pub fn activate_focused_row(
+        &self, groups: &[ServerFocusGroup], group_index: usize, row_index: usize,
+    ) -> bool {
+        let Some(group) = groups.get(group_index) else {
+            return false;
+        };
+        let Some(row) = group.rows.get(row_index) else {
+            return false;
+        };
+        if let Ok(action_row) = row.clone().downcast::<adw::ActionRow>()
+            && let Some(button) = action_row
+                .last_child()
+                .and_then(|child| child.downcast::<gtk::Button>().ok())
+        {
+            button.emit_clicked();
+            return true;
+        }
+        false
     }
 }
 

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -38,6 +38,7 @@ use crate::{
             SimpleListItem,
         },
     },
+    tv::set_tv_focused,
     ui::provider::tu_item::PreferPoster,
     utils::{
         spawn,
@@ -394,6 +395,10 @@ impl SingleGrid {
         Object::new()
     }
 
+    pub fn tuview_scrolled(&self) -> super::tuview_scrolled::TuViewScrolled {
+        self.imp().scrolled.get()
+    }
+
     #[template_callback]
     fn on_view_changed_cb(&self, _param: Option<glib::ParamSpec>, group: &adw::ToggleGroup) {
         let view_type = if group.active_name() == Some(glib::GString::from("grid")) {
@@ -639,5 +644,86 @@ impl SingleGrid {
                 ));
             }
         ));
+    }
+
+    pub fn toolbar_widget_count(&self) -> usize {
+        7
+    }
+
+    pub fn clear_toolbar_focus(&self) {
+        let imp = self.imp();
+        set_tv_focused(&imp.postmenu.get(), false);
+        set_tv_focused(&imp.filter.get(), false);
+        set_tv_focused(&imp.glgroup.get(), false);
+        set_tv_focused(&imp.adgroup.get(), false);
+        set_tv_focused(&imp.dropdown.get(), false);
+    }
+
+    pub fn focus_toolbar_index(&self, index: usize) {
+        self.clear_toolbar_focus();
+        let imp = self.imp();
+        match index {
+            0 => {
+                let widget = imp.postmenu.get();
+                set_tv_focused(&widget, true);
+                widget.grab_focus();
+            }
+            1 => {
+                let widget = imp.filter.get();
+                set_tv_focused(&widget, true);
+                widget.grab_focus();
+            }
+            2 | 3 => {
+                let widget = imp.glgroup.get();
+                set_tv_focused(&widget, true);
+                widget.grab_focus();
+            }
+            4 | 5 => {
+                let widget = imp.adgroup.get();
+                set_tv_focused(&widget, true);
+                widget.grab_focus();
+            }
+            6 => {
+                let widget = imp.dropdown.get();
+                set_tv_focused(&widget, true);
+                widget.grab_focus();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn activate_toolbar_index(&self, index: usize) -> bool {
+        let imp = self.imp();
+        match index {
+            0 => {
+                imp.postmenu.get().popup();
+                true
+            }
+            1 => {
+                imp.filter.get().emit_clicked();
+                true
+            }
+            2 => {
+                imp.glgroup.get().set_active_name(Some("grid"));
+                true
+            }
+            3 => {
+                imp.glgroup.get().set_active_name(Some("list"));
+                true
+            }
+            4 => {
+                imp.adgroup.get().set_active_name(Some("asce"));
+                true
+            }
+            5 => {
+                imp.adgroup.get().set_active_name(Some("desc"));
+                true
+            }
+            6 => {
+                gtk::prelude::WidgetExt::activate(&imp.dropdown.get());
+                true
+            }
+            _ => false,
+        }
     }
 }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -22,8 +22,8 @@ use crate::ui::{
     SETTINGS,
     provider::tu_item::TuItem,
     widgets::utils::{
-        TU_ITEM_BANNER_SIZE,
-        TU_ITEM_VIDEO_SIZE,
+        tu_item_banner_size,
+        tu_item_video_size,
     },
 };
 
@@ -109,6 +109,10 @@ pub mod imp {
 
         #[template_child]
         pub hover_scale: TemplateChild<HoverScale>,
+        #[template_child]
+        pub focus_title_revealer: TemplateChild<gtk::Revealer>,
+        #[template_child]
+        pub focus_title: TemplateChild<gtk::Label>,
 
         pub backdrop_cache: RefCell<Option<BackdropNodeCache>>,
         pub is_dark: Cell<bool>,
@@ -459,10 +463,34 @@ impl TuListItem {
         }
     }
 
+    pub fn set_poster_focused(&self, focused: bool) {
+        let imp = self.imp();
+        let focused_now = imp.content_box.has_css_class("poster-focused");
+        if focused == focused_now {
+            return;
+        }
+        if focused {
+            imp.content_box.add_css_class("poster-focused");
+            imp.hover_scale.set_highlighted(true);
+            if crate::tv::is_tv_mode_active() {
+                let title = self
+                    .item()
+                    .list_item_title()
+                    .unwrap_or_else(|| self.item().name());
+                imp.focus_title.set_text(&title);
+                imp.focus_title_revealer.set_reveal_child(true);
+            }
+        } else {
+            imp.content_box.remove_css_class("poster-focused");
+            imp.hover_scale.set_highlighted(false);
+            imp.focus_title_revealer.set_reveal_child(false);
+        }
+    }
+
     fn size_hint(&self) -> (i32, i32) {
         match self.poster_type() {
-            PosterType::Banner => TU_ITEM_BANNER_SIZE,
-            PosterType::Backdrop => TU_ITEM_VIDEO_SIZE,
+            PosterType::Banner => tu_item_banner_size(),
+            PosterType::Backdrop => tu_item_video_size(),
             _ => self.item().size_hint(),
         }
     }

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -22,9 +22,9 @@ use super::{
     },
     tu_list_item::imp::PosterType,
     utils::{
-        TU_ITEM_POST_SIZE,
-        TU_ITEM_VIDEO_SIZE,
         run_time_ticks_to_label,
+        tu_item_post_size,
+        tu_item_video_size,
     },
 };
 use crate::ui::provider::tu_item::TuItem;
@@ -205,7 +205,7 @@ impl TuOverviewItem {
                     item.name()
                 ));
                 imp.overlay
-                    .set_size_request(TU_ITEM_VIDEO_SIZE.0, TU_ITEM_VIDEO_SIZE.1);
+                    .set_size_request(tu_item_video_size().0, tu_item_video_size().1);
                 if let Some(premiere_date) = item.premiere_date() {
                     imp.time_label.set_visible(true);
                     imp.time_label
@@ -239,11 +239,11 @@ impl TuOverviewItem {
                         item.name()
                     ));
                     imp.overlay
-                        .set_size_request(TU_ITEM_VIDEO_SIZE.0, TU_ITEM_VIDEO_SIZE.1);
+                        .set_size_request(tu_item_video_size().0, tu_item_video_size().1);
                 } else {
                     imp.listlabel.set_text(&item.name());
                     imp.overlay
-                        .set_size_request(TU_ITEM_POST_SIZE.0, TU_ITEM_POST_SIZE.1);
+                        .set_size_request(tu_item_post_size().0, tu_item_post_size().1);
                 }
                 let year = if item.production_year() != 0 {
                     item.production_year().to_string()

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -16,7 +16,6 @@ use gtk::{
     gio,
     glib::{
         self,
-        clone,
     },
     template_callbacks,
 };
@@ -43,6 +42,32 @@ use crate::{
     },
 };
 
+// #region agent log
+fn agent_log(hypothesis_id: &str, location: &str, message: &str, data: serde_json::Value) {
+    use std::io::Write;
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let line = serde_json::json!({
+        "sessionId": "ef5d72",
+        "hypothesisId": hypothesis_id,
+        "location": location,
+        "message": message,
+        "data": data,
+        "timestamp": ts,
+            "runId": "post-fix"
+    });
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/var/mnt/SSD/Atlas Commons/technitiumdns-api/.cursor/debug-ef5d72.log")
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+// #endregion
+
 pub(crate) mod imp {
 
     use std::sync::{
@@ -50,9 +75,12 @@ pub(crate) mod imp {
         atomic::AtomicBool,
     };
 
-    use std::cell::{
-        Cell,
-        RefCell,
+    use std::{
+        cell::{
+            Cell,
+            RefCell,
+        },
+        collections::HashMap,
     };
 
     use glib::subclass::InitializingObject;
@@ -61,18 +89,20 @@ pub(crate) mod imp {
     use super::*;
     use crate::ui::provider::tu_object::TuObject;
 
-    pub struct NoSelectionWrap(pub gtk::NoSelection);
+    type LoadNearEndCb = std::rc::Rc<dyn Fn(&super::TuViewScrolled)>;
 
-    impl Default for NoSelectionWrap {
+    pub struct SelectionWrap(pub gtk::SingleSelection);
+
+    impl Default for SelectionWrap {
         fn default() -> Self {
-            Self(gtk::NoSelection::new(Some(
-                gio::ListStore::new::<TuObject>(),
-            )))
+            Self(gtk::SingleSelection::new(Some(gio::ListStore::new::<
+                TuObject,
+            >())))
         }
     }
 
-    impl std::ops::Deref for NoSelectionWrap {
-        type Target = gtk::NoSelection;
+    impl std::ops::Deref for SelectionWrap {
+        type Target = gtk::SingleSelection;
         fn deref(&self) -> &Self::Target {
             &self.0
         }
@@ -91,7 +121,7 @@ pub(crate) mod imp {
         #[template_child]
         pub spinner_revealer: TemplateChild<gtk::Revealer>,
 
-        pub selection: NoSelectionWrap,
+        pub selection: SelectionWrap,
         pub lock: Arc<AtomicBool>,
 
         #[property(get, set, builder(UnifySize::default()))]
@@ -101,6 +131,11 @@ pub(crate) mod imp {
         #[property(get, set, default = false)]
         pub is_resume: Cell<bool>,
         pub prefer_size_cache: RefCell<PreferSize>,
+        pub cached_columns: RefCell<i32>,
+        pub measured_item_width: RefCell<Option<i32>>,
+        pub bound_items: RefCell<HashMap<u32, gtk::ListItem>>,
+        pub last_pagination_at: Cell<u32>,
+        pub load_near_end: RefCell<Option<LoadNearEndCb>>,
     }
 
     #[glib::object_subclass]
@@ -123,7 +158,30 @@ pub(crate) mod imp {
     impl ObjectImpl for TuViewScrolled {
         fn constructed(&self) {
             self.parent_constructed();
-            self.obj().set_view_type(ViewType::GridView);
+            let obj = self.obj();
+            obj.set_view_type(ViewType::GridView);
+            let weak = obj.downgrade();
+            self.scrolled_window
+                .connect_notify_local(Some("width"), move |_, _| {
+                    if let Some(obj) = weak.upgrade() {
+                        obj.update_grid_columns();
+                    }
+                });
+            let weak = obj.downgrade();
+            obj.connect_map(move |_| {
+                if let Some(obj) = weak.upgrade() {
+                    obj.schedule_grid_layout_refresh();
+                }
+            });
+            let weak = obj.downgrade();
+            self.selection.connect_selected_notify(move |_| {
+                if let Some(obj) = weak.upgrade() {
+                    obj.refresh_poster_focus_state();
+                    if crate::tv::cursor::suppress_pointer_hover() {
+                        crate::ui::widgets::hover_scale::request_pointer_targeting_sync();
+                    }
+                }
+            });
         }
     }
 
@@ -155,6 +213,7 @@ impl TuViewScrolled {
         };
 
         let prefer_size = if C {
+            *imp.measured_item_width.borrow_mut() = None;
             let size = resolve_prefer_size(self.unify_size(), &items);
             self.imp().prefer_size_cache.replace(size);
             size
@@ -178,8 +237,31 @@ impl TuViewScrolled {
 
         if C {
             store.splice(0, store.n_items(), &items);
+            imp.last_pagination_at.set(0);
         } else {
             store.extend_from_slice(&items);
+        }
+        self.update_grid_columns();
+        self.schedule_grid_layout_refresh();
+        if crate::tv::cursor::suppress_pointer_hover() {
+            crate::ui::widgets::hover_scale::request_pointer_targeting_sync();
+        }
+    }
+
+    fn schedule_grid_layout_refresh(&self) {
+        let obj = self.clone();
+        glib::idle_add_local_once(move || obj.refresh_grid_layout(5));
+    }
+
+    fn refresh_grid_layout(&self, retries: u32) {
+        *self.imp().measured_item_width.borrow_mut() = None;
+        self.update_grid_columns();
+
+        let width = self.imp().scrolled_window.width();
+        let cols = *self.imp().cached_columns.borrow();
+        if retries > 0 && width >= 100 && cols == 1 && width > self.default_item_width() * 2 {
+            let obj = self.clone();
+            glib::idle_add_local_once(move || obj.refresh_grid_layout(retries - 1));
         }
     }
 
@@ -189,8 +271,70 @@ impl TuViewScrolled {
         match view_type {
             ViewType::GridView => {
                 imp.scrolled_window.set_child(Some(&imp.grid.get()));
-                imp.grid
-                    .set_factory(Some(factory.tu_item(PosterType::default())));
+                let grid_factory = factory.tu_item(PosterType::default());
+                grid_factory.connect_bind(glib::clone!(
+                    #[weak(rename_to = obj)]
+                    self,
+                    move |_factory, item| {
+                        let Some(list_item) = item.downcast_ref::<gtk::ListItem>() else {
+                            return;
+                        };
+                        let position = list_item.position();
+                        obj.imp()
+                            .bound_items
+                            .borrow_mut()
+                            .insert(position, list_item.clone());
+                        let selected = obj.imp().selection.selected();
+                        if let Some(child) = list_item
+                            .child()
+                            .and_downcast::<super::tu_list_item::TuListItem>()
+                        {
+                            child.set_poster_focused(
+                                selected != gtk::INVALID_LIST_POSITION && position == selected,
+                            );
+                            if crate::tv::cursor::suppress_pointer_hover() {
+                                crate::ui::widgets::hover_scale::request_pointer_targeting_sync();
+                            }
+                        }
+                        Self::attach_grid_pointer_activate(&obj, list_item);
+                        if let Some(child) = list_item.child() {
+                            let width = child.width();
+                            if width > 0 {
+                                let viewport = obj.imp().scrolled_window.width().max(1);
+                                // GridView stretches items in a single column — ignore that width.
+                                if width >= viewport.saturating_sub(72) {
+                                    return;
+                                }
+                                let imp = obj.imp();
+                                let changed = imp
+                                    .measured_item_width
+                                    .borrow()
+                                    .is_none_or(|current| current != width);
+                                if changed {
+                                    *imp.measured_item_width.borrow_mut() = Some(width);
+                                    let obj = obj.clone();
+                                    glib::idle_add_local_once(move || {
+                                        obj.update_grid_columns();
+                                    });
+                                }
+                            }
+                        }
+                    }
+                ));
+                grid_factory.connect_unbind(glib::clone!(
+                    #[weak(rename_to = obj)]
+                    self,
+                    move |_factory, item| {
+                        let Some(list_item) = item.downcast_ref::<gtk::ListItem>() else {
+                            return;
+                        };
+                        obj.imp()
+                            .bound_items
+                            .borrow_mut()
+                            .remove(&list_item.position());
+                    }
+                ));
+                imp.grid.set_factory(Some(grid_factory));
                 imp.grid.set_model(Some(&imp.selection.0));
             }
             ViewType::ListView => {
@@ -228,22 +372,108 @@ impl TuViewScrolled {
     where
         F: Fn(&Self, Arc<AtomicBool>) + 'static,
     {
-        self.imp().scrolled_window.connect_edge_overshot(clone!(
-            #[weak(rename_to = obj)]
-            self,
-            move |_scrolled, pos| if pos == gtk::PositionType::Bottom {
+        let cb = std::rc::Rc::new(cb);
+        let try_load: std::rc::Rc<dyn Fn(&Self)> = std::rc::Rc::new({
+            let cb = std::rc::Rc::clone(&cb);
+            move |obj: &Self| {
                 let is_running = Arc::clone(&obj.imp().lock);
-
                 if is_running
                     .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
                     .is_err()
                 {
                     return;
                 }
-
-                cb(&obj, is_running);
+                cb(obj, is_running);
             }
-        ));
+        });
+        *self.imp().load_near_end.borrow_mut() = Some(std::rc::Rc::clone(&try_load));
+
+        let edge_load = std::rc::Rc::clone(&try_load);
+        let weak = self.downgrade();
+        self.imp()
+            .scrolled_window
+            .connect_edge_reached(move |_scrolled, pos| {
+                if pos == gtk::PositionType::Bottom
+                    && let Some(obj) = weak.upgrade()
+                {
+                    edge_load(&obj);
+                }
+            });
+
+        let overshot_load = std::rc::Rc::clone(&try_load);
+        let weak = self.downgrade();
+        self.imp()
+            .scrolled_window
+            .connect_edge_overshot(move |_scrolled, pos| {
+                if pos == gtk::PositionType::Bottom
+                    && let Some(obj) = weak.upgrade()
+                {
+                    overshot_load(&obj);
+                }
+            });
+    }
+
+    fn maybe_load_near_end(&self) {
+        let total = self.imp().selection.n_items();
+        if total == 0 {
+            return;
+        }
+        let selected = self.selected_index();
+        let cols = self.grid_column_count().max(1) as u32;
+        let last_row = total.saturating_sub(1) / cols;
+        let selected_row = selected / cols;
+        let near_end = selected_row >= last_row.saturating_sub(1);
+        let blocked_by_pagination = total <= self.imp().last_pagination_at.get();
+        // #region agent log
+        if near_end {
+            agent_log(
+                "E",
+                "tuview_scrolled.rs:maybe_load_near_end",
+                "pagination check",
+                serde_json::json!({
+                    "selected": selected,
+                    "selectedRow": selected_row,
+                    "total": total,
+                    "cols": cols,
+                    "lastRow": last_row,
+                    "nearEnd": near_end,
+                    "blockedByPagination": blocked_by_pagination,
+                    "lastPaginationAt": self.imp().last_pagination_at.get()
+                }),
+            );
+        }
+        // #endregion
+        if selected_row < last_row.saturating_sub(1) {
+            return;
+        }
+        if blocked_by_pagination {
+            return;
+        }
+        self.imp().last_pagination_at.set(total);
+        if let Some(load) = self.imp().load_near_end.borrow().as_ref() {
+            // #region agent log
+            agent_log(
+                "E",
+                "tuview_scrolled.rs:maybe_load_near_end",
+                "triggering load_near_end",
+                serde_json::json!({ "total": total, "selected": selected }),
+            );
+            // #endregion
+            load(self);
+        }
+    }
+
+    fn scroll_metrics(&self) -> serde_json::Value {
+        let adj = self.imp().scrolled_window.vadjustment();
+        let bound = self.imp().bound_items.borrow();
+        serde_json::json!({
+            "adjValue": adj.value(),
+            "adjUpper": adj.upper(),
+            "adjPage": adj.page_size(),
+            "adjMax": (adj.upper() - adj.page_size()).max(0.0),
+            "boundCount": bound.len(),
+            "selectedBound": bound.contains_key(&self.selected_index())
+        })
     }
 
     pub fn n_items(&self) -> u32 {
@@ -256,5 +486,390 @@ impl TuViewScrolled {
 
     pub fn reveal_spinner(&self, reveal: bool) {
         self.imp().spinner_revealer.set_reveal_child(reveal);
+    }
+
+    pub fn ensure_selection(&self) {
+        let imp = self.imp();
+        if imp.selection.n_items() == 0 {
+            return;
+        }
+        if imp.selection.selected() == gtk::INVALID_LIST_POSITION {
+            imp.selection.set_selected(0);
+            self.refresh_poster_focus_state();
+        }
+    }
+
+    pub fn clear_selection(&self) {
+        self.imp()
+            .selection
+            .set_selected(gtk::INVALID_LIST_POSITION);
+        self.clear_tv_focus();
+    }
+
+    pub fn clear_tv_focus(&self) {
+        self.imp()
+            .selection
+            .set_selected(gtk::INVALID_LIST_POSITION);
+    }
+
+    fn default_item_width(&self) -> i32 {
+        match *self.imp().prefer_size_cache.borrow() {
+            crate::ui::provider::tu_item::PreferSize::Video => 280,
+            crate::ui::provider::tu_item::PreferSize::Post => 185,
+            crate::ui::provider::tu_item::PreferSize::Auto => 210,
+        }
+    }
+
+    pub fn update_grid_columns(&self) {
+        let imp = self.imp();
+        let width = imp.scrolled_window.width().max(100);
+        let item_width = self.default_item_width().max(1);
+        let cols = ((width.saturating_sub(36)) / item_width).max(1);
+        let prev = *imp.cached_columns.borrow();
+        *imp.cached_columns.borrow_mut() = cols;
+        imp.grid.set_max_columns(cols as u32);
+        if prev != cols {
+            imp.grid.queue_resize();
+        }
+    }
+
+    pub fn selected_index(&self) -> u32 {
+        let imp = self.imp();
+        if imp.selection.selected() == gtk::INVALID_LIST_POSITION {
+            0
+        } else {
+            imp.selection.selected()
+        }
+    }
+
+    pub fn is_at_top_row(&self) -> bool {
+        let imp = self.imp();
+        let current = self.selected_index();
+        let grid = imp.grid.get();
+        let Some(current_item) = imp.bound_items.borrow().get(&current).cloned() else {
+            return current == 0;
+        };
+        let Some((_, cur_y)) = Self::list_item_center(&current_item, &grid) else {
+            return current == 0;
+        };
+        for (&pos, item) in imp.bound_items.borrow().iter() {
+            if pos == current {
+                continue;
+            }
+            let Some((_, y)) = Self::list_item_center(item, &grid) else {
+                continue;
+            };
+            if cur_y - y > 8.0 {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn move_selection(&self, delta: i32) {
+        let imp = self.imp();
+        let count = imp.selection.n_items() as i32;
+        if count == 0 {
+            return;
+        }
+        let current = self.selected_index() as i32;
+        let next = (current + delta).clamp(0, count - 1) as u32;
+        imp.selection.set_selected(next);
+        self.scroll_to_selected(next, delta, 0);
+    }
+
+    pub fn grid_column_count(&self) -> i32 {
+        self.update_grid_columns();
+        if let Some(visible_cols) = self.infer_columns_from_visible_items() {
+            return visible_cols.max(1);
+        }
+        (*self.imp().cached_columns.borrow()).max(1)
+    }
+
+    fn infer_columns_from_visible_items(&self) -> Option<i32> {
+        let grid = self.imp().grid.get();
+        let mut buckets = std::collections::BTreeSet::new();
+        for item in self.imp().bound_items.borrow().values() {
+            let Some((x, _)) = Self::list_item_center(item, &grid) else {
+                continue;
+            };
+            buckets.insert((x / 48.0).round() as i32);
+        }
+        (!buckets.is_empty()).then_some(buckets.len() as i32)
+    }
+
+    fn list_item_center(list_item: &gtk::ListItem, grid: &gtk::GridView) -> Option<(f64, f64)> {
+        let widget = list_item.child()?.upcast::<gtk::Widget>();
+        let width = widget.width();
+        let height = widget.height();
+        if width <= 0 || height <= 0 {
+            return None;
+        }
+        let point = gtk::graphene::Point::new(width as f32 / 2.0, height as f32 / 2.0);
+        let translated = widget.compute_point(grid.upcast_ref::<gtk::Widget>(), &point)?;
+        Some((f64::from(translated.x()), f64::from(translated.y())))
+    }
+
+    fn move_grid_selection_spatial(&self, row_delta: i32) -> bool {
+        self.move_grid_selection_spatial_axis(row_delta, 0)
+    }
+
+    fn move_grid_selection_spatial_horizontal(&self, col_delta: i32) -> bool {
+        self.move_grid_selection_spatial_axis(0, col_delta)
+    }
+
+    fn move_grid_selection_spatial_axis(&self, row_delta: i32, col_delta: i32) -> bool {
+        let imp = self.imp();
+        let current = self.selected_index();
+        let grid = imp.grid.get();
+        let Some(current_item) = imp.bound_items.borrow().get(&current).cloned() else {
+            return false;
+        };
+        let Some((cur_x, cur_y)) = Self::list_item_center(&current_item, &grid) else {
+            return false;
+        };
+
+        let mut best: Option<(u32, f64)> = None;
+        for (&pos, item) in imp.bound_items.borrow().iter() {
+            if pos == current {
+                continue;
+            }
+            let Some((x, y)) = Self::list_item_center(item, &grid) else {
+                continue;
+            };
+            if row_delta != 0 {
+                let dy = y - cur_y;
+                if row_delta > 0 && dy <= 8.0 {
+                    continue;
+                }
+                if row_delta < 0 && dy >= -8.0 {
+                    continue;
+                }
+                let score = dy.abs() * 10_000.0 + (x - cur_x).abs();
+                if best.is_none_or(|(_, best_score)| score < best_score) {
+                    best = Some((pos, score));
+                }
+            } else if col_delta != 0 {
+                let dx = x - cur_x;
+                if col_delta > 0 && dx <= 8.0 {
+                    continue;
+                }
+                if col_delta < 0 && dx >= -8.0 {
+                    continue;
+                }
+                let score = dx.abs() * 10_000.0 + (y - cur_y).abs();
+                if best.is_none_or(|(_, best_score)| score < best_score) {
+                    best = Some((pos, score));
+                }
+            }
+        }
+
+        let Some((next, _)) = best else {
+            return false;
+        };
+        if row_delta > 0 {
+            self.maybe_load_near_end();
+        }
+        imp.selection.set_selected(next);
+        self.scroll_to_selected(next, row_delta, 0);
+        self.refresh_poster_focus_state();
+        true
+    }
+
+    fn move_grid_selection_by_index(&self, row_delta: i32, col_delta: i32) -> bool {
+        let imp = self.imp();
+        let count = imp.selection.n_items() as i32;
+        if count == 0 {
+            return false;
+        }
+        let cols = self.grid_column_count().max(1);
+        let current = if imp.selection.selected() == gtk::INVALID_LIST_POSITION {
+            0
+        } else {
+            imp.selection.selected() as i32
+        };
+        let row = current / cols;
+        let col = current % cols;
+        let max_row = (count - 1) / cols;
+        let next_row = (row + row_delta).clamp(0, max_row);
+        let next_col = if row_delta != 0 {
+            col
+        } else {
+            (col + col_delta).clamp(0, cols - 1)
+        };
+        let mut next = next_row * cols + next_col;
+        if next >= count {
+            next = ((count - 1) / cols) * cols + next_col;
+            if next >= count {
+                next = count - 1;
+            }
+        }
+        if next == current {
+            return false;
+        }
+        if row_delta > 0 {
+            self.maybe_load_near_end();
+        }
+        imp.selection.set_selected(next as u32);
+        self.scroll_to_selected(next as u32, row_delta, col_delta);
+        self.refresh_poster_focus_state();
+        self.maybe_load_near_end();
+        true
+    }
+
+    pub fn move_grid_selection(&self, row_delta: i32, col_delta: i32) {
+        let imp = self.imp();
+        let count = imp.selection.n_items() as i32;
+        if count == 0 {
+            return;
+        }
+        if row_delta != 0 && col_delta == 0 && self.move_grid_selection_by_index(row_delta, 0) {
+            // #region agent log
+            agent_log(
+                "A",
+                "tuview_scrolled.rs:move_grid_selection",
+                "moved by index",
+                serde_json::json!({
+                    "rowDelta": row_delta,
+                    "selected": self.selected_index(),
+                    "cols": self.grid_column_count(),
+                    "total": count,
+                    "metrics": self.scroll_metrics()
+                }),
+            );
+            // #endregion
+            return;
+        }
+        if col_delta != 0 && row_delta == 0 && self.move_grid_selection_by_index(0, col_delta) {
+            return;
+        }
+        if row_delta != 0 && col_delta == 0 && self.move_grid_selection_spatial(row_delta) {
+            self.maybe_load_near_end();
+            return;
+        }
+        if col_delta != 0
+            && row_delta == 0
+            && self.move_grid_selection_spatial_horizontal(col_delta)
+        {
+            return;
+        }
+        let cols = self.grid_column_count();
+        let current = if imp.selection.selected() == gtk::INVALID_LIST_POSITION {
+            0
+        } else {
+            imp.selection.selected() as i32
+        };
+        let row = current / cols;
+        let col = current % cols;
+        let max_row = (count - 1) / cols;
+        let next_row = (row + row_delta).clamp(0, max_row);
+        let next_col = if row_delta != 0 {
+            col
+        } else {
+            (col + col_delta).clamp(0, cols - 1)
+        };
+        let mut next = next_row * cols + next_col;
+        if next >= count {
+            next = ((count - 1) / cols) * cols + next_col;
+            if next >= count {
+                next = count - 1;
+            }
+        }
+        imp.selection.set_selected(next as u32);
+        self.scroll_to_selected(next as u32, row_delta, col_delta);
+        self.refresh_poster_focus_state();
+        self.maybe_load_near_end();
+    }
+
+    fn refresh_poster_focus_state(&self) {
+        let selected = self.imp().selection.selected();
+        for item in self.imp().bound_items.borrow().values() {
+            if let Some(child) = item
+                .child()
+                .and_downcast::<super::tu_list_item::TuListItem>()
+            {
+                child.set_poster_focused(
+                    selected != gtk::INVALID_LIST_POSITION && item.position() == selected,
+                );
+            }
+        }
+    }
+
+    fn attach_grid_pointer_activate(scrolled: &TuViewScrolled, list_item: &gtk::ListItem) {
+        if !crate::tv::controller_navigation_enabled() {
+            return;
+        }
+        let Some(child) = list_item.child() else {
+            return;
+        };
+        if child.widget_name() == "tv-grid-pointer-bound" {
+            return;
+        }
+        child.set_widget_name("tv-grid-pointer-bound");
+        let gesture = gtk::GestureClick::new();
+        gesture.set_button(1);
+        let scrolled = scrolled.clone();
+        let weak_item = list_item.downgrade();
+        gesture.connect_released(move |gesture, _, _, _| {
+            crate::tv::osk::mark_pointer_input();
+            let Some(list_item) = weak_item.upgrade() else {
+                return;
+            };
+            let position = list_item.position();
+            gesture.set_state(gtk::EventSequenceState::Claimed);
+            scrolled.imp().selection.set_selected(position);
+            scrolled.refresh_poster_focus_state();
+            if let Some(window) = scrolled.root().and_downcast::<crate::Window>() {
+                scrolled.activate_selected(&window);
+            }
+        });
+        child.add_controller(gesture);
+    }
+
+    pub fn activate_selected(&self, window: &crate::Window) {
+        let imp = self.imp();
+        let index = imp.selection.selected();
+        if index == gtk::INVALID_LIST_POSITION {
+            return;
+        }
+        if let Some(tu_obj) = imp
+            .selection
+            .item(index)
+            .and_downcast::<crate::ui::provider::tu_object::TuObject>()
+        {
+            tu_obj.item().activate(window);
+        }
+    }
+
+    fn scroll_to_selected(&self, index: u32, row_delta: i32, _col_delta: i32) {
+        let imp = self.imp();
+        let flags = gtk::ListScrollFlags::all();
+        if imp
+            .scrolled_window
+            .child()
+            .is_some_and(|child| child.is::<gtk::GridView>())
+        {
+            // #region agent log
+            if row_delta != 0 {
+                agent_log(
+                    "C",
+                    "tuview_scrolled.rs:scroll_to_selected",
+                    "grid.scroll_to only",
+                    serde_json::json!({
+                        "index": index,
+                        "rowDelta": row_delta,
+                        "total": imp.selection.n_items(),
+                        "metrics": self.scroll_metrics()
+                    }),
+                );
+            }
+            // #endregion
+            imp.grid.scroll_to(index, flags, None);
+            if row_delta > 0 {
+                self.maybe_load_near_end();
+            }
+        } else {
+            imp.list.scroll_to(index, flags, None);
+        }
     }
 }

--- a/src/ui/widgets/utils.rs
+++ b/src/ui/widgets/utils.rs
@@ -75,6 +75,22 @@ pub const TU_ITEM_VIDEO_SIZE: (i32, i32) = (250, 141);
 pub const TU_ITEM_SQUARE_SIZE: (i32, i32) = (190, 190);
 pub const TU_ITEM_BANNER_SIZE: (i32, i32) = (375, 70);
 
+pub fn tu_item_post_size() -> (i32, i32) {
+    crate::tv::scale_pair(TU_ITEM_POST_SIZE)
+}
+
+pub fn tu_item_video_size() -> (i32, i32) {
+    crate::tv::scale_pair(TU_ITEM_VIDEO_SIZE)
+}
+
+pub fn tu_item_square_size() -> (i32, i32) {
+    crate::tv::scale_pair(TU_ITEM_SQUARE_SIZE)
+}
+
+pub fn tu_item_banner_size() -> (i32, i32) {
+    crate::tv::scale_pair(TU_ITEM_BANNER_SIZE)
+}
+
 pub trait GlobalToast {
     fn toast(&self, message: impl Into<String>);
 

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -7,6 +7,7 @@ use gtk::{
     Widget,
     subclass::prelude::*,
 };
+
 mod imp {
     use std::cell::{
         OnceCell,
@@ -25,6 +26,19 @@ mod imp {
     use crate::{
         ui::{
             SETTINGS,
+            input::{
+                FocusManager,
+                GamepadManager,
+                GridNavigator,
+                ItemPageNavigator,
+                LikedNavigator,
+                MediaViewerNavigator,
+                MpvNavigator,
+                PlaceholderNavigator,
+                PushedNavigator,
+                SearchNavigator,
+                SettingsNavigator,
+            },
             mpv::{
                 control_sidebar::MPVControlSidebar,
                 page::MPVPage,
@@ -74,6 +88,8 @@ mod imp {
         #[template_child]
         pub login_stack: TemplateChild<gtk::Stack>,
         #[template_child]
+        pub add_server: TemplateChild<gtk::Button>,
+        #[template_child]
         pub namerow: TemplateChild<adw::ActionRow>,
         #[template_child]
         pub player_toolbar_box: TemplateChild<PlayerToolbarBox>,
@@ -120,6 +136,26 @@ mod imp {
         pub mpv_playlist_selection: gtk::SingleSelection,
 
         pub suspend_cookie: RefCell<Option<u32>>,
+
+        pub focus_manager: RefCell<FocusManager>,
+        pub gamepad_manager: RefCell<GamepadManager>,
+        pub placeholder_navigator: RefCell<PlaceholderNavigator>,
+        pub liked_navigator: RefCell<LikedNavigator>,
+        pub search_navigator: RefCell<SearchNavigator>,
+        pub mpv_navigator: RefCell<MpvNavigator>,
+        pub settings_navigator: RefCell<SettingsNavigator>,
+        pub item_navigator: RefCell<ItemPageNavigator>,
+        pub grid_navigator: RefCell<GridNavigator>,
+        pub pushed_navigator: RefCell<PushedNavigator>,
+        pub media_viewer_navigator: RefCell<MediaViewerNavigator>,
+        pub home_focus_snapshot: RefCell<Option<crate::ui::input::HomeFocusSnapshot>>,
+        pub active_settings: RefCell<Option<crate::ui::widgets::account_settings::AccountSettings>>,
+        pub active_account_dialog: RefCell<Option<crate::ui::widgets::account_add::AccountWindow>>,
+        pub tv_hints_revealer: RefCell<Option<gtk::Revealer>>,
+        pub tv_hints_label: RefCell<Option<gtk::Label>>,
+        pub tv_hints_hide_source: RefCell<Option<glib::SourceId>>,
+        pub tv_preferences_section: RefCell<Option<adw::SidebarSection>>,
+        pub tv_session_section: RefCell<Option<adw::SidebarSection>>,
 
         #[template_child]
         pub sidebar_breakpoint: TemplateChild<adw::Breakpoint>,
@@ -171,6 +207,11 @@ mod imp {
             klass.install_action("win.add-server", None, |obj, _, _| {
                 obj.new_account();
             });
+            klass.install_action("win.quit", None, |window, _, _| {
+                if let Some(app) = window.application() {
+                    app.quit();
+                }
+            });
         }
 
         fn instance_init(obj: &InitializingObject<Self>) {
@@ -206,6 +247,12 @@ mod imp {
                 #[weak]
                 obj,
                 move |_breakpoint| {
+                    if crate::tv::is_tv_mode_active() && SETTINGS.tv_hide_sidebar() {
+                        let split_view = obj.imp().split_view.get();
+                        split_view.set_collapsed(true);
+                        split_view.set_show_sidebar(false);
+                        return;
+                    }
                     if !SETTINGS.is_overlay() {
                         obj.imp().split_view.set_collapsed(false);
                     }
@@ -255,6 +302,7 @@ use super::{
     search::SearchPage,
     server_action_row,
     server_panel::ServerPanel,
+    single_grid::SingleGrid,
     tu_item::PROGRESSBAR_ANIMATION_DURATION,
     utils::GlobalToast,
 };
@@ -265,6 +313,13 @@ use crate::{
         jellyfin_client::JELLYFIN_CLIENT,
     },
     ui::{
+        input::{
+            InputAction,
+            MainTab,
+            NavigationContext,
+            PushedPageKind,
+            key_to_action,
+        },
         models::SETTINGS,
         provider::{
             IS_ADMIN,
@@ -306,6 +361,9 @@ impl Window {
         imp.insidestack.set_visible_child_name("homepage");
         imp.popbutton.set_visible(false);
         imp.last_content_list_selection.replace(Some(0));
+        if let Some(home) = imp.homepage.child().and_downcast::<HomePage>() {
+            imp.focus_manager.borrow().register_home(&home);
+        }
     }
 
     pub fn likedpage(&self) {
@@ -318,6 +376,9 @@ impl Window {
         imp.insidestack.set_visible_child_name("likedpage");
         imp.popbutton.set_visible(false);
         imp.last_content_list_selection.replace(Some(1));
+        if let Some(liked) = imp.likedpage.child().and_downcast::<LikedPage>() {
+            imp.liked_navigator.borrow().register(&liked);
+        }
     }
 
     pub fn searchpage(&self) {
@@ -349,6 +410,16 @@ impl Window {
 
         imp.popbutton.set_visible(false);
         imp.navipage.set_title("");
+        if imp.insidestack.visible_child_name().as_deref() == Some("homepage")
+            && let Some(home) = imp.homepage.child().and_downcast::<HomePage>()
+        {
+            let fm = imp.focus_manager.borrow();
+            if let Some(snapshot) = imp.home_focus_snapshot.borrow_mut().take() {
+                fm.restore_home_focus(&home, snapshot);
+            } else {
+                fm.refresh_home_rows(&home);
+            }
+        }
         self.refresh_homepage_if_needed();
     }
 
@@ -374,10 +445,19 @@ impl Window {
         }
         if accounts.is_empty() {
             imp.login_stack.set_visible_child_name("no-server");
+            imp.placeholder_navigator.borrow().reset();
+            if crate::tv::focus::tv_focus_enabled() {
+                let add_button = self.imp().add_server.get();
+                self.imp()
+                    .placeholder_navigator
+                    .borrow()
+                    .focus_add_server(&add_button);
+            }
             return;
         } else {
             imp.login_stack.set_visible_child_name("servers");
         }
+        imp.placeholder_navigator.borrow().reset();
         for (index, account) in accounts.iter().enumerate() {
             let server_action_row = server_action_row::ServerActionRow::new(account.to_owned());
 
@@ -455,6 +535,17 @@ impl Window {
 
             listbox.append(&server_action_row);
         }
+
+        if accounts.len() == 1 {
+            if let Some(row) = listbox.row_at_index(0) {
+                listbox.select_row(Some(&row));
+            }
+        } else if crate::tv::focus::tv_focus_enabled() {
+            self.imp()
+                .placeholder_navigator
+                .borrow()
+                .select_initial(listbox);
+        }
     }
 
     pub fn set_nav_servers(&self) {
@@ -521,6 +612,14 @@ impl Window {
         let ac = crate::ui::widgets::account_settings::AccountSettings::new(window_clone);
         ac.set_transient_for(Some(self));
         ac.set_application(Some(&self.application().unwrap()));
+        if crate::tv::is_tv_mode_active() {
+            ac.set_decorated(false);
+        }
+        *self.imp().active_settings.borrow_mut() = Some(ac.clone());
+        self.imp()
+            .settings_navigator
+            .borrow()
+            .reset_for_preferences(&ac);
         ac.present();
     }
 
@@ -568,6 +667,7 @@ impl Window {
 
     pub fn mainpage(&self) {
         self.imp().stack.set_visible_child_name("main");
+        self.sync_tv_button_hints();
     }
 
     pub fn refresh_homepage_if_needed(&self) {
@@ -591,6 +691,23 @@ impl Window {
 
     pub fn overlay_sidebar(&self, overlay: bool) {
         self.imp().split_view.set_collapsed(overlay);
+    }
+
+    /// In TV mode with a collapsed sidebar, show or hide the overlay panel.
+    pub fn set_sidebar_panel_visible(&self, visible: bool) {
+        let split_view = self.imp().split_view.get();
+        if crate::tv::is_tv_mode_active() && SETTINGS.tv_hide_sidebar() {
+            split_view.set_collapsed(true);
+            split_view.set_show_sidebar(visible);
+            return;
+        }
+        if visible != split_view.shows_sidebar() {
+            gtk::prelude::ActionGroupExt::activate_action(self, "win.sidebar", None);
+        }
+    }
+
+    pub fn tv_sidebar_collapsed(&self) -> bool {
+        crate::tv::is_tv_mode_active() && SETTINGS.tv_hide_sidebar()
     }
 
     pub fn add_toast(&self, toast: adw::Toast) {
@@ -677,6 +794,7 @@ impl Window {
 
     pub fn new_account(&self) {
         let dialog = crate::ui::widgets::account_add::AccountWindow::new();
+        *self.imp().active_account_dialog.borrow_mut() = Some(dialog.clone());
         dialog.present(Some(self));
     }
 
@@ -755,12 +873,14 @@ impl Window {
 
     pub fn play_media(
         &self, selected: Option<SelectedVideoSubInfo>, item: TuItem, episode_list: Vec<TuItem>,
-        matcher: Option<String>, start_seconds: f64,
+        matcher: Option<String>, start_seconds: f64, external_sub: Option<String>,
     ) {
         let imp = self.imp();
         imp.stack.set_visible_child_name("mpv");
+        self.sync_tv_button_hints();
         self.prevent_suspend();
         self.set_mpv_playlist(&episode_list);
+        imp.mpvnav.set_external_sub_override(external_sub);
         imp.mpvnav
             .play(selected, item, episode_list, matcher, start_seconds);
     }
@@ -769,6 +889,16 @@ impl Window {
     where
         T: NavigationPageExt,
     {
+        if self.now_page_tag().as_deref() == Some("mainpage")
+            && self.imp().insidestack.visible_child_name().as_deref() == Some("homepage")
+            && let Some(home) = self.imp().homepage.child().and_downcast::<HomePage>()
+        {
+            let snapshot = self.imp().focus_manager.borrow().snapshot_home_focus();
+            *self.imp().home_focus_snapshot.borrow_mut() = Some(snapshot);
+            self.imp().focus_manager.borrow().clear_all_row_selections();
+            let _ = home;
+        }
+
         let imp = self.imp();
         page.set_title(name);
         imp.navipage.set_title(name);
@@ -820,14 +950,30 @@ impl Window {
         self.imp().stack.visible_child_name() == Some("mpv".into())
     }
 
+    pub fn is_on_mpv_stack_pub(&self) -> bool {
+        self.is_on_mpv_stack()
+    }
+
     #[template_callback]
     fn key_pressed_cb(&self, key: u32, _code: u32, state: gtk::gdk::ModifierType) -> bool {
+        if state.contains(gtk::gdk::ModifierType::CONTROL_MASK)
+            || state.contains(gtk::gdk::ModifierType::ALT_MASK)
+        {
+            return false;
+        }
+
         if self.is_on_mpv_stack() {
             self.imp().mpvnav.key_pressed_cb(key, state);
             if self.imp().mpv_view.shows_sidebar() {
                 return false;
             }
             return true;
+        }
+
+        if crate::tv::controller_navigation_enabled()
+            && let Some(action) = key_to_action(key)
+        {
+            return self.handle_input_action(action);
         }
 
         false
@@ -850,6 +996,28 @@ impl Window {
         let Some(section) = item.section() else {
             return;
         };
+
+        if let Some(prefs) = imp.tv_preferences_section.borrow().as_ref()
+            && prefs == &section
+        {
+            self.account_settings();
+            return;
+        }
+
+        if let Some(session) = imp.tv_session_section.borrow().as_ref()
+            && session == &section
+        {
+            match item.section_index() {
+                0 => {
+                    let _ = gtk::prelude::WidgetExt::activate_action(self, "win.relogin", None);
+                }
+                1 => {
+                    let _ = gtk::prelude::WidgetExt::activate_action(self, "win.quit", None);
+                }
+                _ => {}
+            }
+            return;
+        }
 
         if section == *imp.servers_section {
             let section_idx = item.section_index() as usize;
@@ -892,6 +1060,424 @@ impl Window {
             1 => self.on_liked_update(),
             _ => {}
         }
+    }
+
+    pub fn setup_input(&self) {
+        crate::tv::cursor::register_window(self);
+        let window = self.clone();
+        glib::timeout_add_local(std::time::Duration::from_millis(16), move || {
+            let actions = {
+                let mut mgr = window.imp().gamepad_manager.borrow_mut();
+                mgr.poll(&window)
+            };
+            if !actions.is_empty() {
+                crate::tv::cursor::on_gamepad_activity();
+                glib::idle_add_local_once(crate::tv::cursor::on_gamepad_activity);
+            }
+            for action in actions {
+                window.handle_input_action(action);
+            }
+            glib::ControlFlow::Continue
+        });
+
+        let pointer = gtk::GestureClick::new();
+        pointer.connect_pressed(|_, _, _, _| crate::tv::osk::mark_pointer_input());
+        self.add_controller(pointer);
+
+        let motion = gtk::EventControllerMotion::new();
+        motion.connect_motion(|_, _, _| crate::tv::osk::mark_pointer_input());
+        self.add_controller(motion);
+
+        let keys = gtk::EventControllerKey::new();
+        keys.connect_key_pressed(|_, _, _, _| {
+            crate::tv::osk::mark_keyboard_input();
+            glib::Propagation::Proceed
+        });
+        self.add_controller(keys);
+
+        self.sync_tv_button_hints();
+    }
+
+    pub fn refresh_focus_manager(&self) {
+        if let Some(home) = self.imp().homepage.child().and_downcast::<HomePage>() {
+            self.imp().focus_manager.borrow().refresh_home_rows(&home);
+        }
+    }
+
+    pub fn activate_sidebar_selection(&self) {
+        let sidebar = self.imp().selectlist.get();
+        self.on_sidebar_activated(sidebar.selected());
+    }
+
+    pub fn is_on_placeholder(&self) -> bool {
+        self.imp().stack.visible_child_name().as_deref() == Some("placeholder")
+    }
+
+    pub fn enable_tv_mode_ui(&self, cli_fullscreen: bool) {
+        self.add_css_class("tv-mode");
+        self.set_decorated(false);
+
+        if self.imp().tv_hints_revealer.borrow().is_none() {
+            self.setup_tv_hints();
+        }
+        self.sync_tv_button_hints();
+
+        let start_fullscreen = cli_fullscreen
+            || SETTINGS.tv_start_fullscreen()
+            || crate::steam::is_steam_big_picture();
+        if start_fullscreen {
+            self.fullscreen();
+        }
+
+        if SETTINGS.tv_hide_sidebar() {
+            self.set_sidebar_panel_visible(false);
+            let window = self.clone();
+            glib::idle_add_local_once(move || {
+                window.set_sidebar_panel_visible(false);
+            });
+        }
+
+        self.setup_tv_preferences_sidebar();
+        self.setup_tv_session_sidebar();
+    }
+
+    fn setup_tv_preferences_sidebar(&self) {
+        if self.imp().tv_preferences_section.borrow().is_some() {
+            return;
+        }
+        let section = adw::SidebarSection::new();
+        section.set_title(Some(&gettext("Settings")));
+        let item = adw::SidebarItem::new(&gettext("Preferences"));
+        item.set_icon_name(Some("applications-system-symbolic"));
+        section.append(item);
+        let stored = section.clone();
+        self.imp().selectlist.get().append(section);
+        *self.imp().tv_preferences_section.borrow_mut() = Some(stored);
+    }
+
+    fn setup_tv_session_sidebar(&self) {
+        if self.imp().tv_session_section.borrow().is_some() {
+            return;
+        }
+        let section = adw::SidebarSection::new();
+        section.set_title(Some(&gettext("Session")));
+        let logout = adw::SidebarItem::new(&gettext("Log Out"));
+        logout.set_icon_name(Some("system-log-out-symbolic"));
+        let quit = adw::SidebarItem::new(&gettext("Quit"));
+        quit.set_icon_name(Some("application-exit-symbolic"));
+        section.append(logout);
+        section.append(quit);
+        let stored = section.clone();
+        self.imp().selectlist.get().append(section);
+        *self.imp().tv_session_section.borrow_mut() = Some(stored);
+    }
+
+    fn remove_tv_session_sidebar(&self) {
+        if let Some(section) = self.imp().tv_session_section.borrow_mut().take() {
+            self.imp().selectlist.get().remove(&section);
+        }
+    }
+
+    fn remove_tv_preferences_sidebar(&self) {
+        if let Some(section) = self.imp().tv_preferences_section.borrow_mut().take() {
+            self.imp().selectlist.get().remove(&section);
+        }
+    }
+
+    pub fn disable_tv_mode_ui(&self) {
+        self.remove_tv_preferences_sidebar();
+        self.remove_tv_session_sidebar();
+        self.remove_css_class("tv-mode");
+        crate::tv::cursor::restore();
+        self.set_decorated(true);
+        if let Some(revealer) = self.imp().tv_hints_revealer.borrow().as_ref() {
+            revealer.set_visible(false);
+            revealer.set_reveal_child(false);
+        }
+        if self.is_fullscreen() && !SETTINGS.is_fullscreen() && !SETTINGS.tv_start_fullscreen() {
+            self.unfullscreen();
+        }
+        self.overlay_sidebar(SETTINGS.overlay());
+    }
+
+    pub fn handle_input_action(&self, action: InputAction) -> bool {
+        if crate::tv::osk::handle_input(action) {
+            return true;
+        }
+        if self.is_on_mpv_stack() && SETTINGS.tv_show_button_hints() {
+            self.flash_tv_button_hints();
+        }
+        if crate::subtitles::dialog::handle_active_input(action) {
+            return true;
+        }
+        if crate::ui::input::popover_navigator::handle(self, action) {
+            return true;
+        }
+        if crate::playback::rule_editor::handle_active_input(action) {
+            return true;
+        }
+        if crate::ui::input::dialog_navigator::handle(self, action) {
+            return true;
+        }
+
+        match self.resolve_navigation_context() {
+            NavigationContext::Mpv => {
+                self.imp()
+                    .mpv_navigator
+                    .borrow()
+                    .handle(self, &self.imp().mpvnav, action)
+            }
+            NavigationContext::Placeholder => {
+                let imp = self.imp();
+                imp.placeholder_navigator.borrow().handle(
+                    self,
+                    &imp.login_stack.get(),
+                    &imp.serversbox.get(),
+                    action,
+                )
+            }
+            NavigationContext::MediaViewer => self.imp().media_viewer_navigator.borrow().handle(
+                self,
+                &self.imp().media_viewer.get(),
+                action,
+            ),
+            NavigationContext::Modal => self.handle_modal_input(action),
+            NavigationContext::Pushed(PushedPageKind::Item) => {
+                if let Some(page) = self
+                    .imp()
+                    .mainview
+                    .visible_page()
+                    .and_downcast::<ItemPage>()
+                {
+                    return self
+                        .imp()
+                        .item_navigator
+                        .borrow()
+                        .handle(self, &page, action);
+                }
+                false
+            }
+            NavigationContext::Pushed(PushedPageKind::Grid) => {
+                if let Some(page) = self
+                    .imp()
+                    .mainview
+                    .visible_page()
+                    .and_downcast::<SingleGrid>()
+                {
+                    return self
+                        .imp()
+                        .grid_navigator
+                        .borrow()
+                        .handle(self, &page, action);
+                }
+                false
+            }
+            NavigationContext::Pushed(PushedPageKind::Other) => {
+                self.imp().pushed_navigator.borrow().handle(self, action)
+            }
+            NavigationContext::Main(MainTab::Home) => match action {
+                InputAction::ToggleHints => {
+                    self.toggle_tv_hints();
+                    true
+                }
+                InputAction::SwitchGamepad => {
+                    let enabled = !crate::ui::SETTINGS.gamepad_enabled();
+                    let _ = crate::ui::SETTINGS.set_gamepad_enabled(enabled);
+                    if !enabled {
+                        crate::tv::cursor::restore();
+                    }
+                    let mgr = self.imp().gamepad_manager.borrow();
+                    self.toast(if enabled {
+                        format!(
+                            "{} — {} ({})",
+                            gettext("Controller navigation enabled"),
+                            mgr.active_name(),
+                            match mgr.active_profile() {
+                                crate::ui::input::GamepadProfile::Xbox => "Xbox",
+                                crate::ui::input::GamepadProfile::PlayStation => "PlayStation",
+                                crate::ui::input::GamepadProfile::SteamDeck => "Steam Deck",
+                                crate::ui::input::GamepadProfile::Nintendo => "Nintendo",
+                                crate::ui::input::GamepadProfile::Generic => "Generic",
+                            }
+                        )
+                    } else {
+                        gettext("Controller navigation disabled").to_string()
+                    });
+                    true
+                }
+                InputAction::PlayPause => {
+                    self.imp().player_toolbar_box.toggle_playback();
+                    true
+                }
+                _ => self.imp().focus_manager.borrow().handle(self, action),
+            },
+            NavigationContext::Main(MainTab::Liked) => {
+                if let Some(liked) = self.imp().likedpage.child().and_downcast::<LikedPage>() {
+                    self.imp()
+                        .liked_navigator
+                        .borrow()
+                        .handle(self, &liked, action)
+                } else {
+                    false
+                }
+            }
+            NavigationContext::Main(MainTab::Search) => {
+                if let Some(search) = self.imp().searchpage.child().and_downcast::<SearchPage>() {
+                    self.imp()
+                        .search_navigator
+                        .borrow()
+                        .handle(self, &search, action)
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn handle_modal_input(&self, action: InputAction) -> bool {
+        if let Some(settings) = self.imp().active_settings.borrow().clone() {
+            if settings.is_visible() {
+                return self
+                    .imp()
+                    .settings_navigator
+                    .borrow()
+                    .handle_window(&settings, action);
+            }
+            *self.imp().active_settings.borrow_mut() = None;
+        }
+        if let Some(account) = self.imp().active_account_dialog.borrow().clone() {
+            if account.is_visible() {
+                return self
+                    .imp()
+                    .settings_navigator
+                    .borrow()
+                    .handle_account_window(&account, action);
+            }
+            *self.imp().active_account_dialog.borrow_mut() = None;
+        }
+        false
+    }
+
+    fn setup_tv_hints(&self) {
+        if !crate::tv::is_tv_mode_active() {
+            return;
+        }
+        if self.imp().tv_hints_revealer.borrow().is_some() {
+            return;
+        }
+        let revealer = gtk::Revealer::builder()
+            .valign(gtk::Align::End)
+            .halign(gtk::Align::Center)
+            .transition_type(gtk::RevealerTransitionType::SlideUp)
+            .reveal_child(false)
+            .visible(false)
+            .build();
+
+        let bar = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .build();
+        bar.add_css_class("tv-hints-bar");
+
+        let label = gtk::Label::new(None);
+        label.set_wrap(false);
+        bar.append(&label);
+        revealer.set_child(Some(&bar));
+
+        let toast = self.imp().toast.get();
+        if let Some(overlay) = toast.parent().and_downcast::<gtk::Overlay>() {
+            overlay.add_overlay(&revealer);
+        }
+
+        *self.imp().tv_hints_revealer.borrow_mut() = Some(revealer);
+        *self.imp().tv_hints_label.borrow_mut() = Some(label);
+    }
+
+    pub fn sync_tv_button_hints(&self) {
+        if !crate::tv::is_tv_mode_active() {
+            if let Some(revealer) = self.imp().tv_hints_revealer.borrow().as_ref() {
+                revealer.set_visible(false);
+                revealer.set_reveal_child(false);
+            }
+            return;
+        }
+
+        if self.imp().tv_hints_revealer.borrow().is_none() {
+            self.setup_tv_hints();
+        }
+
+        let Some(revealer) = self.imp().tv_hints_revealer.borrow().clone() else {
+            return;
+        };
+
+        if !SETTINGS.tv_show_button_hints() {
+            if let Some(id) = self.imp().tv_hints_hide_source.borrow_mut().take() {
+                id.remove();
+            }
+            revealer.set_visible(false);
+            revealer.set_reveal_child(false);
+            return;
+        }
+
+        revealer.set_visible(true);
+        self.update_tv_hints_label();
+
+        let show = self.imp().stack.visible_child_name().as_deref() == Some("main")
+            && !self.is_on_mpv_stack();
+
+        revealer.set_reveal_child(show);
+    }
+
+    pub fn flash_tv_button_hints(&self) {
+        if !crate::tv::is_tv_mode_active() || !SETTINGS.tv_show_button_hints() {
+            return;
+        }
+
+        if self.imp().tv_hints_revealer.borrow().is_none() {
+            self.setup_tv_hints();
+        }
+        let Some(revealer) = self.imp().tv_hints_revealer.borrow().clone() else {
+            return;
+        };
+
+        revealer.set_visible(true);
+        self.update_tv_hints_label();
+        revealer.set_reveal_child(true);
+
+        if let Some(id) = self.imp().tv_hints_hide_source.borrow_mut().take() {
+            id.remove();
+        }
+        let window = self.clone();
+        let id = glib::timeout_add_local(std::time::Duration::from_secs(4), move || {
+            if window.is_on_mpv_stack() {
+                if let Some(revealer) = window.imp().tv_hints_revealer.borrow().as_ref() {
+                    revealer.set_reveal_child(false);
+                }
+            } else {
+                window.sync_tv_button_hints();
+            }
+            window.imp().tv_hints_hide_source.borrow_mut().take();
+            glib::ControlFlow::Break
+        });
+        *self.imp().tv_hints_hide_source.borrow_mut() = Some(id);
+    }
+
+    fn update_tv_hints_label(&self) {
+        let Some(label) = self.imp().tv_hints_label.borrow().clone() else {
+            return;
+        };
+        let profile = self.imp().gamepad_manager.borrow().active_profile();
+        label.set_text(&format!(
+            "{}: Navigate   {}: Select   {}: Back   Menu: Sidebar",
+            "D-pad",
+            profile.activate_label(),
+            profile.back_label(),
+        ));
+    }
+
+    fn toggle_tv_hints(&self) {
+        let enabled = !SETTINGS.tv_show_button_hints();
+        let _ = SETTINGS.set_tv_show_button_hints(enabled);
+        self.sync_tv_button_hints();
     }
 
     pub fn set_shortcuts(&self) {


### PR DESCRIPTION
> **Disclaimer:** This PR description was written with AI assistance. I'm autistic and find writing these kinds of summaries difficult, so I used AI to help organise the changes clearly. The code itself was also developed with AI Assistance primarily in debugging/Reading logs and updating documentation to speed up the process.

## Summary

This PR adds a full TV / HTPC experience to Tsukimi: larger UI scaling, gamepad/controller navigation across the app, an on-screen keyboard, conditional subtitle playback rules, in-app subtitle search, and Steam Big Picture integration. Mouse and keyboard still work alongside controller input.

---

## What's new

### TV / HTPC mode

- New `--tv-mode` and `--fullscreen` CLI flags
- New `moe.tsuna.tsukimi-tv.desktop.in` launcher (`tsukimi --tv-mode --fullscreen`)
- TV mode activates from CLI, fullscreen launch, Steam Big Picture, or the **TV / HTPC** settings page
- Scaled UI via `tv.css` and configurable **TV UI Scale** (default 1.25×)
- Optional: start fullscreen, hide sidebar by default, show controller hints
- Window decorations hidden in TV mode; **Log Out** / **Quit** moved into the sidebar session menu
- Mouse remains usable while controller navigation is enabled
- Preferences, Sign Out and Quit options in the sidebar (TV Mode only)

### Gamepad / controller support

- Gamepad input via `gilrs` (Xbox, PlayStation, Steam Deck, etc.)
- Toggle in **Settings → TV / HTPC → Enable Gamepad**
- Generic + profile-aware button mapping (`gamepad_profile.rs`)
- Central input router maps controller/keyboard to `InputAction`s (D-pad, A/B, menu, play/pause, etc.)
- Focus highlighting via `.tv-focused` CSS class

### Navigation system

New `src/ui/input/` module with per-context navigators:

| Navigator | Covers |
|-----------|--------|
| `grid_navigator` / `pushed_navigator` | Library grids, home rows, pushed pages |
| `item_navigator` | Episode/series pages (play, subtitle, menus, season dropdown, lower sections) |
| `mpv_navigator` | Video player controls |
| `settings_navigator` | Preferences window (tab switching + row focus) |
| `popover_navigator` | Dropdowns and popovers (B to close) |
| `dialog_navigator` | Modal dialogs |
| `search_navigator` | Search page |
| `placeholder_navigator` | Server select rows (login / edit / delete) |

Also includes scroll/focus improvements in `tuview_scrolled`, `hortu_scrolled`, `horbu_scrolled`, and related list/grid widgets.

### On-screen keyboard (OSK)

- TV-friendly OSK for text fields (password, search, server add, subtitle search, etc.)
- Opens on **A** / click when controller navigation is active
- Does not auto-open just from navigating to a text row

### Conditional subtitle playback rules

- New **Settings → Playback Rules** page
- Rules are subtitle-focused, e.g. *When audio language = Japanese → Subtitles: Off*
- Condition: language (`Any`, `English`, `Japanese`, …) + `Equals` / `Not equals`
- Outcome: subtitle mode (Off / Forced / Full / Prefer language) + language
- Rules apply at playback time via `playback/resolver.rs` and override episode-page subtitle picks when enabled
- Persists as JSON in GSettings (`playback-conditional-rules`)

### Subtitle search

- New subtitle search dialog (`src/subtitles/`)
- Providers: **OpenSubtitles** and **SubDL** (API keys in settings)
- Search/download subtitles from within the app

### Steam integration

- Detect Steam / Big Picture mode
- **Add to Steam** button in TV / HTPC settings
- Uses `steam_shortcuts_util` to add a Tsukimi shortcut to the Steam library

### MPV player

- Controller navigation for player controls
- Trickplay support scaffolding (`trickplay.rs`)
- Playback rules respected when starting playback (`set_slang`, `sid=no`, Jellyfin stream selection)
- GStreamer preview player: fixed unpause panic (no longer `.expect()` on pipeline state changes)

### Dev tooling

- Expanded `justfile` with Distrobox workflows for immutable Fedora hosts (Bazzite, Silverblue, etc.)
- `just dev-tv` — compile, install, and launch with `--tv-mode`
- `docs/build_on_linux.md` updated with dev workflow notes

---

## New dependencies

| Crate | Purpose |
|-------|---------|
| `gilrs` | Gamepad input |
| `steam_shortcuts_util` | Add Tsukimi to Steam library |
| `async-trait` | Subtitle provider trait |

---

## New GSettings keys

- `gamepad-enabled`
- `tv-mode`, `tv-ui-scale`, `tv-start-fullscreen`, `tv-hide-sidebar`, `tv-show-button-hints`
- `playback-conditional-rules`
- `opensubtitles-api-key`, `subdl-api-key`, `subtitle-providers-enabled`

---

## Notes for reviewers

This is a large feature branch (~10k lines). The bulk of new code is in:

- `src/ui/input/` — controller navigation framework
- `src/tv/` — TV mode styling and OSK
- `src/playback/` — conditional subtitle rules
- `src/subtitles/` — subtitle search providers
- `src/ui/widgets/window.rs`, `item.rs`, `tuview_scrolled.rs` — TV navigation hooks

Controller navigation is opt-in via the gamepad toggle or TV mode. Desktop behaviour should be unchanged when neither is active.

Happy to split this into smaller PRs if preferred — TV mode shell, gamepad framework, subtitle rules, and subtitle search are fairly separable.

closes #598 
closes #526 
closes #523 
closes #358 

may also fix #558 via the use of conditional subtitle rules

edit because github didnt like closes issue1 2 3 4 etc