### PR TITLE
feat: support automatically skipping intros and outros

### DIFF
--- a/po/tsukimi.pot
+++ b/po/tsukimi.pot
@@ -6,23 +6,23 @@ msgstr ""
 msgid "Connection Error, Check your internet connection"
 msgstr ""
 
-#: src/ui/mpv/control_sidebar.rs:468
+#: src/ui/mpv/control_sidebar.rs:532
 msgid "Video filter settings cleared."
 msgstr ""
 
-#: src/ui/mpv/control_sidebar.rs:491
+#: src/ui/mpv/control_sidebar.rs:556
 msgid "Subtitle settings cleared."
 msgstr ""
 
-#: src/ui/mpv/control_sidebar.rs:504
+#: src/ui/mpv/control_sidebar.rs:569
 msgid "Subtitle color settings cleared."
 msgstr ""
 
-#: src/ui/mpv/control_sidebar.rs:513
+#: src/ui/mpv/control_sidebar.rs:578
 msgid "Subtitle offset settings cleared."
 msgstr ""
 
-#: src/ui/mpv/control_sidebar.rs:555
+#: src/ui/mpv/control_sidebar.rs:620
 msgid "Deband settings cleared."
 msgstr ""
 
@@ -34,7 +34,7 @@ msgstr ""
 msgid "Failed to get GLContext"
 msgstr ""
 
-#: src/ui/mpv/page.rs:407 src/ui/mpv/page.rs:409 src/ui/widgets/item.rs:689
+#: src/ui/mpv/page.rs:407 src/ui/mpv/page.rs:409 src/ui/widgets/item.rs:699
 #: resources/ui/album_widget.ui:94 resources/ui/item.ui:186
 #: resources/ui/mpv_menu_actions.ui:27 resources/ui/other.ui:95
 #: resources/ui/player_toolbar.ui:90
@@ -45,19 +45,19 @@ msgstr ""
 msgid "Pause"
 msgstr ""
 
-#: src/ui/mpv/page.rs:770
+#: src/ui/mpv/page.rs:777
 msgid "Skip Intro"
 msgstr ""
 
-#: src/ui/mpv/page.rs:771
+#: src/ui/mpv/page.rs:778
 msgid "Skip Outro"
 msgstr ""
 
-#: src/ui/mpv/page.rs:925
+#: src/ui/mpv/page.rs:930
 msgid "No more video found"
 msgstr ""
 
-#: src/ui/mpv/page.rs:1026
+#: src/ui/mpv/page.rs:1031
 msgid ""
 "MPV has been shutdown, Application will exit.\n"
 "Tsukimi can't restart MPV."
@@ -89,39 +89,39 @@ msgstr ""
 msgid "Server added successfully"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:237
+#: src/ui/widgets/account_settings.rs:239
 msgid "Password cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:241
+#: src/ui/widgets/account_settings.rs:243
 msgid "Passwords do not match!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:248
+#: src/ui/widgets/account_settings.rs:250
 msgid "Password changed successfully! Please login again."
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:252
+#: src/ui/widgets/account_settings.rs:254
 msgid "Failed to change password"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:286
+#: src/ui/widgets/account_settings.rs:288
 msgid "Cache Cleared"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:307
+#: src/ui/widgets/account_settings.rs:309
 msgid "No file selected"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:556
 #: src/ui/widgets/account_settings.rs:565
-#: src/ui/widgets/account_settings.rs:599
+#: src/ui/widgets/account_settings.rs:574
 #: src/ui/widgets/account_settings.rs:608
+#: src/ui/widgets/account_settings.rs:617
 msgid "Descriptor cannot be empty!"
 msgstr ""
 
-#: src/ui/widgets/account_settings.rs:570
-#: src/ui/widgets/account_settings.rs:613
+#: src/ui/widgets/account_settings.rs:579
+#: src/ui/widgets/account_settings.rs:622
 msgid "Invalid regex"
 msgstr ""
 
@@ -146,33 +146,33 @@ msgstr ""
 msgid "Failed to get path"
 msgstr ""
 
-#: src/ui/widgets/identify/search_page.rs:124 resources/ui/identify_dialog.ui:6
+#: src/ui/widgets/identify/search_page.rs:125 resources/ui/identify_dialog.ui:6
 #: resources/ui/identify_dialog.ui:14
 #: resources/ui/identify_dialog_search_page.ui:4 resources/ui/pop-menu.ui:56
 msgid "Identify"
 msgstr ""
 
-#: src/ui/widgets/identify/search_page.rs:126
+#: src/ui/widgets/identify/search_page.rs:127
 #: src/ui/widgets/image_dialog/search_page.rs:145
-#: src/ui/widgets/metadata_dialog.rs:290 src/ui/widgets/tu_item/action.rs:485
+#: src/ui/widgets/metadata_dialog.rs:286 src/ui/widgets/tu_item/action.rs:485
 msgid "Are you sure you wish to continue?"
 msgstr ""
 
-#: src/ui/widgets/identify/search_page.rs:129
+#: src/ui/widgets/identify/search_page.rs:130
 #: src/ui/widgets/image_dialog/search_page.rs:148
-#: src/ui/widgets/metadata_dialog.rs:293 src/ui/widgets/tu_item/action.rs:489
-#: src/ui/widgets/tu_item/action.rs:549 resources/ui/account_settings.ui:561
-#: resources/ui/account_settings.ui:671
+#: src/ui/widgets/metadata_dialog.rs:289 src/ui/widgets/tu_item/action.rs:489
+#: src/ui/widgets/tu_item/action.rs:549 resources/ui/account_settings.ui:572
+#: resources/ui/account_settings.ui:682
 msgid "Cancel"
 msgstr ""
 
-#: src/ui/widgets/identify/search_page.rs:130
+#: src/ui/widgets/identify/search_page.rs:131
 #: src/ui/widgets/image_dialog/search_page.rs:149
-#: src/ui/widgets/metadata_dialog.rs:294
+#: src/ui/widgets/metadata_dialog.rs:290
 msgid "Ok"
 msgstr ""
 
-#: src/ui/widgets/identify/search_page.rs:133
+#: src/ui/widgets/identify/search_page.rs:134
 msgid "Replace existing images"
 msgstr ""
 
@@ -188,105 +188,109 @@ msgstr ""
 msgid "Failed to load image"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/image_infocard.rs:153
+#: src/ui/widgets/image_dialog/image_infocard.rs:156
 msgid "No image to view"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/image_infocard.rs:169
+#: src/ui/widgets/image_dialog/image_infocard.rs:172
 msgid "No image to copy"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/image_infocard.rs:173
+#: src/ui/widgets/image_dialog/image_infocard.rs:176
 #: src/ui/widgets/media_viewer.rs:349
 msgid "Image copied to clipboard"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/image_infocard.rs:206
+#: src/ui/widgets/image_dialog/image_infocard.rs:209
 msgid "Image deleted"
 msgstr ""
 
-#: src/ui/widgets/image_dialog/image_infocard.rs:211
+#: src/ui/widgets/image_dialog/image_infocard.rs:214
 msgid "Error deleting image"
+msgstr ""
+
+#: src/ui/widgets/image_dialog/image_infocard.rs:245
+msgid "Error loading image"
 msgstr ""
 
 #: src/ui/widgets/image_dialog/search_page.rs:143
 msgid "Replace Image"
 msgstr ""
 
-#: src/ui/widgets/item.rs:345
+#: src/ui/widgets/item.rs:349
 msgid "No episode selected"
 msgstr ""
 
-#: src/ui/widgets/item.rs:346
+#: src/ui/widgets/item.rs:350
 msgid "Select an episode"
 msgstr ""
 
-#: src/ui/widgets/item.rs:685 src/ui/widgets/list.rs:130
+#: src/ui/widgets/item.rs:695 src/ui/widgets/list.rs:130
 msgid "Resume"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1074
+#: src/ui/widgets/item.rs:1087
 msgid "Codec"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1077
+#: src/ui/widgets/item.rs:1090
 msgid "Language"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1080 resources/ui/metadata_dialog.ui:90
+#: src/ui/widgets/item.rs:1093 resources/ui/metadata_dialog.ui:91
 #: resources/ui/single_grid.ui:108
 msgid "Title"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1084 resources/ui/single_grid.ui:109
+#: src/ui/widgets/item.rs:1097 resources/ui/single_grid.ui:109
 msgid "Bitrate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1089
+#: src/ui/widgets/item.rs:1102
 msgid "BitDepth"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1093
+#: src/ui/widgets/item.rs:1106
 msgid "SampleRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1097
+#: src/ui/widgets/item.rs:1110
 msgid "Height"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1100
+#: src/ui/widgets/item.rs:1113
 msgid "Width"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1103
+#: src/ui/widgets/item.rs:1116
 msgid "ColorSpace"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1107
+#: src/ui/widgets/item.rs:1120
 msgid "DisplayTitle"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1111
+#: src/ui/widgets/item.rs:1124
 msgid "Channel"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1115
+#: src/ui/widgets/item.rs:1128
 msgid "ChannelLayout"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1120
+#: src/ui/widgets/item.rs:1133
 msgid "AverageFrameRate"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1124
+#: src/ui/widgets/item.rs:1137
 msgid "PixelFormat"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1236
+#: src/ui/widgets/item.rs:1249
 msgid "No video source found"
 msgstr ""
 
-#: src/ui/widgets/item.rs:1372
+#: src/ui/widgets/item.rs:1322
 msgid "Season not found. Is this a continue watching list?"
 msgstr ""
 
@@ -311,12 +315,12 @@ msgid "BoxSet"
 msgstr ""
 
 #: src/ui/widgets/list.rs:132 resources/ui/filter.ui:85
-#: resources/ui/item.ui:489 resources/ui/other.ui:168
+#: resources/ui/item.ui:490 resources/ui/other.ui:168
 msgid "Tags"
 msgstr ""
 
 #: src/ui/widgets/list.rs:133 resources/ui/filter.ui:78
-#: resources/ui/item.ui:484 resources/ui/other.ui:173
+#: resources/ui/item.ui:485 resources/ui/other.ui:173
 msgid "Genres"
 msgstr ""
 
@@ -329,8 +333,8 @@ msgstr ""
 msgid "Folder"
 msgstr ""
 
-#: src/ui/widgets/metadata_dialog.rs:288 resources/ui/filter.ui:179
-#: resources/ui/metadata_dialog.ui:230
+#: src/ui/widgets/metadata_dialog.rs:284 resources/ui/filter.ui:179
+#: resources/ui/metadata_dialog.ui:231
 msgid "Apply"
 msgstr ""
 
@@ -350,7 +354,7 @@ msgstr ""
 msgid "Scanning..."
 msgstr ""
 
-#: src/ui/widgets/search.rs:199
+#: src/ui/widgets/search.rs:205
 msgid "No overview"
 msgstr ""
 
@@ -447,7 +451,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: src/ui/widgets/window.rs:328 resources/ui/identify_dialog.ui:94
+#: src/ui/widgets/window.rs:328 resources/ui/identify_dialog.ui:95
 #: resources/ui/image_info_card.ui:127 resources/ui/search.ui:23
 #: resources/ui/window.ui:21 resources/ui/window.ui:262
 msgid "Search"
@@ -457,16 +461,16 @@ msgstr ""
 msgid "Server Panel"
 msgstr ""
 
-#: src/ui/widgets/window.rs:989
+#: src/ui/widgets/window.rs:988
 msgid "Fatal Error"
 msgstr ""
 
-#: src/ui/widgets/window.rs:992
+#: src/ui/widgets/window.rs:991
 msgid "Copy Error & Close"
 msgstr ""
 
 #. TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-#: src/ui/widgets/window.rs:1021
+#: src/ui/widgets/window.rs:1020
 msgid "translator-credits"
 msgstr ""
 
@@ -478,7 +482,7 @@ msgstr ""
 msgid "Enter the server details below."
 msgstr ""
 
-#: resources/ui/account.ui:48 resources/ui/identify_dialog.ui:74
+#: resources/ui/account.ui:48 resources/ui/identify_dialog.ui:75
 #: resources/ui/other.ui:73
 msgid "Name"
 msgstr ""
@@ -499,7 +503,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: resources/ui/account.ui:108 resources/ui/account_settings.ui:567
+#: resources/ui/account.ui:108 resources/ui/account_settings.ui:578
 msgid "Add"
 msgstr ""
 
@@ -524,7 +528,7 @@ msgid "Preferred Audio Language"
 msgstr ""
 
 #: resources/ui/account_settings.ui:30 resources/ui/account_settings.ui:56
-#: resources/ui/account_settings.ui:201
+#: resources/ui/account_settings.ui:212
 msgid "Default"
 msgstr ""
 
@@ -532,255 +536,263 @@ msgstr ""
 msgid "Preferred Subtitle Language"
 msgstr ""
 
-#: resources/ui/account_settings.ui:75
-msgid "Appearance"
+#: resources/ui/account_settings.ui:75 resources/ui/mpv_shortcuts_window.ui:6
+msgid "Playback"
 msgstr ""
 
 #: resources/ui/account_settings.ui:78
-msgid "Use Custom Accent Color"
+msgid "Automatically Skip Intros and Outros"
 msgstr ""
 
-#: resources/ui/account_settings.ui:79
-msgid "Disable to follow the system accent color"
-msgstr ""
-
-#: resources/ui/account_settings.ui:84
-msgid "Accent Color"
-msgstr ""
-
-#: resources/ui/account_settings.ui:100
-msgid "Hide Sidebar"
-msgstr ""
-
-#: resources/ui/account_settings.ui:105
-msgid "Auto Select Last Server"
-msgstr ""
-
-#: resources/ui/account_settings.ui:110
-msgid "Text Display"
-msgstr ""
-
-#: resources/ui/account_settings.ui:116
-msgid "Compact"
-msgstr ""
-
-#: resources/ui/account_settings.ui:122
-msgid "Full"
-msgstr ""
-
-#: resources/ui/account_settings.ui:132
-msgid "Card Style"
-msgstr ""
-
-#: resources/ui/account_settings.ui:138
-msgid "Integrated"
-msgstr ""
-
-#: resources/ui/account_settings.ui:144
-msgid "Separated"
-msgstr ""
-
-#: resources/ui/account_settings.ui:156
-msgid "Home Page"
-msgstr ""
-
-#: resources/ui/account_settings.ui:159
-msgid "Refresh when returning to home page"
-msgstr ""
-
-#: resources/ui/account_settings.ui:164
-msgid "Merge Continue Watching and Next Up"
-msgstr ""
-
-#: resources/ui/account_settings.ui:165
+#: resources/ui/account_settings.ui:79 resources/ui/account_settings.ui:176
 msgid "Jellyfin only"
 msgstr ""
 
-#: resources/ui/account_settings.ui:172
-msgid "Network"
+#: resources/ui/account_settings.ui:86
+msgid "Appearance"
+msgstr ""
+
+#: resources/ui/account_settings.ui:89
+msgid "Use Custom Accent Color"
+msgstr ""
+
+#: resources/ui/account_settings.ui:90
+msgid "Disable to follow the system accent color"
+msgstr ""
+
+#: resources/ui/account_settings.ui:95
+msgid "Accent Color"
+msgstr ""
+
+#: resources/ui/account_settings.ui:111
+msgid "Hide Sidebar"
+msgstr ""
+
+#: resources/ui/account_settings.ui:116
+msgid "Auto Select Last Server"
+msgstr ""
+
+#: resources/ui/account_settings.ui:121
+msgid "Text Display"
+msgstr ""
+
+#: resources/ui/account_settings.ui:127
+msgid "Compact"
+msgstr ""
+
+#: resources/ui/account_settings.ui:133
+msgid "Full"
+msgstr ""
+
+#: resources/ui/account_settings.ui:143
+msgid "Card Style"
+msgstr ""
+
+#: resources/ui/account_settings.ui:149
+msgid "Integrated"
+msgstr ""
+
+#: resources/ui/account_settings.ui:155
+msgid "Separated"
+msgstr ""
+
+#: resources/ui/account_settings.ui:167
+msgid "Home Page"
+msgstr ""
+
+#: resources/ui/account_settings.ui:170
+msgid "Refresh when returning to home page"
 msgstr ""
 
 #: resources/ui/account_settings.ui:175
+msgid "Merge Continue Watching and Next Up"
+msgstr ""
+
+#: resources/ui/account_settings.ui:183
+msgid "Network"
+msgstr ""
+
+#: resources/ui/account_settings.ui:186
 msgid "Threads"
 msgstr ""
 
-#: resources/ui/account_settings.ui:176
+#: resources/ui/account_settings.ui:187
 msgid "Excessive thread counts may exhaust the system's connection pool"
 msgstr ""
 
-#: resources/ui/account_settings.ui:192 resources/ui/mpv_control_sidebar.ui:399
+#: resources/ui/account_settings.ui:203 resources/ui/mpv_control_sidebar.ui:399
 msgid "Background"
 msgstr ""
 
-#: resources/ui/account_settings.ui:224
+#: resources/ui/account_settings.ui:235
 msgid "Opacity"
 msgstr ""
 
-#: resources/ui/account_settings.ui:238
+#: resources/ui/account_settings.ui:249
 msgid "Blur"
 msgstr ""
 
-#: resources/ui/account_settings.ui:243
+#: resources/ui/account_settings.ui:254
 msgid "Blur Radius"
 msgstr ""
 
-#: resources/ui/account_settings.ui:259 resources/ui/mpv_control_sidebar.ui:84
+#: resources/ui/account_settings.ui:270 resources/ui/mpv_control_sidebar.ui:84
 msgid "Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:262
+#: resources/ui/account_settings.ui:273
 msgid "Clear Cache"
 msgstr ""
 
-#: resources/ui/account_settings.ui:277 resources/ui/account_settings.ui:396
+#: resources/ui/account_settings.ui:288 resources/ui/account_settings.ui:407
 msgid "Others"
 msgstr ""
 
-#: resources/ui/account_settings.ui:280 resources/ui/account_settings.ui:472
+#: resources/ui/account_settings.ui:291 resources/ui/account_settings.ui:483
 msgid "Preferred Video Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:292
+#: resources/ui/account_settings.ui:303
 msgid "Account"
 msgstr ""
 
-#: resources/ui/account_settings.ui:305 resources/ui/account_settings.ui:322
+#: resources/ui/account_settings.ui:316 resources/ui/account_settings.ui:333
 msgid "Change Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:308
+#: resources/ui/account_settings.ui:319
 msgid "New Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:313
+#: resources/ui/account_settings.ui:324
 msgid "Confirm Password"
 msgstr ""
 
-#: resources/ui/account_settings.ui:336
+#: resources/ui/account_settings.ui:347
 msgid "Media"
 msgstr ""
 
-#: resources/ui/account_settings.ui:341
+#: resources/ui/account_settings.ui:352
 msgid "Music Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:344 resources/ui/player_toolbar.ui:197
+#: resources/ui/account_settings.ui:355 resources/ui/player_toolbar.ui:197
 msgid "Repeat Mode"
 msgstr ""
 
-#: resources/ui/account_settings.ui:348 resources/ui/player_toolbar.ui:231
+#: resources/ui/account_settings.ui:359 resources/ui/player_toolbar.ui:231
 msgid "Repeat One"
 msgstr ""
 
-#: resources/ui/account_settings.ui:349 resources/ui/player_toolbar.ui:235
+#: resources/ui/account_settings.ui:360 resources/ui/player_toolbar.ui:235
 msgid "Repeat All"
 msgstr ""
 
-#: resources/ui/account_settings.ui:350 resources/ui/account_settings.ui:378
+#: resources/ui/account_settings.ui:361 resources/ui/account_settings.ui:389
 #: resources/ui/player_toolbar.ui:239
 msgid "None"
 msgstr ""
 
-#: resources/ui/account_settings.ui:360
+#: resources/ui/account_settings.ui:371
 msgid "Video Player"
 msgstr ""
 
-#: resources/ui/account_settings.ui:361
+#: resources/ui/account_settings.ui:372
 msgid "Requires restart"
 msgstr ""
 
-#: resources/ui/account_settings.ui:364
+#: resources/ui/account_settings.ui:375
 msgid "Enable external config"
 msgstr ""
 
-#: resources/ui/account_settings.ui:369
+#: resources/ui/account_settings.ui:380
 msgid "Config dir"
 msgstr ""
 
-#: resources/ui/account_settings.ui:401
+#: resources/ui/account_settings.ui:412
 msgid "Video Output"
 msgstr ""
 
-#: resources/ui/account_settings.ui:402
+#: resources/ui/account_settings.ui:413
 msgid "Only for debugging"
 msgstr ""
 
-#: resources/ui/account_settings.ui:405
+#: resources/ui/account_settings.ui:416
 msgid "libmpv (default)"
 msgstr ""
 
-#: resources/ui/account_settings.ui:450
+#: resources/ui/account_settings.ui:461
 msgid "Preferred Version"
 msgstr ""
 
-#: resources/ui/account_settings.ui:473
+#: resources/ui/account_settings.ui:484
 msgid ""
 "Weight is ordered from high to low, until a specific version is matched, or "
 "the highest matching version is obtained before clearing the match list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:488
+#: resources/ui/account_settings.ui:499
 msgid "Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:510
+#: resources/ui/account_settings.ui:521
 msgid "It is recommended to set no more than 3 lines"
 msgstr ""
 
-#: resources/ui/account_settings.ui:531
+#: resources/ui/account_settings.ui:542
 msgid "No Descriptors"
 msgstr ""
 
-#: resources/ui/account_settings.ui:550
+#: resources/ui/account_settings.ui:561
 msgid "Add a descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:592 resources/ui/account_settings.ui:702
+#: resources/ui/account_settings.ui:603 resources/ui/account_settings.ui:713
 msgid "This will use exact matching to obtain a list"
 msgstr ""
 
-#: resources/ui/account_settings.ui:595 resources/ui/account_settings.ui:705
+#: resources/ui/account_settings.ui:606 resources/ui/account_settings.ui:716
 msgid "Descriptor Type"
 msgstr ""
 
-#: resources/ui/account_settings.ui:600 resources/ui/account_settings.ui:710
+#: resources/ui/account_settings.ui:611 resources/ui/account_settings.ui:721
 msgid "String"
 msgstr ""
 
-#: resources/ui/account_settings.ui:601 resources/ui/account_settings.ui:711
+#: resources/ui/account_settings.ui:612 resources/ui/account_settings.ui:722
 msgid "Regular Expression"
 msgstr ""
 
-#: resources/ui/account_settings.ui:613 resources/ui/account_settings.ui:723
+#: resources/ui/account_settings.ui:624 resources/ui/account_settings.ui:734
 msgid "Descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:618 resources/ui/account_settings.ui:728
+#: resources/ui/account_settings.ui:629 resources/ui/account_settings.ui:739
 msgid "Descriptor should not be too long"
 msgstr ""
 
-#: resources/ui/account_settings.ui:629 resources/ui/account_settings.ui:739
+#: resources/ui/account_settings.ui:640 resources/ui/account_settings.ui:750
 msgid "eg. 1080p"
 msgstr ""
 
-#: resources/ui/account_settings.ui:640 resources/ui/account_settings.ui:750
+#: resources/ui/account_settings.ui:651 resources/ui/account_settings.ui:761
 msgid "eg. 1080p.*WebDL"
 msgstr ""
 
-#: resources/ui/account_settings.ui:660
+#: resources/ui/account_settings.ui:671
 msgid "Edit descriptor"
 msgstr ""
 
-#: resources/ui/account_settings.ui:677
+#: resources/ui/account_settings.ui:688
 #: resources/ui/image_dialog_edit_page.ui:37
 msgid "Save"
 msgstr ""
 
-#: resources/ui/account_settings.ui:770
+#: resources/ui/account_settings.ui:781
 msgid "Change folder"
 msgstr ""
 
-#: resources/ui/account_settings.ui:772
+#: resources/ui/account_settings.ui:783
 msgid "Select new mpv config folder"
 msgstr ""
 
@@ -821,7 +833,7 @@ msgstr ""
 msgid "Official Ratings"
 msgstr ""
 
-#: resources/ui/filter.ui:106 resources/ui/item.ui:479
+#: resources/ui/filter.ui:106 resources/ui/item.ui:480
 #: resources/ui/other.ui:163
 msgid "Studios"
 msgstr ""
@@ -860,21 +872,21 @@ msgid ""
 "results."
 msgstr ""
 
-#: resources/ui/identify_dialog.ui:60 resources/ui/metadata_dialog.ui:80
+#: resources/ui/identify_dialog.ui:61 resources/ui/metadata_dialog.ui:81
 msgid "Path"
 msgstr ""
 
-#: resources/ui/identify_dialog.ui:61
+#: resources/ui/identify_dialog.ui:62
 #: resources/ui/image_dialog_search_page.ui:54 resources/ui/item.ui:110
 #: resources/ui/item.ui:158
 msgid "Loading..."
 msgstr ""
 
-#: resources/ui/identify_dialog.ui:79
+#: resources/ui/identify_dialog.ui:80
 msgid "Year"
 msgstr ""
 
-#: resources/ui/identify_dialog.ui:86
+#: resources/ui/identify_dialog.ui:87
 msgid "External"
 msgstr ""
 
@@ -965,36 +977,36 @@ msgstr ""
 msgid "View this season"
 msgstr ""
 
-#: resources/ui/item.ui:422 resources/ui/liked.ui:69
+#: resources/ui/item.ui:423 resources/ui/liked.ui:69
 #: resources/ui/single_grid.ui:167
 msgid "Nothing Here"
 msgstr ""
 
-#: resources/ui/item.ui:449
+#: resources/ui/item.ui:450
 msgid "Included In"
 msgstr ""
 
-#: resources/ui/item.ui:454
+#: resources/ui/item.ui:455
 msgid "Additional Parts"
 msgstr ""
 
-#: resources/ui/item.ui:459
+#: resources/ui/item.ui:460
 msgid "Seasons"
 msgstr ""
 
-#: resources/ui/item.ui:464 resources/ui/other.ui:158
+#: resources/ui/item.ui:465 resources/ui/other.ui:158
 msgid "Actors"
 msgstr ""
 
-#: resources/ui/item.ui:469
+#: resources/ui/item.ui:470
 msgid "Recommend"
 msgstr ""
 
-#: resources/ui/item.ui:474 resources/ui/other.ui:178
+#: resources/ui/item.ui:475 resources/ui/other.ui:178
 msgid "Links"
 msgstr ""
 
-#: resources/ui/item.ui:507
+#: resources/ui/item.ui:508
 msgid "MediaInfo"
 msgstr ""
 
@@ -1039,47 +1051,47 @@ msgstr ""
 msgid "Exit Fullscreen"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:81
+#: resources/ui/metadata_dialog.ui:82
 msgid "No data."
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:95
+#: resources/ui/metadata_dialog.ui:96
 msgid "Sort Title"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:100 resources/ui/single_grid.ui:110
+#: resources/ui/metadata_dialog.ui:101 resources/ui/single_grid.ui:110
 msgid "Date Created"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:106
+#: resources/ui/metadata_dialog.ui:107
 msgid "Pick Date"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:126
+#: resources/ui/metadata_dialog.ui:127
 msgid "Pick Time"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:179
+#: resources/ui/metadata_dialog.ui:180
 msgid "Overview"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:196
+#: resources/ui/metadata_dialog.ui:197
 msgid "External Ids"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:202
+#: resources/ui/metadata_dialog.ui:203
 msgid "TheMovieDb Id"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:207
+#: resources/ui/metadata_dialog.ui:208
 msgid "TheTVDb Id"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:212
+#: resources/ui/metadata_dialog.ui:213
 msgid "IMDb Id"
 msgstr ""
 
-#: resources/ui/metadata_dialog.ui:220
+#: resources/ui/metadata_dialog.ui:221
 msgid "Lock The Item"
 msgstr ""
 
@@ -1402,10 +1414,6 @@ msgstr ""
 
 #: resources/ui/mpv_menu_actions.ui:42 resources/ui/mpvpage.ui:291
 msgid "Forward"
-msgstr ""
-
-#: resources/ui/mpv_shortcuts_window.ui:6
-msgid "Playback"
 msgstr ""
 
 #: resources/ui/mpv_shortcuts_window.ui:9

--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -275,6 +275,10 @@
       <summary>Merge Continue Watching and Next Up on Jellyfin</summary>
       <default>false</default>
     </key>
+    <key name="auto-skip-intro-outro" type="b">
+      <summary>Automatically skip intro and outro segments</summary>
+      <default>false</default>
+    </key>
     <key name="is-danmaku-enabled" type="b">
       <summary>Whether the danmaku is enabled</summary>
       <default>false</default>

--- a/resources/ui/account_settings.ui
+++ b/resources/ui/account_settings.ui
@@ -72,6 +72,17 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">Playback</property>
+            <child>
+              <object class="AdwSwitchRow" id="auto_skip_intro_outro_control">
+                <property name="title" translatable="yes">Automatically Skip Intros and Outros</property>
+                <property name="subtitle" translatable="yes">Jellyfin only</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">Appearance</property>
             <child>
               <object class="AdwSwitchRow" id="custom_accent_color_control">

--- a/src/ui/models/settings.rs
+++ b/src/ui/models/settings.rs
@@ -70,6 +70,7 @@ impl Settings {
     const KEY_MPV_CONFIG_DIR: &'static str = "mpv-config-path"; // String
     const KEY_IS_REFRESH: &'static str = "is-refresh"; // bool
     const KEY_MERGE_RESUME_AND_NEXT_UP: &'static str = "merge-resume-and-next-up"; // bool
+    const KEY_AUTO_SKIP_INTRO_OUTRO: &'static str = "auto-skip-intro-outro"; // bool
     const KEY_DEVICE_UUID: &'static str = "device-uuid"; // String
     const KEY_MAIN_THEME: &'static str = "main-theme"; // i32
     const KEY_WINDOW_WIDTH: &'static str = "window-width"; // i32
@@ -131,6 +132,10 @@ impl Settings {
 
     pub fn merge_resume_and_next_up(&self) -> bool {
         self.boolean(Self::KEY_MERGE_RESUME_AND_NEXT_UP)
+    }
+
+    pub fn auto_skip_intro_outro(&self) -> bool {
+        self.boolean(Self::KEY_AUTO_SKIP_INTRO_OUTRO)
     }
 
     pub fn item_text_display(&self) -> String {

--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -765,6 +765,13 @@ impl MPVPage {
                             .then_some((segment.segment_type, end))
                     })
                 });
+        let segment_end = current_segment.map(|(_, end)| end);
+        self.imp().current_segment_end.set(segment_end);
+
+        if segment_end.is_some() && SETTINGS.auto_skip_intro_outro() {
+            return self.on_skip_segment_clicked();
+        }
+
         if let Some((kind, _)) = current_segment {
             let label = match kind {
                 MediaSegmentType::Intro => gettext("Skip Intro"),
@@ -773,8 +780,6 @@ impl MPVPage {
             };
             self.imp().skip_segment_button.set_label(&label);
         }
-        let segment_end = current_segment.map(|(_, end)| end);
-        self.imp().current_segment_end.set(segment_end);
         self.imp()
             .skip_segment_revealer
             .set_reveal_child(segment_end.is_some());

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -71,6 +71,8 @@ mod imp {
         #[template_child]
         pub merge_resume_next_up_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub auto_skip_intro_outro_control: TemplateChild<adw::SwitchRow>,
+        #[template_child]
         pub selectlastcontrol: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub text_display_group: TemplateChild<adw::ToggleGroup>,
@@ -421,6 +423,13 @@ impl AccountSettings {
             .bind(
                 "merge-resume-and-next-up",
                 &imp.merge_resume_next_up_control.get(),
+                "active",
+            )
+            .build();
+        SETTINGS
+            .bind(
+                "auto-skip-intro-outro",
+                &imp.auto_skip_intro_outro_control.get(),
                 "active",
             )
             .build();


### PR DESCRIPTION
We previously introduced intro and outro skip buttons for Jellyfin. This PR adds an automatic skipping option. When enabled, it bypasses the button display logic and behaves as if the skip button were clicked immediately.