### PR TITLE
Adds hide library toggle button

### DIFF
--- a/resources/moe.tsuna.tsukimi.gschema.xml
+++ b/resources/moe.tsuna.tsukimi.gschema.xml
@@ -278,5 +278,9 @@
       <summary>Whether the danmaku is enabled</summary>
       <default>false</default>
     </key>
+    <key name="hide-libraries" type="b">
+      <summary>Whether to hide libraries</summary>
+      <default>false</default>
+      </key>
   </schema>
 </schemalist>

--- a/resources/ui/account_settings.ui
+++ b/resources/ui/account_settings.ui
@@ -176,6 +176,12 @@
                 <property name="subtitle" translatable="yes">Jellyfin only</property>
               </object>
             </child>
+        <child>
+          <object class="AdwSwitchRow" id="hide_libraries_control">
+            <property name="title" translatable="yes">Hide Libraries</property>
+            <property name="subtitle" translatable="yes">Hide the library row at the top of the home page</property>
+          </object>
+        </child>
           </object>
         </child>
         <child>

--- a/src/ui/widgets/account_settings.rs
+++ b/src/ui/widgets/account_settings.rs
@@ -69,6 +69,8 @@ mod imp {
         #[template_child]
         pub refresh_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
+        pub hide_libraries_control: TemplateChild<adw::SwitchRow>,
+        #[template_child]
         pub merge_resume_next_up_control: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub auto_skip_intro_outro_control: TemplateChild<adw::SwitchRow>,
@@ -423,6 +425,13 @@ impl AccountSettings {
             .bind(
                 "merge-resume-and-next-up",
                 &imp.merge_resume_next_up_control.get(),
+                "active",
+            )
+            .build();
+        SETTINGS
+            .bind(
+                "hide-libraries",
+                &imp.hide_libraries_control.get(),
                 "active",
             )
             .build();

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -113,6 +113,7 @@ mod imp {
             self.parent_constructed();
             let obj = self.obj();
             obj.setup_next_up_morebutton();
+            obj.bind_hide_libraries();
             obj.init_load();
         }
     }
@@ -163,6 +164,14 @@ impl HomePage {
                 obj.setup(enable_cache).await;
             }
         ));
+    }
+
+    pub fn bind_hide_libraries(&self) {
+        let hortu = self.imp().libhortu.get();
+        SETTINGS
+            .bind("hide-libraries", &hortu, "visible")
+            .flags(gio::SettingsBindFlags::GET | gio::SettingsBindFlags::INVERT_BOOLEAN)
+            .build();
     }
 
     pub async fn setup(&self, enable_cache: bool) {


### PR DESCRIPTION
This small PR adds another Toggle under Home Page in the General tab of Preferences. Toggling Hide Libraries to On will hide the Library row at the top of Home (pending reload), making the Continue Watching (or merged Continue Watching + Next Up) row show up as the first row, which puts the focus on new content available.


<img width="554" height="464" alt="image" src="https://github.com/user-attachments/assets/cd51ef82-2b9f-4981-a4e8-75f121453766" />


This does mean libraries are difficult to navigate to when this is toggled on. If this PR is accepted, I will continue to work on exposing libraries under the server name under Servers in the side bar. This would allow them to be easily accessible, but also out of the way. This seemed a more involved change at first glance, so I figured I'd make this small change first and test the waters.


AI Disclaimer: I did use AI to help me navigate the new-to-me code base, and to understand some of the logic behind the rendering of the home page.