### PR TITLE
Fix poster card bounds and multi-button context-menu gestures

### DIFF
--- a/src/ui/mpv/page.rs
+++ b/src/ui/mpv/page.rs
@@ -1799,9 +1799,7 @@ impl MPVPage {
         }
     }
 
-    pub fn key_pressed_cb(
-        &self, key: gtk::gdk::Key, state: gtk::gdk::ModifierType,
-    ) -> bool {
+    pub fn key_pressed_cb(&self, key: gtk::gdk::Key, state: gtk::gdk::ModifierType) -> bool {
         if key.to_lower() == gtk::gdk::Key::f || key == gtk::gdk::Key::Escape {
             return true;
         }

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -156,7 +156,10 @@ mod imp {
                     gesture.connect_released(glib::clone!(
                         #[weak]
                         tu_item,
-                        move |gesture, _, _, _| {
+                        move |gesture, _, x, y| {
+                            if !tu_item.contains(x, y) {
+                                return;
+                            }
                             gesture.set_state(gtk::EventSequenceState::Claimed);
                             tu_item.item().activate(&tu_item);
                         }

--- a/src/ui/widgets/hover_scale.rs
+++ b/src/ui/widgets/hover_scale.rs
@@ -42,6 +42,7 @@ mod imp {
 
         pub cursor_nx: Cell<f32>,
         pub cursor_ny: Cell<f32>,
+        pub pointer_inside: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -79,19 +80,7 @@ mod imp {
                 #[weak]
                 obj,
                 move |_, x, y| {
-                    let imp = obj.imp();
-                    let w = obj.width() as f64;
-                    let h = obj.height() as f64;
-                    if w > 0.0 && h > 0.0 {
-                        imp.cursor_nx.set((x / w - 0.5) as f32);
-                        imp.cursor_ny.set((y / h - 0.5) as f32);
-                    }
-                    let Some(animation) = imp.animation() else {
-                        return;
-                    };
-                    animation.set_value_from(animation.value());
-                    animation.set_value_to(1.0);
-                    animation.play();
+                    obj.imp().update_pointer(x, y);
                 }
             ));
 
@@ -100,14 +89,7 @@ mod imp {
                 #[weak]
                 obj,
                 move |_, x, y| {
-                    let imp = obj.imp();
-                    let w = obj.width() as f64;
-                    let h = obj.height() as f64;
-                    if w > 0.0 && h > 0.0 {
-                        imp.cursor_nx.set((x / w - 0.5) as f32);
-                        imp.cursor_ny.set((y / h - 0.5) as f32);
-                        obj.queue_draw();
-                    }
+                    obj.imp().update_pointer(x, y);
                 }
             ));
 
@@ -115,12 +97,7 @@ mod imp {
                 #[weak]
                 obj,
                 move |_| {
-                    let Some(animation) = obj.imp().animation() else {
-                        return;
-                    };
-                    animation.set_value_from(animation.value());
-                    animation.set_value_to(0.0);
-                    animation.play();
+                    obj.imp().set_pointer_inside(false);
                 }
             ));
 
@@ -235,6 +212,34 @@ mod imp {
     }
 
     impl HoverScale {
+        fn update_pointer(&self, x: f64, y: f64) {
+            let obj = self.obj();
+            let w = obj.width() as f64;
+            let h = obj.height() as f64;
+            if w <= 0.0 || h <= 0.0 || !obj.contains(x, y) {
+                self.set_pointer_inside(false);
+                return;
+            }
+
+            self.cursor_nx.set((x / w - 0.5) as f32);
+            self.cursor_ny.set((y / h - 0.5) as f32);
+            self.set_pointer_inside(true);
+            obj.queue_draw();
+        }
+
+        fn set_pointer_inside(&self, inside: bool) {
+            if self.pointer_inside.replace(inside) == inside {
+                return;
+            }
+
+            let Some(animation) = self.animation() else {
+                return;
+            };
+            animation.set_value_from(animation.value());
+            animation.set_value_to(if inside { 1.0 } else { 0.0 });
+            animation.play();
+        }
+
         fn call_underlay(&self, snapshot: &gtk::Snapshot) {
             if let Some(f) = self.underlay.borrow().as_ref() {
                 f(snapshot);

--- a/src/ui/widgets/tu_item/action.rs
+++ b/src/ui/widgets/tu_item/action.rs
@@ -146,6 +146,14 @@ where
     fn gesture_click(&self) -> gtk::GestureClick {
         let gesture = gtk::GestureClick::new();
         gesture.set_button(3);
+        gesture.connect_pressed(|gesture, _, _, _| {
+            if !gesture
+                .current_event()
+                .is_some_and(|event| event.triggers_context_menu())
+            {
+                gesture.set_state(gtk::EventSequenceState::Denied);
+            }
+        });
         gesture.connect_released(glib::clone!(
             #[weak(rename_to = obj)]
             self,

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -817,9 +817,7 @@ impl Window {
     }
 
     #[template_callback]
-    fn key_released_cb(
-        &self, key: gtk::gdk::Key, _code: u32, state: gtk::gdk::ModifierType,
-    ) {
+    fn key_released_cb(&self, key: gtk::gdk::Key, _code: u32, state: gtk::gdk::ModifierType) {
         if self.is_on_mpv_stack() {
             self.imp().mpvnav.key_released_cb(key, state);
         }

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -18,7 +18,6 @@ mod imp {
     use gtk::{
         CompositeTemplate,
         glib,
-        prelude::*,
         subclass::prelude::*,
     };
 


### PR DESCRIPTION
Previously, holding the mouse button on a poster card and moving the pointer outside it could make the card tilt excessively and produce visual artifacts. Releasing the button outside the card could also activate it unexpectedly. This PR makes the card return to its normal state when the pointer leaves and only activates it when the button is released inside the card, matching standard button behavior.

It also fixes a Wayland issue where right-clicking while holding the left mouse button could cause the app to stop responding to further mouse clicks.

Before:

https://github.com/user-attachments/assets/36ae0565-bcf7-4db8-9df5-9fcca72dcf76

After:

https://github.com/user-attachments/assets/f3c46202-5408-44a9-912c-bb289641b025

