### PR TITLE
feat: align core image fallback and sizing logic with Jellyfin Web

### DIFF
--- a/resources/ui/danmaku_search_dialog.ui
+++ b/resources/ui/danmaku_search_dialog.ui
@@ -98,7 +98,7 @@
                         <child>
                           <object class="TuViewScrolled" id="view">
                             <property name="vexpand">True</property>
-                            <property name="unify-size">ForcePost</property>
+                            <property name="card-shape">Portrait</property>
                           </object>
                         </child>
                       </object>

--- a/resources/ui/home.ui
+++ b/resources/ui/home.ui
@@ -20,16 +20,16 @@
                   <object class="HortuScrolled" id="hishortu">
                     <property name="title" translatable="yes">Continue Watching</property>
                     <property name="is-resume">True</property>
-                    <property name="prefer-poster">ParentVideo</property>
-                    <property name="unify-size">ForceVideo</property>
+                    <property name="prefer-thumb">True</property>
+                    <property name="card-shape">Backdrop</property>
                   </object>
                 </child>
                 <child>
                   <object class="HortuScrolled" id="nextuphortu">
                     <property name="title" translatable="yes">Next Up</property>
                     <property name="is-resume">True</property>
-                    <property name="prefer-poster">ParentVideo</property>
-                    <property name="unify-size">ForceVideo</property>
+                    <property name="prefer-thumb">True</property>
+                    <property name="card-shape">Backdrop</property>
                   </object>
                 </child>
                 <child>

--- a/resources/ui/item.ui
+++ b/resources/ui/item.ui
@@ -272,7 +272,7 @@
                             <property name="halign">start</property>
                             <property name="valign">start</property>
                             <child>
-                              <object class="GtkBox" id="logobox">
+                              <object class="AdwBin" id="logo_bin">
                                 <property name="height-request">150</property>
                                 <style>
                                   <class name="logo"/>
@@ -460,6 +460,7 @@
                         <child>
                           <object class="HortuScrolled" id="actorhortu">
                             <property name="title" translatable="yes">Actors</property>
+                            <property name="card-shape">Portrait</property>
                           </object>
                         </child>
                         <child>

--- a/resources/ui/other.ui
+++ b/resources/ui/other.ui
@@ -156,6 +156,7 @@
                             <child>
                               <object class="HortuScrolled" id="actorhortu">
                                 <property name="title" translatable="yes">Actors</property>
+                                <property name="card-shape">Portrait</property>
                               </object>
                             </child>
                             <child>

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -633,7 +633,7 @@ impl JellyfinClient {
     }
 
     pub async fn image_request(
-        &self, id: &str, image_type: &str, tag: Option<u8>, etag: Option<String>,
+        &self, id: &str, image_type: &str, tag: Option<String>, etag: Option<String>,
     ) -> Result<Response> {
         let mut path = format!("Items/{id}/Images/{image_type}");
         if let Some(tag) = tag {
@@ -660,9 +660,16 @@ impl JellyfinClient {
         self.request_picture(&path, &params, etag).await
     }
 
-    pub async fn get_image(&self, id: &str, image_type: &str, tag: Option<u8>) -> Result<String> {
+    pub async fn get_image(
+        &self, id: &str, image_type: &str, tag: Option<String>,
+    ) -> Result<String> {
         let mut path = jellyfin_cache_path().await;
-        path.push(format!("{}-{}-{}", id, image_type, tag.unwrap_or(0)));
+        path.push(format!(
+            "{}-{}-{}",
+            id,
+            image_type,
+            tag.clone().unwrap_or_else(|| "0".into())
+        ));
 
         let mut etag: Option<String> = None;
 
@@ -673,7 +680,7 @@ impl JellyfinClient {
                 .and_then(|v| String::from_utf8(v).ok());
         }
 
-        match self.image_request(id, image_type, tag, etag).await {
+        match self.image_request(id, image_type, tag.clone(), etag).await {
             Ok(response) => {
                 if response.status() == reqwest::StatusCode::NOT_MODIFIED {
                     return Ok(path.to_string_lossy().to_string());
@@ -690,11 +697,11 @@ impl JellyfinClient {
 
                 let bytes = response.bytes().await?;
 
-                let path = if bytes.len() > 1000 {
-                    self.save_image(id, image_type, tag, &bytes, etag).await
-                } else {
-                    String::new()
-                };
+                if bytes.is_empty() {
+                    return Ok(String::new());
+                }
+
+                let path = self.save_image(id, image_type, tag, &bytes, etag).await;
 
                 Ok(path)
             }
@@ -717,7 +724,7 @@ impl JellyfinClient {
     }
 
     pub async fn post_image_url(
-        &self, id: &str, image_type: &str, tag: u8, url: &str,
+        &self, id: &str, image_type: &str, tag: String, url: &str,
     ) -> Result<Response> {
         let path = format!("Items/{id}/Images/{tag}/{image_type}");
         let body = json!({ "Url": url });
@@ -725,7 +732,7 @@ impl JellyfinClient {
     }
 
     pub async fn delete_image(
-        &self, id: &str, image_type: &str, tag: Option<u8>,
+        &self, id: &str, image_type: &str, tag: Option<String>,
     ) -> Result<Response> {
         let mut path = format!("Items/{id}/Images/{image_type}");
         if let Some(tag) = tag {
@@ -736,10 +743,15 @@ impl JellyfinClient {
     }
 
     pub async fn save_image(
-        &self, id: &str, image_type: &str, tag: Option<u8>, bytes: &[u8], etag: Option<String>,
+        &self, id: &str, image_type: &str, tag: Option<String>, bytes: &[u8], etag: Option<String>,
     ) -> String {
         let cache_path = jellyfin_cache_path().await;
-        let path = format!("{}-{}-{}", id, image_type, tag.unwrap_or(0));
+        let path = format!(
+            "{}-{}-{}",
+            id,
+            image_type,
+            tag.clone().unwrap_or_else(|| "0".into())
+        );
         let path = cache_path.join(path);
         tokio::fs::write(&path, bytes).await.unwrap();
         if let Some(etag) = etag {

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -633,11 +633,11 @@ impl JellyfinClient {
     }
 
     pub async fn image_request(
-        &self, id: &str, image_type: &str, tag: Option<String>, etag: Option<String>,
+        &self, id: &str, image_type: &str, image_index: Option<u8>, etag: Option<String>,
     ) -> Result<Response> {
         let mut path = format!("Items/{id}/Images/{image_type}");
-        if let Some(tag) = tag {
-            path.push_str(&format!("/{tag}"));
+        if let Some(image_index) = image_index {
+            path.push_str(&format!("/{image_index}"));
         }
         let params = [
             (
@@ -661,14 +661,14 @@ impl JellyfinClient {
     }
 
     pub async fn get_image(
-        &self, id: &str, image_type: &str, tag: Option<String>,
+        &self, id: &str, image_type: &str, image_index: Option<u8>,
     ) -> Result<String> {
         let mut path = jellyfin_cache_path().await;
         path.push(format!(
             "{}-{}-{}",
             id,
             image_type,
-            tag.clone().unwrap_or_else(|| "0".into())
+            image_index.unwrap_or(0)
         ));
 
         let mut etag: Option<String> = None;
@@ -680,7 +680,7 @@ impl JellyfinClient {
                 .and_then(|v| String::from_utf8(v).ok());
         }
 
-        match self.image_request(id, image_type, tag.clone(), etag).await {
+        match self.image_request(id, image_type, image_index, etag).await {
             Ok(response) => {
                 if response.status() == reqwest::StatusCode::NOT_MODIFIED {
                     return Ok(path.to_string_lossy().to_string());
@@ -701,7 +701,9 @@ impl JellyfinClient {
                     return Ok(String::new());
                 }
 
-                let path = self.save_image(id, image_type, tag, &bytes, etag).await;
+                let path = self
+                    .save_image(id, image_type, image_index, &bytes, etag)
+                    .await;
 
                 Ok(path)
             }
@@ -724,34 +726,30 @@ impl JellyfinClient {
     }
 
     pub async fn post_image_url(
-        &self, id: &str, image_type: &str, tag: String, url: &str,
+        &self, id: &str, image_type: &str, image_index: u8, url: &str,
     ) -> Result<Response> {
-        let path = format!("Items/{id}/Images/{tag}/{image_type}");
+        let path = format!("Items/{id}/Images/{image_index}/{image_type}");
         let body = json!({ "Url": url });
         self.post(&path, &[], body).await
     }
 
     pub async fn delete_image(
-        &self, id: &str, image_type: &str, tag: Option<String>,
+        &self, id: &str, image_type: &str, image_index: Option<u8>,
     ) -> Result<Response> {
         let mut path = format!("Items/{id}/Images/{image_type}");
-        if let Some(tag) = tag {
-            path.push_str(&format!("/{tag}"));
+        if let Some(image_index) = image_index {
+            path.push_str(&format!("/{image_index}"));
         }
         path.push_str("/Delete");
         self.post(&path, &[], json!({})).await
     }
 
     pub async fn save_image(
-        &self, id: &str, image_type: &str, tag: Option<String>, bytes: &[u8], etag: Option<String>,
+        &self, id: &str, image_type: &str, image_index: Option<u8>, bytes: &[u8],
+        etag: Option<String>,
     ) -> String {
         let cache_path = jellyfin_cache_path().await;
-        let path = format!(
-            "{}-{}-{}",
-            id,
-            image_type,
-            tag.clone().unwrap_or_else(|| "0".into())
-        );
+        let path = format!("{}-{}-{}", id, image_type, image_index.unwrap_or(0));
         let path = cache_path.join(path);
         tokio::fs::write(&path, bytes).await.unwrap();
         if let Some(etag) = etag {

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -315,8 +315,16 @@ pub struct SimpleListItem {
     pub season_name: Option<String>,
     #[serde(rename = "ParentBackdropItemId")]
     pub parent_backdrop_item_id: Option<String>,
+    #[serde(rename = "ParentBackdropImageTags")]
+    pub parent_backdrop_image_tags: Option<Vec<String>>,
+    #[serde(rename = "ParentLogoItemId")]
+    pub parent_logo_item_id: Option<String>,
+    #[serde(rename = "ParentLogoImageTag")]
+    pub parent_logo_image_tag: Option<String>,
     #[serde(rename = "ParentThumbItemId")]
     pub parent_thumb_item_id: Option<String>,
+    #[serde(rename = "ParentThumbImageTag")]
+    pub parent_thumb_image_tag: Option<String>,
     #[serde(rename = "PlayedPercentage")]
     pub played_percentage: Option<f64>,
     #[serde(rename = "ImageUrl")]
@@ -333,12 +341,26 @@ pub struct SimpleListItem {
     pub artists: Option<Vec<String>>,
     #[serde(rename = "AlbumId")]
     pub album_id: Option<String>,
+    #[serde(rename = "AlbumPrimaryImageTag")]
+    pub album_primary_image_tag: Option<String>,
     #[serde(rename = "Role")]
     pub role: Option<String>,
     #[serde(rename = "RunTimeTicks")]
     pub run_time_ticks: Option<u64>,
     #[serde(rename = "PrimaryImageItemId")]
     pub primary_image_item_id: Option<String>,
+    #[serde(rename = "PrimaryImageTag")]
+    pub primary_image_tag: Option<String>,
+    #[serde(rename = "ParentPrimaryImageItemId")]
+    pub parent_primary_image_item_id: Option<String>,
+    #[serde(rename = "ParentPrimaryImageTag")]
+    pub parent_primary_image_tag: Option<String>,
+    #[serde(rename = "SeriesPrimaryImageTag")]
+    pub series_primary_image_tag: Option<String>,
+    #[serde(rename = "SeriesThumbImageTag")]
+    pub series_thumb_image_tag: Option<String>,
+    #[serde(rename = "ChildCount")]
+    pub child_count: Option<u32>,
     #[serde(rename = "BackdropImageTags")]
     pub backdrop_image_tags: Option<Vec<String>>,
     #[serde(rename = "PrimaryImageAspectRatio")]
@@ -415,8 +437,6 @@ pub struct ImageTags {
     pub thumb: Option<String>,
     #[serde(rename = "Banner")]
     pub banner: Option<String>,
-    #[serde(rename = "Backdrop")]
-    pub backdrop: Option<String>,
     #[serde(rename = "Logo")]
     pub logo: Option<String>,
 }
@@ -658,7 +678,6 @@ use gtk::glib;
 
 use super::jellyfin_client::JELLYFIN_CLIENT;
 use crate::ui::widgets::{
-    hortu_scrolled::UnifySize,
     single_grid::SingleGrid,
     window::Window,
 };
@@ -669,7 +688,6 @@ impl SGTitem {
         T: gtk::prelude::WidgetExt + glib::clone::Downgrade,
     {
         let page = SingleGrid::new();
-        page.set_unify_size(UnifySize::Majority);
         let id = self.id.to_string();
         let list_type_clone = list_type.to_owned();
         page.connect_sort_changed_tokio(move |sort_by, sort_order, filters_list| {

--- a/src/gstl/player.rs
+++ b/src/gstl/player.rs
@@ -100,7 +100,7 @@ pub mod imp {
         #[property(get, set, builder(ListRepeatMode::default()))]
         pub repeat_mode: Cell<ListRepeatMode>,
         #[property(get, set, default_value = false)]
-        pub gapless: RefCell<bool>,
+        pub gapless: Cell<bool>,
 
         pub mpris_server: OnceCell<LocalServer<super::MusicPlayer>>,
     }

--- a/src/ui/mpv/volume_bar.rs
+++ b/src/ui/mpv/volume_bar.rs
@@ -6,7 +6,10 @@ use gtk::{
 
 mod imp {
 
-    use std::cell::RefCell;
+    use std::cell::{
+        Cell,
+        RefCell,
+    };
 
     use glib::subclass::InitializingObject;
     use gtk::prelude::*;
@@ -18,7 +21,7 @@ mod imp {
     #[properties(wrapper_type = super::VolumeBar)]
     pub struct VolumeBar {
         #[property(get, set = Self::set_level, default_value = 100.0)]
-        pub level: RefCell<f64>,
+        pub level: Cell<f64>,
         #[template_child]
         pub progress: TemplateChild<gtk::ProgressBar>,
         #[template_child]

--- a/src/ui/provider/core_song.rs
+++ b/src/ui/provider/core_song.rs
@@ -32,9 +32,9 @@ pub mod imp {
         #[property(get, set)]
         pub album_id: RefCell<String>,
         #[property(get, set)]
-        pub have_single_track_image: RefCell<bool>,
+        pub have_single_track_image: Cell<bool>,
         #[property(get, set)]
-        pub duration: RefCell<u64>,
+        pub duration: Cell<u64>,
     }
 
     #[glib::derived_properties]

--- a/src/ui/provider/image_tags.rs
+++ b/src/ui/provider/image_tags.rs
@@ -40,22 +40,22 @@ glib::wrapper! {
     pub struct ImageTags(ObjectSubclass<imp::ImageTags>);
 }
 
-impl Default for ImageTags {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ImageTags {
-    pub fn new() -> ImageTags {
-        glib::object::Object::new()
-    }
-
-    pub fn all_none(&self) -> bool {
-        let imp = self.imp();
-        imp.backdrop.borrow().is_none()
-            && imp.primary.borrow().is_none()
-            && imp.thumb.borrow().is_none()
-            && imp.banner.borrow().is_none()
+    pub fn new(
+        image_tags: Option<crate::client::structs::ImageTags>,
+        backdrop_image_tags: Option<Vec<String>>,
+    ) -> Option<Self> {
+        let backdrop = backdrop_image_tags.and_then(|tags| tags.into_iter().next());
+        if image_tags.is_none() && backdrop.is_none() {
+            return None;
+        }
+        let provider: Self = glib::object::Object::new();
+        provider.set_backdrop(backdrop);
+        if let Some(image_tags) = image_tags {
+            provider.set_primary(image_tags.primary);
+            provider.set_thumb(image_tags.thumb);
+            provider.set_banner(image_tags.banner);
+        }
+        Some(provider)
     }
 }

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -118,9 +118,9 @@ pub mod imp {
         #[property(get, set)]
         name: RefCell<String>,
         #[property(get, set)]
-        index_number: RefCell<u32>,
+        index_number: Cell<u32>,
         #[property(get, set)]
-        parent_index_number: RefCell<u32>,
+        parent_index_number: Cell<u32>,
         #[property(get, set, nullable)]
         series_name: RefCell<Option<String>>,
         #[property(get, set, nullable)]
@@ -130,19 +130,19 @@ pub mod imp {
         #[property(get, set, nullable)]
         season_id: RefCell<Option<String>>,
         #[property(get, set)]
-        played_percentage: RefCell<f64>,
+        played_percentage: Cell<f64>,
         #[property(get, set)]
-        played: RefCell<bool>,
+        played: Cell<bool>,
         #[property(get, set)]
-        unplayed_item_count: RefCell<u32>,
+        unplayed_item_count: Cell<u32>,
         #[property(get, set)]
-        is_favorite: RefCell<bool>,
+        is_favorite: Cell<bool>,
         #[property(get, set)]
-        is_resume: RefCell<bool>,
+        is_resume: Cell<bool>,
         #[property(get, set)]
         item_type: RefCell<String>,
         #[property(get, set)]
-        production_year: RefCell<u32>,
+        production_year: Cell<u32>,
         #[property(get, set, nullable)]
         parent_thumb_item_id: RefCell<Option<String>>,
         #[property(get, set, nullable)]
@@ -181,7 +181,7 @@ pub mod imp {
         series_thumb_image_tag: RefCell<Option<String>>,
         pub child_count: Cell<Option<u32>>,
         #[property(get, set)]
-        run_time_ticks: RefCell<u64>,
+        run_time_ticks: Cell<u64>,
         #[property(get, set, nullable)]
         collection_type: RefCell<Option<String>>,
         #[property(name = "albumartist-name", get, set, type = String, member = name)]
@@ -206,7 +206,7 @@ pub mod imp {
         #[property(get, set, nullable)]
         path: RefCell<Option<String>>,
         #[property(get, set)]
-        playback_position_ticks: RefCell<u64>,
+        playback_position_ticks: Cell<u64>,
     }
 
     #[glib::derived_properties]

--- a/src/ui/provider/tu_item.rs
+++ b/src/ui/provider/tu_item.rs
@@ -1,4 +1,7 @@
-use std::cell::RefCell;
+use std::cell::{
+    Cell,
+    RefCell,
+};
 
 use adw::prelude::*;
 use dandanapi_client::{
@@ -74,7 +77,6 @@ use crate::{
             },
         },
         widgets::{
-            hortu_scrolled::UnifySize,
             item::ItemPage,
             list::ListPage,
             music_album::AlbumPage,
@@ -84,7 +86,6 @@ use crate::{
                 imp::ListType,
             },
             song_widget::SongWidget,
-            utils::*,
             window::Window,
         },
     },
@@ -101,26 +102,6 @@ use crate::{
 struct AlbumArtist {
     name: String,
     id: String,
-}
-
-#[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
-#[repr(u32)]
-#[enum_type(name = "PreferSize")]
-pub enum PreferSize {
-    #[default]
-    Auto,
-    Video,
-    Post,
-}
-
-#[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
-#[repr(u32)]
-#[enum_type(name = "PreferPoster")]
-pub enum PreferPoster {
-    #[default]
-    Auto,
-    ParentPost,
-    ParentVideo,
 }
 
 pub mod imp {
@@ -165,17 +146,17 @@ pub mod imp {
         #[property(get, set, nullable)]
         parent_thumb_item_id: RefCell<Option<String>>,
         #[property(get, set, nullable)]
+        parent_thumb_image_tag: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
         parent_backdrop_item_id: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        parent_backdrop_image_tag: RefCell<Option<String>>,
         #[property(get, set)]
         poster: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         image_url: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         image_tags: RefCell<Option<crate::ui::provider::image_tags::ImageTags>>,
-        #[property(get, set, builder(PreferSize::default()))]
-        prefer_size: RefCell<PreferSize>,
-        #[property(get, set, builder(PreferPoster::default()))]
-        prefer_poster: RefCell<PreferPoster>,
         #[property(get, set, nullable)]
         role: RefCell<Option<String>>,
         #[property(get, set, nullable)]
@@ -183,9 +164,22 @@ pub mod imp {
         #[property(get, set, nullable)]
         album_id: RefCell<Option<String>>,
         #[property(get, set, nullable)]
+        album_primary_image_tag: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
         rating: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         primary_image_item_id: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        primary_image_tag: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        parent_primary_image_item_id: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        parent_primary_image_tag: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        series_primary_image_tag: RefCell<Option<String>>,
+        #[property(get, set, nullable)]
+        series_thumb_image_tag: RefCell<Option<String>>,
+        pub child_count: Cell<Option<u32>>,
         #[property(get, set)]
         run_time_ticks: RefCell<u64>,
         #[property(get, set, nullable)]
@@ -223,19 +217,6 @@ pub mod imp {
         const NAME: &'static str = "TuItem";
         type Type = super::TuItem;
     }
-
-    impl TuItem {
-        pub fn set_image_tags(&self, s: Option<crate::client::structs::ImageTags>) {
-            let image_tags = crate::ui::provider::image_tags::ImageTags::new();
-            if let Some(s) = s {
-                image_tags.set_backdrop(s.backdrop.to_owned());
-                image_tags.set_primary(s.primary.to_owned());
-                image_tags.set_thumb(s.thumb.to_owned());
-                image_tags.set_banner(s.banner.to_owned());
-            }
-            self.image_tags.replace(Some(image_tags));
-        }
-    }
 }
 
 glib::wrapper! {
@@ -268,10 +249,17 @@ impl From<SimpleListItem> for TuItem {
                 .set_playback_position_ticks(userdata.playback_position_ticks.unwrap_or_default());
             tu_item.set_is_favorite(userdata.is_favorite.unwrap_or(false));
         }
-
-        tu_item.imp().set_image_tags(item.image_tags);
+        tu_item.set_image_tags(crate::ui::provider::image_tags::ImageTags::new(
+            item.image_tags,
+            item.backdrop_image_tags,
+        ));
         tu_item.set_parent_thumb_item_id(item.parent_thumb_item_id);
+        tu_item.set_parent_thumb_image_tag(item.parent_thumb_image_tag);
         tu_item.set_parent_backdrop_item_id(item.parent_backdrop_item_id);
+        tu_item.set_parent_backdrop_image_tag(
+            item.parent_backdrop_image_tags
+                .and_then(|tags| tags.into_iter().next()),
+        );
         tu_item.set_series_name(item.series_name);
         tu_item.set_season_name(item.season_name);
 
@@ -297,9 +285,16 @@ impl From<SimpleListItem> for TuItem {
         tu_item.set_role(item.role);
         tu_item.set_artists(item.artists.map(|artists| artists.join(" , ")));
         tu_item.set_album_id(item.album_id);
+        tu_item.set_album_primary_image_tag(item.album_primary_image_tag);
         tu_item.set_run_time_ticks(item.run_time_ticks.unwrap_or_default());
         tu_item.set_tagline(item.taglines.and_then(|taglines| taglines.first().cloned()));
         tu_item.set_primary_image_item_id(item.primary_image_item_id);
+        tu_item.set_primary_image_tag(item.primary_image_tag);
+        tu_item.set_parent_primary_image_item_id(item.parent_primary_image_item_id);
+        tu_item.set_parent_primary_image_tag(item.parent_primary_image_tag);
+        tu_item.set_series_primary_image_tag(item.series_primary_image_tag);
+        tu_item.set_series_thumb_image_tag(item.series_thumb_image_tag);
+        tu_item.imp().child_count.replace(item.child_count);
         tu_item.set_rating(item.community_rating.map(|rating| format!("{rating:.1}")));
         tu_item.set_collection_type(item.collection_type);
 
@@ -426,7 +421,6 @@ impl TuItem {
             }
             TAG | GENRE | MUSIC_GENRE => {
                 let page = SingleGrid::new();
-                page.set_unify_size(UnifySize::Majority);
                 let id = self.id();
 
                 let mut parent_id = None;
@@ -485,7 +479,6 @@ impl TuItem {
             FOLDER => {
                 let page = SingleGrid::new();
                 page.set_list_type(ListType::Folder);
-                page.set_unify_size(UnifySize::Majority);
                 let id = self.id();
                 page.connect_sort_changed_tokio(move |sort_by, sort_order, filters_list| {
                     let id = id.to_owned();
@@ -803,22 +796,6 @@ impl TuItem {
 
     pub fn has_folder_mark(&self) -> bool {
         matches!(self.item_type().as_str(), FOLDER)
-    }
-
-    pub fn size_hint(&self) -> (i32, i32) {
-        match self.prefer_size() {
-            PreferSize::Video => return TU_ITEM_VIDEO_SIZE,
-            PreferSize::Post => return TU_ITEM_POST_SIZE,
-            _ => (),
-        }
-
-        match self.item_type().as_str() {
-            MOVIE | SERIES | BOX_SET | ACTOR | PERSON | DIRECTOR | WRITER | PRODUCER
-            | GUEST_STAR | SEASON => TU_ITEM_POST_SIZE,
-            VIDEO | MUSIC_VIDEO | ADULT_VIDEO | TV_CHANNEL | COLLECTION_FOLDER | EPISODE
-            | USER_VIEW => TU_ITEM_VIDEO_SIZE,
-            _ => TU_ITEM_SQUARE_SIZE,
-        }
     }
 
     pub fn list_item_title(&self) -> Option<String> {

--- a/src/ui/widgets/check_row.rs
+++ b/src/ui/widgets/check_row.rs
@@ -6,7 +6,7 @@ use gtk::{
 
 mod imp {
 
-    use std::cell::RefCell;
+    use std::cell::Cell;
 
     use glib::subclass::InitializingObject;
 
@@ -17,7 +17,7 @@ mod imp {
     pub struct CheckRow {
         #[template_child]
         pub check: TemplateChild<gtk::CheckButton>,
-        pub track_id: RefCell<i64>,
+        pub track_id: Cell<i64>,
     }
 
     #[glib::object_subclass]

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -11,14 +11,12 @@ use gtk::{
 };
 
 use super::{
-    hortu_scrolled::{
-        HortuScrolled,
-        UnifySize,
-    },
+    hortu_scrolled::HortuScrolled,
     single_grid::{
         SingleGrid,
         imp::ListType,
     },
+    tu_item::CardShape,
     utils::GlobalToast,
     window::Window,
 };
@@ -32,10 +30,7 @@ use crate::{
     fraction_reset,
     ui::{
         SETTINGS,
-        provider::tu_item::{
-            PreferPoster,
-            TuItem,
-        },
+        provider::tu_item::TuItem,
     },
     utils::{
         CacheEvent,
@@ -287,8 +282,8 @@ impl HomePage {
                 let page = SingleGrid::new();
 
                 page.set_list_type(ListType::NextUp);
-                page.set_unify_size(UnifySize::ForceVideo);
-                page.set_prefer_poster(PreferPoster::ParentVideo);
+                page.set_card_shape(CardShape::Backdrop);
+                page.set_prefer_thumb(true);
 
                 let title = if SETTINGS.merge_resume_and_next_up() {
                     page.set_is_resume(true);
@@ -386,9 +381,7 @@ impl HomePage {
 
         hortu.set_moreview(true);
 
-        hortu.set_unify_size(UnifySize::Majority);
-
-        hortu.set_prefer_poster(PreferPoster::ParentPost);
+        hortu.set_prefer_parent_poster(true);
 
         hortu.set_title(format!("{} {}", gettext("Latest"), ac_view.name));
 

--- a/src/ui/widgets/home.rs
+++ b/src/ui/widgets/home.rs
@@ -16,7 +16,10 @@ use super::{
         SingleGrid,
         imp::ListType,
     },
-    tu_item::CardShape,
+    tu_item::{
+        CardOptions,
+        CardShape,
+    },
     utils::GlobalToast,
     window::Window,
 };
@@ -282,8 +285,11 @@ impl HomePage {
                 let page = SingleGrid::new();
 
                 page.set_list_type(ListType::NextUp);
-                page.set_card_shape(CardShape::Backdrop);
-                page.set_prefer_thumb(true);
+                page.set_card_options(CardOptions {
+                    shape: CardShape::Backdrop,
+                    prefer_thumb: true,
+                    ..Default::default()
+                });
 
                 let title = if SETTINGS.merge_resume_and_next_up() {
                     page.set_is_resume(true);
@@ -381,7 +387,10 @@ impl HomePage {
 
         hortu.set_moreview(true);
 
-        hortu.set_prefer_parent_poster(true);
+        hortu.set_card_options(CardOptions {
+            prefer_parent_poster: true,
+            ..Default::default()
+        });
 
         hortu.set_title(format!("{} {}", gettext("Latest"), ac_view.name));
 

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -57,7 +57,7 @@ mod imp {
         pub right_button: TemplateChild<gtk::Button>,
 
         #[property(get, set, default_value = false)]
-        pub moreview: RefCell<bool>,
+        pub moreview: Cell<bool>,
         #[property(get, set)]
         pub title: RefCell<String>,
 

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -16,7 +16,10 @@ use crate::{
             fix::ScrolledWindowFixExt,
             hor_controls::HorControlsExt,
             lazy_diff_view::LazyDiffView,
-            tu_item::CardShape,
+            tu_item::{
+                CardOptions,
+                CardShape,
+            },
             tu_list_item::TuListItem,
         },
     },
@@ -113,9 +116,7 @@ mod imp {
                 move |_tu_obj: &TuObject| {
                     let tu_item = TuListItem::default();
                     if let Some(obj) = weak_obj.upgrade() {
-                        tu_item.set_card_shape(obj.resolved_card_shape());
-                        tu_item.set_prefer_thumb(obj.prefer_thumb());
-                        tu_item.set_prefer_parent_poster(obj.prefer_parent_poster());
+                        tu_item.set_card_options(obj.card_options());
                     }
 
                     let gesture = gtk::GestureClick::new();
@@ -173,6 +174,20 @@ impl HortuScrolled {
     pub fn set_morebutton(&self) {
         let imp = self.imp();
         imp.morebutton.set_visible(true);
+    }
+
+    pub fn set_card_options(&self, options: CardOptions) {
+        self.set_card_shape(options.shape);
+        self.set_prefer_thumb(options.prefer_thumb);
+        self.set_prefer_parent_poster(options.prefer_parent_poster);
+    }
+
+    fn card_options(&self) -> CardOptions {
+        CardOptions {
+            shape: self.resolved_card_shape(),
+            prefer_thumb: self.prefer_thumb(),
+            prefer_parent_poster: self.prefer_parent_poster(),
+        }
     }
 
     pub fn set_items(&self, items: Vec<SimpleListItem>) {

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -11,60 +11,16 @@ use gtk::{
 use crate::{
     client::structs::SimpleListItem,
     ui::{
-        provider::{
-            tu_item::{
-                PreferPoster,
-                PreferSize,
-            },
-            tu_object::TuObject,
-        },
+        provider::tu_object::TuObject,
         widgets::{
             fix::ScrolledWindowFixExt,
             hor_controls::HorControlsExt,
             lazy_diff_view::LazyDiffView,
-            tu_list_item::{
-                TuListItem,
-                imp::PosterType,
-            },
+            tu_item::CardShape,
+            tu_list_item::TuListItem,
         },
     },
 };
-
-#[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
-#[repr(u32)]
-#[enum_type(name = "UnifySize")]
-pub enum UnifySize {
-    #[default]
-    Disable,
-    Majority,
-    ForceVideo,
-    ForcePost,
-}
-
-pub fn resolve_prefer_size(unify_size: UnifySize, items: &[SimpleListItem]) -> PreferSize {
-    match unify_size {
-        UnifySize::Disable => PreferSize::Auto,
-        UnifySize::ForceVideo => PreferSize::Video,
-        UnifySize::ForcePost => PreferSize::Post,
-        UnifySize::Majority => {
-            let primary_ratio: Vec<_> = items
-                .iter()
-                .filter(|i| i.item_type != "Episode")
-                .filter_map(|i| i.primary_image_aspect_ratio)
-                .collect();
-            if primary_ratio.is_empty() {
-                return PreferSize::Auto;
-            }
-            let video_percentage = primary_ratio.iter().filter(|i| **i > 1.0).count() as f64
-                / primary_ratio.len() as f64;
-            match video_percentage {
-                p if p > 0.8 => PreferSize::Video,
-                p if p < 0.2 => PreferSize::Post,
-                _ => PreferSize::Auto,
-            }
-        }
-    }
-}
 
 mod imp {
     use std::{
@@ -105,11 +61,15 @@ mod imp {
         #[property(get, set)]
         pub title: RefCell<String>,
 
-        #[property(get, set, builder(UnifySize::default()))]
-        pub unify_size: RefCell<UnifySize>,
+        #[property(get, set, builder(CardShape::default()))]
+        pub card_shape: Cell<CardShape>,
 
-        #[property(get, set, builder(PreferPoster::default()))]
-        pub prefer_poster: RefCell<PreferPoster>,
+        #[property(get, set, default = false)]
+        pub prefer_thumb: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_banner: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_parent_poster: Cell<bool>,
 
         pub show_left_animation: OnceCell<adw::TimedAnimation>,
         pub hide_left_animation: OnceCell<adw::TimedAnimation>,
@@ -117,6 +77,8 @@ mod imp {
         pub hide_right_animation: OnceCell<adw::TimedAnimation>,
         pub is_hovering: Cell<bool>,
         pub item_cache: RefCell<HashMap<String, TuObject>>,
+        #[property(get, set, builder(CardShape::default()))]
+        pub resolved_card_shape: Cell<CardShape>,
     }
 
     #[glib::object_subclass]
@@ -140,16 +102,24 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
+            let obj = self.obj();
+
             self.diffview.set_orientation(gtk::Orientation::Horizontal);
             self.diffview
                 .scroll()
                 .fix()
                 .set_hscrollbar_policy(gtk::PolicyType::Never);
+            let weak_obj = obj.downgrade();
             self.diffview.configure(
                 |tu_obj: &TuObject| tu_obj.item().key(),
-                |_tu_obj: &TuObject| {
+                move |_tu_obj: &TuObject| {
                     let tu_item = TuListItem::default();
-                    tu_item.set_poster_type(PosterType::default());
+                    if let Some(obj) = weak_obj.upgrade() {
+                        tu_item.set_card_shape(obj.resolved_card_shape());
+                        tu_item.set_prefer_thumb(obj.prefer_thumb());
+                        tu_item.set_prefer_banner(obj.prefer_banner());
+                        tu_item.set_prefer_parent_poster(obj.prefer_parent_poster());
+                    }
 
                     let gesture = gtk::GestureClick::new();
                     gesture.set_button(1);
@@ -217,7 +187,7 @@ impl HortuScrolled {
             return;
         }
 
-        let prefer_size = resolve_prefer_size(self.unify_size(), &items);
+        self.set_resolved_card_shape(self.card_shape().resolve(&items));
         let visible_ids = items
             .iter()
             .map(|item| item.id.as_str())
@@ -240,8 +210,6 @@ impl HortuScrolled {
                 let tu_item = object.item();
                 tu_item.update_user_data(&item.user_data);
                 tu_item.set_is_resume(self.is_resume());
-                tu_item.set_prefer_size(prefer_size);
-                tu_item.set_prefer_poster(self.prefer_poster());
                 object
             })
             .collect::<Vec<_>>();

--- a/src/ui/widgets/hortu_scrolled.rs
+++ b/src/ui/widgets/hortu_scrolled.rs
@@ -67,8 +67,6 @@ mod imp {
         #[property(get, set, default = false)]
         pub prefer_thumb: Cell<bool>,
         #[property(get, set, default = false)]
-        pub prefer_banner: Cell<bool>,
-        #[property(get, set, default = false)]
         pub prefer_parent_poster: Cell<bool>,
 
         pub show_left_animation: OnceCell<adw::TimedAnimation>,
@@ -117,7 +115,6 @@ mod imp {
                     if let Some(obj) = weak_obj.upgrade() {
                         tu_item.set_card_shape(obj.resolved_card_shape());
                         tu_item.set_prefer_thumb(obj.prefer_thumb());
-                        tu_item.set_prefer_banner(obj.prefer_banner());
                         tu_item.set_prefer_parent_poster(obj.prefer_parent_poster());
                     }
 

--- a/src/ui/widgets/image_dialog/image_edit_dialog_page.rs
+++ b/src/ui/widgets/image_dialog/image_edit_dialog_page.rs
@@ -165,7 +165,7 @@ impl ImageDialogEditPage {
 
             spawn_tokio(async move {
                 JELLYFIN_CLIENT
-                    .post_image_url(&id, &image_type, image_tag, &url)
+                    .post_image_url(&id, &image_type, image_tag.to_string(), &url)
                     .await
             })
             .await

--- a/src/ui/widgets/image_dialog/image_edit_dialog_page.rs
+++ b/src/ui/widgets/image_dialog/image_edit_dialog_page.rs
@@ -43,7 +43,7 @@ mod imp {
         #[property(get, set, construct_only)]
         pub image_type: OnceCell<String>,
         #[property(get, set, construct_only)]
-        pub image_tag: OnceCell<u8>,
+        pub image_index: OnceCell<u8>,
 
         #[template_child]
         pub url_check_button: TemplateChild<gtk::CheckButton>,
@@ -97,11 +97,11 @@ use anyhow::{
 
 #[template_callbacks]
 impl ImageDialogEditPage {
-    pub fn new(id: &str, image_type: &str, image_tag: u8) -> Self {
+    pub fn new(id: &str, image_type: &str, image_index: u8) -> Self {
         glib::Object::builder()
             .property("id", id)
             .property("image-type", image_type)
-            .property("image-tag", image_tag)
+            .property("image-index", image_index)
             .build()
     }
 
@@ -161,11 +161,11 @@ impl ImageDialogEditPage {
 
         let result = if self.imp().url_check_button.is_active() {
             let url = self.imp().entry.text().to_string();
-            let image_tag = self.image_tag();
+            let image_index = self.image_index();
 
             spawn_tokio(async move {
                 JELLYFIN_CLIENT
-                    .post_image_url(&id, &image_type, image_tag.to_string(), &url)
+                    .post_image_url(&id, &image_type, image_index, &url)
                     .await
             })
             .await

--- a/src/ui/widgets/image_dialog/image_infocard.rs
+++ b/src/ui/widgets/image_dialog/image_infocard.rs
@@ -200,7 +200,7 @@ impl ImageInfoCard {
 
         match spawn_tokio(async move {
             JELLYFIN_CLIENT
-                .delete_image(&id, &img_type, Some(image_index))
+                .delete_image(&id, &img_type, Some(image_index.to_string()))
                 .await
         })
         .await

--- a/src/ui/widgets/image_dialog/image_infocard.rs
+++ b/src/ui/widgets/image_dialog/image_infocard.rs
@@ -22,6 +22,7 @@ use crate::{
 
 mod imp {
     use std::cell::{
+        Cell,
         OnceCell,
         RefCell,
     };
@@ -50,7 +51,7 @@ mod imp {
         #[property(get, set)]
         pub imgid: RefCell<String>,
         #[property(get, set, default_value = 0)]
-        pub image_index: RefCell<u8>,
+        pub image_index: Cell<u8>,
 
         #[template_child]
         pub label1: TemplateChild<gtk::Label>,

--- a/src/ui/widgets/image_dialog/image_infocard.rs
+++ b/src/ui/widgets/image_dialog/image_infocard.rs
@@ -200,7 +200,7 @@ impl ImageInfoCard {
 
         match spawn_tokio(async move {
             JELLYFIN_CLIENT
-                .delete_image(&id, &img_type, Some(image_index.to_string()))
+                .delete_image(&id, &img_type, Some(image_index))
                 .await
         })
         .await

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -802,13 +802,9 @@ impl ItemPage {
         let imp = self.imp();
 
         let backdrop = imp.carousel.imp().backdrop.get();
-        let path = get_image_with_cache(
-            id.to_string(),
-            "Backdrop".to_string(),
-            Some("0".to_string()),
-        )
-        .await
-        .unwrap_or_default();
+        let path = get_image_with_cache(id.to_string(), "Backdrop".to_string(), Some(0))
+            .await
+            .unwrap_or_default();
         let file = gtk::gio::File::for_path(&path);
         backdrop.set_file(Some(&file));
         self.imp()
@@ -833,13 +829,10 @@ impl ItemPage {
         let tags = image_tags.len();
         let carousel = imp.carousel.imp().carousel.get();
         for tag_num in 1..tags {
-            let path = get_image_with_cache(
-                id.to_string(),
-                "Backdrop".to_string(),
-                Some(tag_num.to_string()),
-            )
-            .await
-            .unwrap_or_default();
+            let path =
+                get_image_with_cache(id.to_string(), "Backdrop".to_string(), Some(tag_num as u8))
+                    .await
+                    .unwrap_or_default();
             let file = gtk::gio::File::for_path(&path);
             let picture = gtk::Picture::builder()
                 .halign(gtk::Align::Fill)

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -802,9 +802,13 @@ impl ItemPage {
         let imp = self.imp();
 
         let backdrop = imp.carousel.imp().backdrop.get();
-        let path = get_image_with_cache(id.to_string(), "Backdrop".to_string(), Some(0))
-            .await
-            .unwrap_or_default();
+        let path = get_image_with_cache(
+            id.to_string(),
+            "Backdrop".to_string(),
+            Some("0".to_string()),
+        )
+        .await
+        .unwrap_or_default();
         let file = gtk::gio::File::for_path(&path);
         backdrop.set_file(Some(&file));
         self.imp()
@@ -829,10 +833,13 @@ impl ItemPage {
         let tags = image_tags.len();
         let carousel = imp.carousel.imp().carousel.get();
         for tag_num in 1..tags {
-            let path =
-                get_image_with_cache(id.to_string(), "Backdrop".to_string(), Some(tag_num as u8))
-                    .await
-                    .unwrap_or_default();
+            let path = get_image_with_cache(
+                id.to_string(),
+                "Backdrop".to_string(),
+                Some(tag_num.to_string()),
+            )
+            .await
+            .unwrap_or_default();
             let file = gtk::gio::File::for_path(&path);
             let picture = gtk::Picture::builder()
                 .halign(gtk::Align::Fill)

--- a/src/ui/widgets/item.rs
+++ b/src/ui/widgets/item.rs
@@ -5,7 +5,6 @@ use super::{
     },
     fix::ScrolledWindowFixExt,
     hor_controls::HorControlsExt,
-    hortu_scrolled::UnifySize,
     item_utils::*,
     song_widget::format_duration,
     utils::{
@@ -132,7 +131,7 @@ pub(crate) mod imp {
         #[template_child]
         pub itemlist: TemplateChild<gtk::ListView>,
         #[template_child]
-        pub logobox: TemplateChild<gtk::Box>,
+        pub logo_bin: TemplateChild<adw::Bin>,
         #[template_child]
         pub seasonlist: TemplateChild<gtk::DropDown>,
 
@@ -265,7 +264,8 @@ pub(crate) mod imp {
             self.selection.set_model(Some(&store));
             self.itemlist.set_model(Some(&self.selection));
             self.itemlist.set_factory(Some(
-                gtk::SignalListItemFactory::new().tu_overview_item(ViewGroup::EpisodesView),
+                gtk::SignalListItemFactory::new()
+                    .tu_overview_item(ViewGroup::EpisodesView, Default::default()),
             ));
             self.obj().connect_scroll_controls();
 
@@ -405,15 +405,6 @@ impl ItemPage {
 
     async fn setup_item(&self, id: &str) {
         let id = id.to_string();
-        let id_clone = id.to_owned();
-
-        spawn(glib::clone!(
-            #[weak(rename_to = obj)]
-            self,
-            async move {
-                obj.set_logo(&id_clone).await;
-            }
-        ));
 
         self.setup_background(&id).await;
         self.set_overview(&id).await;
@@ -896,9 +887,26 @@ impl ItemPage {
         self.set_intro::<false>(&item.item()).await;
     }
 
-    pub async fn set_logo(&self, id: &str) {
-        let logo = super::logo::set_logo(id.to_string(), "Logo", None).await;
-        self.imp().logobox.append(&logo);
+    pub async fn set_logo(&self, item: &SimpleListItem) {
+        let logo_bin = self.imp().logo_bin.get();
+
+        let logo_id = item
+            .image_tags
+            .as_ref()
+            .and_then(|tags| tags.logo.as_deref())
+            .map(|_| item.id.as_str())
+            .or_else(|| {
+                item.parent_logo_image_tag.as_ref()?;
+                item.parent_logo_item_id.as_deref()
+            });
+
+        let Some(logo_id) = logo_id else {
+            logo_bin.set_child(None::<&gtk::Widget>);
+            return;
+        };
+
+        let logo = super::logo::set_logo(logo_id.to_string(), "Logo", None).await;
+        logo_bin.set_child(Some(&logo));
     }
 
     pub async fn set_overview(&self, id: &str) {
@@ -917,6 +925,7 @@ impl ItemPage {
                     #[weak(rename_to = obj)]
                     self,
                     async move {
+                        obj.set_logo(&item).await;
                         {
                             let mut str = String::new();
                             if let Some(communityrating) = item.community_rating {
@@ -1186,8 +1195,6 @@ impl ItemPage {
             },
         )
         .await;
-
-        hortu.set_unify_size(UnifySize::Majority);
 
         while let Some(event) = events.recv().await {
             match event {

--- a/src/ui/widgets/item_actionbox.rs
+++ b/src/ui/widgets/item_actionbox.rs
@@ -24,7 +24,10 @@ use crate::{
 };
 
 mod imp {
-    use std::cell::RefCell;
+    use std::cell::{
+        Cell,
+        RefCell,
+    };
 
     use glib::subclass::InitializingObject;
 
@@ -42,9 +45,9 @@ mod imp {
         #[property(get, set, nullable)]
         pub series_id: RefCell<Option<String>>,
         #[property(get, set, construct, default = false)]
-        pub is_playable: RefCell<bool>,
+        pub is_playable: Cell<bool>,
         #[property(get, set, default = false)]
-        pub played: RefCell<bool>,
+        pub played: Cell<bool>,
     }
 
     #[glib::object_subclass]

--- a/src/ui/widgets/liked.rs
+++ b/src/ui/widgets/liked.rs
@@ -7,10 +7,7 @@ use gtk::{
     subclass::prelude::*,
 };
 
-use super::{
-    hortu_scrolled::UnifySize,
-    utils::GlobalToast,
-};
+use super::utils::GlobalToast;
 use crate::{
     client::{
         error::UserFacingError,
@@ -188,7 +185,6 @@ impl LikedPage {
             move |_| {
                 let tag = format!("{} {}", "Favourite", type_);
                 let page = crate::ui::widgets::single_grid::SingleGrid::new();
-                page.set_unify_size(UnifySize::Majority);
                 let type_clone1 = type_.to_owned();
                 let type_clone2 = type_.to_owned();
                 page.connect_sort_changed_tokio(move |sort_by, sort_order, filters_list| {

--- a/src/ui/widgets/list.rs
+++ b/src/ui/widgets/list.rs
@@ -7,18 +7,15 @@ use gtk::{
 };
 
 use super::{
-    hortu_scrolled::UnifySize,
     single_grid::{
         SingleGrid,
         imp::ListType,
     },
+    tu_item::CardShape,
 };
 use crate::{
     client::jellyfin_client::JELLYFIN_CLIENT,
-    ui::provider::tu_item::{
-        PreferPoster,
-        TuItem,
-    },
+    ui::provider::tu_item::TuItem,
 };
 mod imp {
 
@@ -112,7 +109,6 @@ impl ListPage {
 
         if &collection_type == "livetv" {
             let page = SingleGrid::new();
-            page.set_unify_size(UnifySize::Majority);
             page.connect_sort_changed_tokio(move |_, _, _| async move {
                 JELLYFIN_CLIENT.get_channels_list(0).await
             });
@@ -138,16 +134,10 @@ impl ListPage {
         for (name, title, list_type) in pages {
             let page = SingleGrid::new();
             page.set_list_type(list_type);
-            page.set_unify_size(if list_type == ListType::Resume {
-                UnifySize::ForceVideo
-            } else {
-                UnifySize::Majority
-            });
-            page.set_prefer_poster(if list_type == ListType::Resume {
-                PreferPoster::ParentVideo
-            } else {
-                PreferPoster::Auto
-            });
+            if list_type == ListType::Resume {
+                page.set_card_shape(CardShape::Backdrop);
+            }
+            page.set_prefer_thumb(list_type == ListType::Resume);
             page.set_is_resume(list_type == ListType::Resume);
             let id_clone1 = id.to_owned();
             let include_item_types_clone1 = include_item_types.to_owned();

--- a/src/ui/widgets/list.rs
+++ b/src/ui/widgets/list.rs
@@ -11,7 +11,10 @@ use super::{
         SingleGrid,
         imp::ListType,
     },
-    tu_item::CardShape,
+    tu_item::{
+        CardOptions,
+        CardShape,
+    },
 };
 use crate::{
     client::jellyfin_client::JELLYFIN_CLIENT,
@@ -134,11 +137,17 @@ impl ListPage {
         for (name, title, list_type) in pages {
             let page = SingleGrid::new();
             page.set_list_type(list_type);
-            if list_type == ListType::Resume {
-                page.set_card_shape(CardShape::Backdrop);
-            }
-            page.set_prefer_thumb(list_type == ListType::Resume);
-            page.set_is_resume(list_type == ListType::Resume);
+            let is_resume = list_type == ListType::Resume;
+            page.set_card_options(CardOptions {
+                shape: if is_resume {
+                    CardShape::Backdrop
+                } else {
+                    CardShape::default()
+                },
+                prefer_thumb: is_resume,
+                ..Default::default()
+            });
+            page.set_is_resume(is_resume);
             let id_clone1 = id.to_owned();
             let include_item_types_clone1 = include_item_types.to_owned();
             page.connect_sort_changed_tokio(move |sort_by, sort_order, filters_list| {

--- a/src/ui/widgets/logo.rs
+++ b/src/ui/widgets/logo.rs
@@ -17,7 +17,7 @@ use crate::{
     },
 };
 
-pub async fn set_logo(id: String, image_type: &str, tag: Option<u8>) -> Revealer {
+pub async fn set_logo(id: String, image_type: &str, tag: Option<String>) -> Revealer {
     let image = gtk::Picture::new();
     image.set_halign(gtk::Align::Fill);
     image.set_content_fit(gtk::ContentFit::Contain);
@@ -30,7 +30,12 @@ pub async fn set_logo(id: String, image_type: &str, tag: Option<u8>) -> Revealer
         .build();
 
     let cache_path = jellyfin_cache_path().await;
-    let path = format!("{}-{}-{}", id, image_type, tag.unwrap_or(0));
+    let path = format!(
+        "{}-{}-{}",
+        id,
+        image_type,
+        tag.clone().unwrap_or_else(|| "0".into())
+    );
 
     let id = id.to_string();
 

--- a/src/ui/widgets/logo.rs
+++ b/src/ui/widgets/logo.rs
@@ -17,7 +17,7 @@ use crate::{
     },
 };
 
-pub async fn set_logo(id: String, image_type: &str, tag: Option<String>) -> Revealer {
+pub async fn set_logo(id: String, image_type: &str, image_index: Option<u8>) -> Revealer {
     let image = gtk::Picture::new();
     image.set_halign(gtk::Align::Fill);
     image.set_content_fit(gtk::ContentFit::Contain);
@@ -30,12 +30,7 @@ pub async fn set_logo(id: String, image_type: &str, tag: Option<String>) -> Reve
         .build();
 
     let cache_path = jellyfin_cache_path().await;
-    let path = format!(
-        "{}-{}-{}",
-        id,
-        image_type,
-        tag.clone().unwrap_or_else(|| "0".into())
-    );
+    let path = format!("{}-{}-{}", id, image_type, image_index.unwrap_or(0));
 
     let id = id.to_string();
 
@@ -56,9 +51,12 @@ pub async fn set_logo(id: String, image_type: &str, tag: Option<String>) -> Reve
         #[weak]
         revealer,
         async move {
-            let _ =
-                spawn_tokio(async move { JELLYFIN_CLIENT.get_image(&id, &image_type, tag).await })
-                    .await;
+            let _ = spawn_tokio(async move {
+                JELLYFIN_CLIENT
+                    .get_image(&id, &image_type, image_index)
+                    .await
+            })
+            .await;
             debug!("Setting image: {}", &pathbuf.display());
             let file = gtk::gio::File::for_path(pathbuf);
             image.set_file(Some(&file));

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -162,7 +162,8 @@ pub(crate) mod imp {
             self.actionbox.set_id(Some(obj.item().id()));
             self.selection.set_model(Some(&store));
             self.episode_list.set_factory(Some(
-                SignalListItemFactory::new().tu_overview_item(ViewGroup::EpisodesView),
+                SignalListItemFactory::new()
+                    .tu_overview_item(ViewGroup::EpisodesView, Default::default()),
             ));
             self.episode_list.set_model(Some(&self.selection));
         }

--- a/src/ui/widgets/other.rs
+++ b/src/ui/widgets/other.rs
@@ -2,6 +2,11 @@ use super::{
     horbu_scrolled::HorbuScrolled,
     item::dt,
     picture_loader::PictureLoader,
+    tu_item::{
+        CardOptions,
+        CardShape,
+        select_picture_source,
+    },
     utils::GlobalToast,
 };
 use crate::{
@@ -193,8 +198,16 @@ impl OtherPage {
 
     pub fn setup_pic(&self) {
         let imp = self.imp();
-        let id = self.item().id();
-        let pic = PictureLoader::new(&id, "Primary", None);
+        let Some(source) = select_picture_source(
+            &self.item(),
+            CardOptions {
+                shape: CardShape::Portrait,
+                ..Default::default()
+            },
+        ) else {
+            return;
+        };
+        let pic = PictureLoader::new_for_source(source);
         pic.set_size_request(218, 328);
         pic.set_halign(gtk::Align::Fill);
         pic.set_valign(gtk::Align::Start);

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -104,7 +104,7 @@ pub mod imp {
         pub imagetype: RefCell<String>,
         #[property(get, set, nullable)]
         pub tag: RefCell<Option<String>>,
-        pub image_index: RefCell<Option<u8>>,
+        pub image_index: Cell<Option<u8>>,
         #[property(get, set, nullable)]
         pub url: RefCell<Option<String>>,
         #[template_child]
@@ -385,7 +385,7 @@ impl PictureLoader {
                 id: self.id(),
                 tag: self.tag(),
                 image_type: self.imagetype(),
-                image_index: *self.imp().image_index.borrow(),
+                image_index: self.imp().image_index.get(),
             }
         }
     }

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -63,6 +63,7 @@ impl LoadToken {
 pub enum PictureSource {
     Item {
         id: String,
+        tag: Option<String>,
         image_type: String,
         image_index: Option<u8>,
     },
@@ -76,6 +77,7 @@ impl PictureSource {
     pub fn item(id: &str, image_type: &str, image_index: Option<u8>) -> Self {
         Self::Item {
             id: id.to_string(),
+            tag: None,
             image_type: image_type.to_string(),
             image_index,
         }
@@ -100,10 +102,11 @@ pub mod imp {
         pub id: RefCell<String>,
         #[property(get, set)]
         pub imagetype: RefCell<String>,
+        #[property(get, set, nullable)]
+        pub tag: RefCell<Option<String>>,
         pub image_index: RefCell<Option<u8>>,
         #[property(get, set, nullable)]
         pub url: RefCell<Option<String>>,
-        pub fallbacks: RefCell<Vec<PictureSource>>,
         #[template_child]
         pub revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
@@ -162,16 +165,7 @@ glib::wrapper! {
 
 impl PictureLoader {
     pub fn new(id: &str, image_type: &str, image_index: Option<u8>) -> Self {
-        Self::new_with_fallbacks(id, image_type, image_index, Vec::new())
-    }
-
-    pub fn new_with_fallbacks(
-        id: &str, image_type: &str, image_index: Option<u8>, fallbacks: Vec<PictureSource>,
-    ) -> Self {
-        Self::new_for_source_with_fallbacks(
-            PictureSource::item(id, image_type, image_index),
-            fallbacks,
-        )
+        Self::new_for_source(PictureSource::item(id, image_type, image_index))
     }
 
     pub fn new_for_url(image_type: &str, url: &str) -> Self {
@@ -182,21 +176,17 @@ impl PictureLoader {
     }
 
     pub(crate) fn new_for_source(source: PictureSource) -> Self {
-        Self::new_for_source_with_fallbacks(source, Vec::new())
-    }
-
-    pub(crate) fn new_for_source_with_fallbacks(
-        source: PictureSource, fallbacks: Vec<PictureSource>,
-    ) -> Self {
         let obj: Self = match source {
             PictureSource::Item {
                 id,
+                tag,
                 image_type,
                 image_index,
             } => {
                 let obj: Self = glib::Object::builder()
                     .property("id", id)
                     .property("imagetype", image_type)
+                    .property("tag", tag.as_deref())
                     .build();
                 obj.imp().image_index.replace(image_index);
                 obj
@@ -207,21 +197,7 @@ impl PictureLoader {
                 .property("url", url)
                 .build(),
         };
-        obj.imp().fallbacks.replace(fallbacks);
         obj
-    }
-
-    pub fn reload(&self, id: &str, image_type: &str, image_index: Option<u8>) {
-        self.reload_with_fallbacks(id, image_type, image_index, Vec::new());
-    }
-
-    pub fn reload_with_fallbacks(
-        &self, id: &str, image_type: &str, image_index: Option<u8>, fallbacks: Vec<PictureSource>,
-    ) {
-        self.reload_source_with_fallbacks(
-            PictureSource::item(id, image_type, image_index),
-            fallbacks,
-        );
     }
 
     pub fn reload_for_url(&self, image_type: &str, url: &str) {
@@ -232,21 +208,17 @@ impl PictureLoader {
     }
 
     pub fn reload_source(&self, source: PictureSource) {
-        self.reload_source_with_fallbacks(source, Vec::new());
-    }
-
-    pub(crate) fn reload_source_with_fallbacks(
-        &self, source: PictureSource, fallbacks: Vec<PictureSource>,
-    ) {
         self.reset_view();
         match &source {
             PictureSource::Item {
                 id,
+                tag,
                 image_type,
                 image_index,
             } => {
                 self.set_id(id.as_str());
                 self.set_imagetype(image_type.as_str());
+                self.set_tag(tag.as_deref());
                 self.imp().image_index.replace(*image_index);
                 self.set_url(None::<String>);
             }
@@ -257,7 +229,6 @@ impl PictureLoader {
                 self.set_url(Some(url.as_str()));
             }
         }
-        self.imp().fallbacks.replace(fallbacks);
         self.load_source(source);
     }
 
@@ -292,12 +263,9 @@ impl PictureLoader {
         if let PictureSource::Url { image_type, .. } = &source {
             self.configure_picture_size(image_type);
         }
-        let fallbacks = self.imp().fallbacks.borrow().clone();
         let weak_self = self.downgrade();
         spawn(async move {
-            let mut candidates = vec![source];
-            candidates.extend(fallbacks);
-            let paintable = Self::load_paintable(load_token.clone(), candidates).await;
+            let paintable = Self::load_paintable(load_token.clone(), source).await;
             let Some(obj) = weak_self.upgrade() else {
                 return;
             };
@@ -341,47 +309,40 @@ impl PictureLoader {
     }
 
     async fn load_paintable(
-        load_token: LoadToken, candidates: Vec<PictureSource>,
+        load_token: LoadToken, source: PictureSource,
     ) -> Result<gdk::Paintable> {
-        for source in candidates {
-            if load_token.is_cancelled() {
-                bail!("image load cancelled");
-            }
-            match source {
-                PictureSource::Url { url, .. } => {
-                    if let Ok(paintable) =
-                        Self::load_file(gio::File::for_uri(&url), &load_token).await
-                    {
-                        return Ok(paintable);
-                    }
-                }
-                PictureSource::Item {
-                    id,
-                    image_type,
-                    image_index,
-                } => {
-                    glib::timeout_future(IMAGE_LOAD_DELAY).await;
-                    if load_token.is_cancelled() {
-                        bail!("image load cancelled");
-                    }
-                    let cache_path = Self::cache_file(&id, &image_type, image_index).await;
-                    let file = gio::File::for_path(&cache_path);
+        if load_token.is_cancelled() {
+            bail!("image load cancelled");
+        }
 
-                    if let Ok(paintable) = Self::load_file(file.clone(), &load_token).await {
-                        return Ok(paintable);
-                    } else {
-                        Self::download_image(&id, &image_type, image_index).await;
-                        if load_token.is_cancelled() {
-                            bail!("image load cancelled");
-                        }
-                        if let Ok(paintable) = Self::load_file(file, &load_token).await {
-                            return Ok(paintable);
-                        }
-                    }
+        match source {
+            PictureSource::Url { url, .. } => {
+                Self::load_file(gio::File::for_uri(&url), &load_token).await
+            }
+            PictureSource::Item {
+                id,
+                tag: _,
+                image_type,
+                image_index,
+            } => {
+                glib::timeout_future(IMAGE_LOAD_DELAY).await;
+                if load_token.is_cancelled() {
+                    bail!("image load cancelled");
                 }
+                let cache_path = Self::cache_file(&id, &image_type, image_index).await;
+                let file = gio::File::for_path(&cache_path);
+
+                if let Ok(paintable) = Self::load_file(file.clone(), &load_token).await {
+                    return Ok(paintable);
+                }
+
+                Self::download_image(&id, &image_type, image_index).await;
+                if load_token.is_cancelled() {
+                    bail!("image load cancelled");
+                }
+                Self::load_file(file, &load_token).await
             }
         }
-        bail!("all image sources failed to load")
     }
 
     async fn load_file(file: gio::File, load_token: &LoadToken) -> Result<gdk::Paintable> {
@@ -422,6 +383,7 @@ impl PictureLoader {
         } else {
             PictureSource::Item {
                 id: self.id(),
+                tag: self.tag(),
                 image_type: self.imagetype(),
                 image_index: *self.imp().image_index.borrow(),
             }

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -72,6 +72,16 @@ pub enum PictureSource {
     },
 }
 
+impl PictureSource {
+    pub fn item(id: &str, image_type: &str, tag: Option<String>) -> Self {
+        Self::Item {
+            id: id.to_string(),
+            image_type: image_type.to_string(),
+            tag,
+        }
+    }
+}
+
 pub mod imp {
     use std::cell::{
         Cell,
@@ -94,6 +104,7 @@ pub mod imp {
         pub tag: RefCell<Option<String>>,
         #[property(get, set, nullable)]
         pub url: RefCell<Option<String>>,
+        pub fallbacks: RefCell<Vec<PictureSource>>,
         #[template_child]
         pub revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
@@ -152,11 +163,13 @@ glib::wrapper! {
 
 impl PictureLoader {
     pub fn new(id: &str, image_type: &str, tag: Option<String>) -> Self {
-        Self::new_for_source(PictureSource::Item {
-            id: id.to_string(),
-            image_type: image_type.to_string(),
-            tag,
-        })
+        Self::new_with_fallbacks(id, image_type, tag, Vec::new())
+    }
+
+    pub fn new_with_fallbacks(
+        id: &str, image_type: &str, tag: Option<String>, fallbacks: Vec<PictureSource>,
+    ) -> Self {
+        Self::new_for_source_with_fallbacks(PictureSource::item(id, image_type, tag), fallbacks)
     }
 
     pub fn new_for_url(image_type: &str, url: &str) -> Self {
@@ -167,7 +180,13 @@ impl PictureLoader {
     }
 
     pub(crate) fn new_for_source(source: PictureSource) -> Self {
-        match source {
+        Self::new_for_source_with_fallbacks(source, Vec::new())
+    }
+
+    pub(crate) fn new_for_source_with_fallbacks(
+        source: PictureSource, fallbacks: Vec<PictureSource>,
+    ) -> Self {
+        let obj: Self = match source {
             PictureSource::Item {
                 id,
                 image_type,
@@ -182,15 +201,19 @@ impl PictureLoader {
                 .property("imagetype", image_type)
                 .property("url", url)
                 .build(),
-        }
+        };
+        obj.imp().fallbacks.replace(fallbacks);
+        obj
     }
 
     pub fn reload(&self, id: &str, image_type: &str, tag: Option<String>) {
-        self.reload_source(PictureSource::Item {
-            id: id.to_string(),
-            image_type: image_type.to_string(),
-            tag,
-        });
+        self.reload_with_fallbacks(id, image_type, tag, Vec::new());
+    }
+
+    pub fn reload_with_fallbacks(
+        &self, id: &str, image_type: &str, tag: Option<String>, fallbacks: Vec<PictureSource>,
+    ) {
+        self.reload_source_with_fallbacks(PictureSource::item(id, image_type, tag), fallbacks);
     }
 
     pub fn reload_for_url(&self, image_type: &str, url: &str) {
@@ -201,6 +224,12 @@ impl PictureLoader {
     }
 
     pub fn reload_source(&self, source: PictureSource) {
+        self.reload_source_with_fallbacks(source, Vec::new());
+    }
+
+    pub(crate) fn reload_source_with_fallbacks(
+        &self, source: PictureSource, fallbacks: Vec<PictureSource>,
+    ) {
         self.reset_view();
         match &source {
             PictureSource::Item {
@@ -220,6 +249,7 @@ impl PictureLoader {
                 self.set_url(Some(url.as_str()));
             }
         }
+        self.imp().fallbacks.replace(fallbacks);
         self.load_source(source);
     }
 
@@ -254,9 +284,12 @@ impl PictureLoader {
         if let PictureSource::Url { image_type, .. } = &source {
             self.configure_picture_size(image_type);
         }
+        let fallbacks = self.imp().fallbacks.borrow().clone();
         let weak_self = self.downgrade();
         spawn(async move {
-            let paintable = Self::load_paintable(load_token.clone(), source).await;
+            let mut candidates = vec![source];
+            candidates.extend(fallbacks);
+            let paintable = Self::load_paintable(load_token.clone(), candidates).await;
             let Some(obj) = weak_self.upgrade() else {
                 return;
             };
@@ -300,35 +333,47 @@ impl PictureLoader {
     }
 
     async fn load_paintable(
-        load_token: LoadToken, source: PictureSource,
+        load_token: LoadToken, candidates: Vec<PictureSource>,
     ) -> Result<gdk::Paintable> {
-        match source {
-            PictureSource::Url { url, .. } => {
-                Self::load_file(gio::File::for_uri(&url), &load_token).await
+        for source in candidates {
+            if load_token.is_cancelled() {
+                bail!("image load cancelled");
             }
-            PictureSource::Item {
-                id,
-                image_type,
-                tag,
-            } => {
-                glib::timeout_future(IMAGE_LOAD_DELAY).await;
-                if load_token.is_cancelled() {
-                    bail!("image load cancelled");
+            match source {
+                PictureSource::Url { url, .. } => {
+                    if let Ok(paintable) =
+                        Self::load_file(gio::File::for_uri(&url), &load_token).await
+                    {
+                        return Ok(paintable);
+                    }
                 }
-                let cache_path = Self::cache_file(&id, &image_type, tag.as_deref()).await;
-                let file = gio::File::for_path(&cache_path);
-
-                if let Ok(paintable) = Self::load_file(file.clone(), &load_token).await {
-                    Ok(paintable)
-                } else {
-                    Self::download_image(&id, &image_type, tag.as_deref()).await;
+                PictureSource::Item {
+                    id,
+                    image_type,
+                    tag,
+                } => {
+                    glib::timeout_future(IMAGE_LOAD_DELAY).await;
                     if load_token.is_cancelled() {
                         bail!("image load cancelled");
                     }
-                    Self::load_file(file, &load_token).await
+                    let cache_path = Self::cache_file(&id, &image_type, tag.as_deref()).await;
+                    let file = gio::File::for_path(&cache_path);
+
+                    if let Ok(paintable) = Self::load_file(file.clone(), &load_token).await {
+                        return Ok(paintable);
+                    } else {
+                        Self::download_image(&id, &image_type, tag.as_deref()).await;
+                        if load_token.is_cancelled() {
+                            bail!("image load cancelled");
+                        }
+                        if let Ok(paintable) = Self::load_file(file, &load_token).await {
+                            return Ok(paintable);
+                        }
+                    }
                 }
             }
         }
+        bail!("all image sources failed to load")
     }
 
     async fn load_file(file: gio::File, load_token: &LoadToken) -> Result<gdk::Paintable> {
@@ -349,12 +394,9 @@ impl PictureLoader {
         let warn_id = id.clone();
         let warn_image_type = image_type.clone();
 
-        let result = spawn_tokio(async move {
-            JELLYFIN_CLIENT
-                .get_image(&id, &image_type, tag.and_then(|s| s.parse::<u8>().ok()))
-                .await
-        })
-        .await;
+        let result =
+            spawn_tokio(async move { JELLYFIN_CLIENT.get_image(&id, &image_type, tag).await })
+                .await;
 
         if let Err(error) = result {
             warn!("{}: {}-{}", error, warn_id, warn_image_type);

--- a/src/ui/widgets/picture_loader.rs
+++ b/src/ui/widgets/picture_loader.rs
@@ -64,7 +64,7 @@ pub enum PictureSource {
     Item {
         id: String,
         image_type: String,
-        tag: Option<String>,
+        image_index: Option<u8>,
     },
     Url {
         image_type: String,
@@ -73,11 +73,11 @@ pub enum PictureSource {
 }
 
 impl PictureSource {
-    pub fn item(id: &str, image_type: &str, tag: Option<String>) -> Self {
+    pub fn item(id: &str, image_type: &str, image_index: Option<u8>) -> Self {
         Self::Item {
             id: id.to_string(),
             image_type: image_type.to_string(),
-            tag,
+            image_index,
         }
     }
 }
@@ -100,8 +100,7 @@ pub mod imp {
         pub id: RefCell<String>,
         #[property(get, set)]
         pub imagetype: RefCell<String>,
-        #[property(get, set, nullable)]
-        pub tag: RefCell<Option<String>>,
+        pub image_index: RefCell<Option<u8>>,
         #[property(get, set, nullable)]
         pub url: RefCell<Option<String>>,
         pub fallbacks: RefCell<Vec<PictureSource>>,
@@ -162,14 +161,17 @@ glib::wrapper! {
 }
 
 impl PictureLoader {
-    pub fn new(id: &str, image_type: &str, tag: Option<String>) -> Self {
-        Self::new_with_fallbacks(id, image_type, tag, Vec::new())
+    pub fn new(id: &str, image_type: &str, image_index: Option<u8>) -> Self {
+        Self::new_with_fallbacks(id, image_type, image_index, Vec::new())
     }
 
     pub fn new_with_fallbacks(
-        id: &str, image_type: &str, tag: Option<String>, fallbacks: Vec<PictureSource>,
+        id: &str, image_type: &str, image_index: Option<u8>, fallbacks: Vec<PictureSource>,
     ) -> Self {
-        Self::new_for_source_with_fallbacks(PictureSource::item(id, image_type, tag), fallbacks)
+        Self::new_for_source_with_fallbacks(
+            PictureSource::item(id, image_type, image_index),
+            fallbacks,
+        )
     }
 
     pub fn new_for_url(image_type: &str, url: &str) -> Self {
@@ -190,12 +192,15 @@ impl PictureLoader {
             PictureSource::Item {
                 id,
                 image_type,
-                tag,
-            } => glib::Object::builder()
-                .property("id", id)
-                .property("imagetype", image_type)
-                .property("tag", tag)
-                .build(),
+                image_index,
+            } => {
+                let obj: Self = glib::Object::builder()
+                    .property("id", id)
+                    .property("imagetype", image_type)
+                    .build();
+                obj.imp().image_index.replace(image_index);
+                obj
+            }
             PictureSource::Url { image_type, url } => glib::Object::builder()
                 .property("id", "")
                 .property("imagetype", image_type)
@@ -206,14 +211,17 @@ impl PictureLoader {
         obj
     }
 
-    pub fn reload(&self, id: &str, image_type: &str, tag: Option<String>) {
-        self.reload_with_fallbacks(id, image_type, tag, Vec::new());
+    pub fn reload(&self, id: &str, image_type: &str, image_index: Option<u8>) {
+        self.reload_with_fallbacks(id, image_type, image_index, Vec::new());
     }
 
     pub fn reload_with_fallbacks(
-        &self, id: &str, image_type: &str, tag: Option<String>, fallbacks: Vec<PictureSource>,
+        &self, id: &str, image_type: &str, image_index: Option<u8>, fallbacks: Vec<PictureSource>,
     ) {
-        self.reload_source_with_fallbacks(PictureSource::item(id, image_type, tag), fallbacks);
+        self.reload_source_with_fallbacks(
+            PictureSource::item(id, image_type, image_index),
+            fallbacks,
+        );
     }
 
     pub fn reload_for_url(&self, image_type: &str, url: &str) {
@@ -235,17 +243,17 @@ impl PictureLoader {
             PictureSource::Item {
                 id,
                 image_type,
-                tag,
+                image_index,
             } => {
                 self.set_id(id.as_str());
                 self.set_imagetype(image_type.as_str());
-                self.set_tag(tag.clone());
+                self.imp().image_index.replace(*image_index);
                 self.set_url(None::<String>);
             }
             PictureSource::Url { image_type, url } => {
                 self.set_id("");
                 self.set_imagetype(image_type.as_str());
-                self.set_tag(None::<String>);
+                self.imp().image_index.replace(None);
                 self.set_url(Some(url.as_str()));
             }
         }
@@ -350,19 +358,19 @@ impl PictureLoader {
                 PictureSource::Item {
                     id,
                     image_type,
-                    tag,
+                    image_index,
                 } => {
                     glib::timeout_future(IMAGE_LOAD_DELAY).await;
                     if load_token.is_cancelled() {
                         bail!("image load cancelled");
                     }
-                    let cache_path = Self::cache_file(&id, &image_type, tag.as_deref()).await;
+                    let cache_path = Self::cache_file(&id, &image_type, image_index).await;
                     let file = gio::File::for_path(&cache_path);
 
                     if let Ok(paintable) = Self::load_file(file.clone(), &load_token).await {
                         return Ok(paintable);
                     } else {
-                        Self::download_image(&id, &image_type, tag.as_deref()).await;
+                        Self::download_image(&id, &image_type, image_index).await;
                         if load_token.is_cancelled() {
                             bail!("image load cancelled");
                         }
@@ -381,22 +389,24 @@ impl PictureLoader {
         paintable_from_file(file, Some(load_token.cancellable.clone())).await
     }
 
-    async fn cache_file(id: &str, image_type: &str, tag: Option<&str>) -> PathBuf {
+    async fn cache_file(id: &str, image_type: &str, image_index: Option<u8>) -> PathBuf {
         let cache_path = jellyfin_cache_path().await;
-        let path = format!("{}-{}-{}", id, image_type, tag.unwrap_or("0"));
+        let path = format!("{}-{}-{}", id, image_type, image_index.unwrap_or(0));
         cache_path.join(path)
     }
 
-    async fn download_image(id: &str, image_type: &str, tag: Option<&str>) {
+    async fn download_image(id: &str, image_type: &str, image_index: Option<u8>) {
         let id = id.to_string();
         let image_type = image_type.to_string();
-        let tag = tag.map(str::to_string);
         let warn_id = id.clone();
         let warn_image_type = image_type.clone();
 
-        let result =
-            spawn_tokio(async move { JELLYFIN_CLIENT.get_image(&id, &image_type, tag).await })
-                .await;
+        let result = spawn_tokio(async move {
+            JELLYFIN_CLIENT
+                .get_image(&id, &image_type, image_index)
+                .await
+        })
+        .await;
 
         if let Err(error) = result {
             warn!("{}: {}-{}", error, warn_id, warn_image_type);
@@ -413,7 +423,7 @@ impl PictureLoader {
             PictureSource::Item {
                 id: self.id(),
                 image_type: self.imagetype(),
-                tag: self.tag(),
+                image_index: *self.imp().image_index.borrow(),
             }
         }
     }

--- a/src/ui/widgets/search.rs
+++ b/src/ui/widgets/search.rs
@@ -44,7 +44,6 @@ mod imp {
     use crate::{
         ui::widgets::{
             filter_panel::FilterPanelDialog,
-            hortu_scrolled::UnifySize,
             tuview_scrolled::TuViewScrolled,
         },
         utils::spawn,
@@ -106,9 +105,6 @@ mod imp {
         fn constructed(&self) {
             let obj = self.obj();
             self.parent_constructed();
-            self.searchscrolled
-                .get()
-                .set_unify_size(UnifySize::Majority);
             self.searchscrolled.connect_end_edge_reached(glib::clone!(
                 #[weak]
                 obj,

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -21,7 +21,7 @@ use super::{
         FilterPanelDialog,
         FiltersList,
     },
-    tu_item::CardShape,
+    tu_item::CardOptions,
     utils::GlobalToast,
 };
 use crate::{
@@ -69,7 +69,10 @@ pub mod imp {
         models::SETTINGS,
         widgets::{
             filter_panel::FilterPanelDialog,
-            tu_item::CardShape,
+            tu_item::{
+                CardOptions,
+                CardShape,
+            },
             tuview_scrolled::TuViewScrolled,
         },
     };
@@ -264,13 +267,20 @@ pub mod imp {
             klass.bind_template();
             klass.bind_template_instance_callbacks();
             klass.install_action("poster", None, |window, _action, _parameter| {
-                window.set_image_options(CardShape::Auto, false);
+                window.set_card_options(CardOptions::default());
             });
             klass.install_action("backdrop", None, |window, _action, _parameter| {
-                window.set_image_options(CardShape::Backdrop, true);
+                window.set_card_options(CardOptions {
+                    shape: CardShape::Backdrop,
+                    prefer_thumb: true,
+                    ..Default::default()
+                });
             });
             klass.install_action("banner", None, |window, _action, _parameter| {
-                window.set_image_options(CardShape::Banner, false);
+                window.set_card_options(CardOptions {
+                    shape: CardShape::Banner,
+                    ..Default::default()
+                });
             });
         }
 
@@ -454,15 +464,8 @@ impl SingleGrid {
         }
     }
 
-    pub fn set_card_shape(&self, card_shape: CardShape) {
-        self.imp().scrolled.get().apply_card_shape(card_shape);
-    }
-
-    pub fn set_image_options(&self, card_shape: CardShape, prefer_thumb: bool) {
-        self.imp()
-            .scrolled
-            .get()
-            .apply_image_options(card_shape, prefer_thumb);
+    pub fn set_card_options(&self, options: CardOptions) {
+        self.imp().scrolled.get().apply_card_options(options);
     }
 
     pub fn add_items<const C: bool>(&self, items: Vec<SimpleListItem>) {
@@ -492,17 +495,6 @@ impl SingleGrid {
             .total_item_count
             .get()
             .is_some_and(|total_item_count| n_items >= total_item_count)
-    }
-
-    pub fn set_prefer_thumb(&self, prefer_thumb: bool) {
-        self.imp().scrolled.get().set_prefer_thumb(prefer_thumb);
-    }
-
-    pub fn set_prefer_parent_poster(&self, prefer_parent_poster: bool) {
-        self.imp()
-            .scrolled
-            .get()
-            .set_prefer_parent_poster(prefer_parent_poster);
     }
 
     pub fn set_is_resume(&self, is_resume: bool) {

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -264,13 +264,13 @@ pub mod imp {
             klass.bind_template();
             klass.bind_template_instance_callbacks();
             klass.install_action("poster", None, |window, _action, _parameter| {
-                window.set_image_options(CardShape::Auto, false, false);
+                window.set_image_options(CardShape::Auto, false);
             });
             klass.install_action("backdrop", None, |window, _action, _parameter| {
-                window.set_image_options(CardShape::Backdrop, true, false);
+                window.set_image_options(CardShape::Backdrop, true);
             });
             klass.install_action("banner", None, |window, _action, _parameter| {
-                window.set_image_options(CardShape::Banner, false, false);
+                window.set_image_options(CardShape::Banner, false);
             });
         }
 
@@ -458,13 +458,11 @@ impl SingleGrid {
         self.imp().scrolled.get().apply_card_shape(card_shape);
     }
 
-    pub fn set_image_options(
-        &self, card_shape: CardShape, prefer_thumb: bool, prefer_banner: bool,
-    ) {
+    pub fn set_image_options(&self, card_shape: CardShape, prefer_thumb: bool) {
         self.imp()
             .scrolled
             .get()
-            .apply_image_options(card_shape, prefer_thumb, prefer_banner);
+            .apply_image_options(card_shape, prefer_thumb);
     }
 
     pub fn add_items<const C: bool>(&self, items: Vec<SimpleListItem>) {
@@ -498,10 +496,6 @@ impl SingleGrid {
 
     pub fn set_prefer_thumb(&self, prefer_thumb: bool) {
         self.imp().scrolled.get().set_prefer_thumb(prefer_thumb);
-    }
-
-    pub fn set_prefer_banner(&self, prefer_banner: bool) {
-        self.imp().scrolled.get().set_prefer_banner(prefer_banner);
     }
 
     pub fn set_prefer_parent_poster(&self, prefer_parent_poster: bool) {

--- a/src/ui/widgets/single_grid.rs
+++ b/src/ui/widgets/single_grid.rs
@@ -7,7 +7,6 @@ use adw::prelude::*;
 use anyhow::Result;
 use glib::Object;
 use gtk::{
-    SignalListItemFactory,
     gio,
     glib,
     subclass::prelude::*,
@@ -22,13 +21,8 @@ use super::{
         FilterPanelDialog,
         FiltersList,
     },
-    hortu_scrolled::UnifySize,
-    tu_list_item::imp::PosterType,
-    tu_overview_item::imp::ViewGroup,
-    utils::{
-        GlobalToast,
-        TuItemBuildExt,
-    },
+    tu_item::CardShape,
+    utils::GlobalToast,
 };
 use crate::{
     client::{
@@ -38,7 +32,6 @@ use crate::{
             SimpleListItem,
         },
     },
-    ui::provider::tu_item::PreferPoster,
     utils::{
         spawn,
         spawn_tokio,
@@ -76,7 +69,7 @@ pub mod imp {
         models::SETTINGS,
         widgets::{
             filter_panel::FilterPanelDialog,
-            tu_list_item::imp::PosterType,
+            tu_item::CardShape,
             tuview_scrolled::TuViewScrolled,
         },
     };
@@ -270,18 +263,14 @@ pub mod imp {
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
             klass.bind_template_instance_callbacks();
-            klass.install_action_async("poster", None, |window, _action, _parameter| async move {
-                window.poster(PosterType::Poster).await;
+            klass.install_action("poster", None, |window, _action, _parameter| {
+                window.set_image_options(CardShape::Auto, false, false);
             });
-            klass.install_action_async(
-                "backdrop",
-                None,
-                |window, _action, _parameter| async move {
-                    window.poster(PosterType::Backdrop).await;
-                },
-            );
-            klass.install_action_async("banner", None, |window, _action, _parameter| async move {
-                window.poster(PosterType::Banner).await;
+            klass.install_action("backdrop", None, |window, _action, _parameter| {
+                window.set_image_options(CardShape::Backdrop, true, false);
+            });
+            klass.install_action("banner", None, |window, _action, _parameter| {
+                window.set_image_options(CardShape::Banner, false, false);
             });
         }
 
@@ -465,23 +454,17 @@ impl SingleGrid {
         }
     }
 
-    pub async fn poster(&self, poster_type: PosterType) {
-        let scrolled = self.imp().scrolled.get();
-        let factory = SignalListItemFactory::new();
-        match self.view_type() {
-            ViewType::GridView => {
-                scrolled
-                    .imp()
-                    .grid
-                    .set_factory(Some(factory.tu_item(poster_type)));
-            }
-            ViewType::ListView => {
-                scrolled
-                    .imp()
-                    .list
-                    .set_factory(Some(factory.tu_overview_item(ViewGroup::ListView)));
-            }
-        };
+    pub fn set_card_shape(&self, card_shape: CardShape) {
+        self.imp().scrolled.get().apply_card_shape(card_shape);
+    }
+
+    pub fn set_image_options(
+        &self, card_shape: CardShape, prefer_thumb: bool, prefer_banner: bool,
+    ) {
+        self.imp()
+            .scrolled
+            .get()
+            .apply_image_options(card_shape, prefer_thumb, prefer_banner);
     }
 
     pub fn add_items<const C: bool>(&self, items: Vec<SimpleListItem>) {
@@ -513,12 +496,19 @@ impl SingleGrid {
             .is_some_and(|total_item_count| n_items >= total_item_count)
     }
 
-    pub fn set_unify_size(&self, unify_size: UnifySize) {
-        self.imp().scrolled.get().set_unify_size(unify_size);
+    pub fn set_prefer_thumb(&self, prefer_thumb: bool) {
+        self.imp().scrolled.get().set_prefer_thumb(prefer_thumb);
     }
 
-    pub fn set_prefer_poster(&self, prefer_poster: PreferPoster) {
-        self.imp().scrolled.get().set_prefer_poster(prefer_poster);
+    pub fn set_prefer_banner(&self, prefer_banner: bool) {
+        self.imp().scrolled.get().set_prefer_banner(prefer_banner);
+    }
+
+    pub fn set_prefer_parent_poster(&self, prefer_parent_poster: bool) {
+        self.imp()
+            .scrolled
+            .get()
+            .set_prefer_parent_poster(prefer_parent_poster);
     }
 
     pub fn set_is_resume(&self, is_resume: bool) {

--- a/src/ui/widgets/tu_item/mod.rs
+++ b/src/ui/widgets/tu_item/mod.rs
@@ -9,6 +9,7 @@ pub use overlay::{
     CardShape,
     TuItemOverlay,
     TuItemOverlayPrelude,
+    select_picture_source,
 };
 pub use prelude::{
     TuItemBasic,

--- a/src/ui/widgets/tu_item/mod.rs
+++ b/src/ui/widgets/tu_item/mod.rs
@@ -5,6 +5,8 @@ mod progressbar_animation;
 
 pub use action::TuItemAction;
 pub use overlay::{
+    CardOptions,
+    CardShape,
     TuItemOverlay,
     TuItemOverlayPrelude,
 };

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -267,23 +267,12 @@ pub fn select_picture_source(item: &TuItem, options: CardOptions) -> Option<Pict
 
 pub trait TuItemOverlayPrelude {
     fn get_image_source(&self, item: &TuItem) -> Option<PictureSource> {
-        select_picture_source(
-            item,
-            CardOptions {
-                shape: self.card_shape_ext(item),
-                prefer_thumb: self.prefer_thumb_ext(),
-                prefer_parent_poster: self.prefer_parent_poster_ext(),
-            },
-        )
+        select_picture_source(item, self.card_options_ext(item))
     }
 
     fn overlay(&self) -> gtk::Overlay;
 
-    fn card_shape_ext(&self, item: &TuItem) -> CardShape;
-
-    fn prefer_thumb_ext(&self) -> bool;
-
-    fn prefer_parent_poster_ext(&self) -> bool;
+    fn card_options_ext(&self, item: &TuItem) -> CardOptions;
 }
 
 pub trait TuItemOverlay: TuItemBasic + TuItemOverlayPrelude {

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -17,7 +17,7 @@ use crate::ui::{
 use super::TuItemBasic;
 
 pub trait TuItemOverlayPrelude {
-    fn get_image_type_and_tag(&self, item: &TuItem) -> (&str, Option<String>, String) {
+    fn get_image_type_and_index(&self, item: &TuItem) -> (&str, Option<u8>, String) {
         if self.poster_type_ext() != PosterType::Poster
             && let Some(imag_tags) = item.image_tags()
         {
@@ -28,12 +28,12 @@ pub trait TuItemOverlayPrelude {
                     } else if imag_tags.thumb().is_some() {
                         return ("Thumb", None, item.id());
                     } else if imag_tags.backdrop().is_some() {
-                        return ("Backdrop", Some(0.to_string()), item.id());
+                        return ("Backdrop", Some(0), item.id());
                     }
                 }
                 PosterType::Backdrop => {
                     if imag_tags.backdrop().is_some() {
-                        return ("Backdrop", Some(0.to_string()), item.id());
+                        return ("Backdrop", Some(0), item.id());
                     } else if imag_tags.thumb().is_some() {
                         return ("Thumb", None, item.id());
                     }
@@ -47,9 +47,9 @@ pub trait TuItemOverlayPrelude {
                 if let Some(parent_thumb_item_id) = item.parent_thumb_item_id() {
                     ("Thumb", None, parent_thumb_item_id)
                 } else if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id() {
-                    ("Backdrop", Some(0.to_string()), parent_backdrop_item_id)
+                    ("Backdrop", Some(0), parent_backdrop_item_id)
                 } else {
-                    ("Backdrop", Some(0.to_string()), item.id())
+                    ("Backdrop", Some(0), item.id())
                 }
             }
             // Latest, use parent primary image if possible, this is for latest episodes
@@ -83,14 +83,14 @@ pub trait TuItemOverlayPrelude {
     fn fallback_sources(&self, item: &TuItem, image_type: &str, id: &str) -> Vec<PictureSource> {
         let mut fallbacks = Vec::new();
         if let Some(image_tags) = item.image_tags() {
-            let mut candidates: Vec<(&str, Option<String>)> = Vec::new();
+            let mut candidates: Vec<(&str, Option<u8>)> = Vec::new();
             match image_type {
                 "Primary" => {
                     if image_tags.thumb().is_some() {
                         candidates.push(("Thumb", None));
                     }
                     if image_tags.backdrop().is_some() {
-                        candidates.push(("Backdrop", Some("0".to_string())));
+                        candidates.push(("Backdrop", Some(0)));
                     }
                     if image_tags.banner().is_some() {
                         candidates.push(("Banner", None));
@@ -101,7 +101,7 @@ pub trait TuItemOverlayPrelude {
                         candidates.push(("Primary", None));
                     }
                     if image_tags.backdrop().is_some() {
-                        candidates.push(("Backdrop", Some("0".to_string())));
+                        candidates.push(("Backdrop", Some(0)));
                     }
                 }
                 "Backdrop" => {
@@ -117,14 +117,14 @@ pub trait TuItemOverlayPrelude {
                         candidates.push(("Thumb", None));
                     }
                     if image_tags.backdrop().is_some() {
-                        candidates.push(("Backdrop", Some("0".to_string())));
+                        candidates.push(("Backdrop", Some(0)));
                     }
                 }
                 _ => {}
             }
-            for (fallback_type, fallback_tag) in candidates {
+            for (fallback_type, fallback_image_index) in candidates {
                 if fallback_type != image_type {
-                    fallbacks.push(PictureSource::item(id, fallback_type, fallback_tag));
+                    fallbacks.push(PictureSource::item(id, fallback_type, fallback_image_index));
                 }
             }
         }
@@ -152,13 +152,13 @@ where
                     Vec::new(),
                 )
             } else {
-                let (image_type, tag, id) = self.get_image_type_and_tag(&item);
+                let (image_type, image_index, id) = self.get_image_type_and_index(&item);
                 let fallbacks = self.fallback_sources(&item, image_type, &id);
                 (
                     PictureSource::Item {
                         id,
                         image_type: image_type.to_string(),
-                        tag,
+                        image_index,
                     },
                     fallbacks,
                 )

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -39,7 +39,6 @@ pub enum CardShape {
 pub struct CardOptions {
     pub shape: CardShape,
     pub prefer_thumb: bool,
-    pub prefer_banner: bool,
     pub prefer_parent_poster: bool,
 }
 
@@ -189,7 +188,6 @@ pub fn select_picture_source(item: &TuItem, options: CardOptions) -> Option<Pict
     let CardOptions {
         shape: card_shape,
         prefer_thumb,
-        prefer_banner,
         prefer_parent_poster,
     } = options;
 
@@ -197,7 +195,7 @@ pub fn select_picture_source(item: &TuItem, options: CardOptions) -> Option<Pict
         return Some(source);
     }
 
-    if (prefer_banner || card_shape == CardShape::Banner)
+    if card_shape == CardShape::Banner
         && let Some(source) = current_source(item, "Banner", None)
     {
         return Some(source);
@@ -274,7 +272,6 @@ pub trait TuItemOverlayPrelude {
             CardOptions {
                 shape: self.card_shape_ext(item),
                 prefer_thumb: self.prefer_thumb_ext(),
-                prefer_banner: self.prefer_banner_ext(),
                 prefer_parent_poster: self.prefer_parent_poster_ext(),
             },
         )
@@ -285,8 +282,6 @@ pub trait TuItemOverlayPrelude {
     fn card_shape_ext(&self, item: &TuItem) -> CardShape;
 
     fn prefer_thumb_ext(&self) -> bool;
-
-    fn prefer_banner_ext(&self) -> bool;
 
     fn prefer_parent_poster_ext(&self) -> bool;
 }

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -79,6 +79,57 @@ pub trait TuItemOverlayPrelude {
     fn overlay(&self) -> gtk::Overlay;
 
     fn poster_type_ext(&self) -> PosterType;
+
+    fn fallback_sources(&self, item: &TuItem, image_type: &str, id: &str) -> Vec<PictureSource> {
+        let mut fallbacks = Vec::new();
+        if let Some(image_tags) = item.image_tags() {
+            let mut candidates: Vec<(&str, Option<String>)> = Vec::new();
+            match image_type {
+                "Primary" => {
+                    if image_tags.thumb().is_some() {
+                        candidates.push(("Thumb", None));
+                    }
+                    if image_tags.backdrop().is_some() {
+                        candidates.push(("Backdrop", Some("0".to_string())));
+                    }
+                    if image_tags.banner().is_some() {
+                        candidates.push(("Banner", None));
+                    }
+                }
+                "Thumb" => {
+                    if image_tags.primary().is_some() {
+                        candidates.push(("Primary", None));
+                    }
+                    if image_tags.backdrop().is_some() {
+                        candidates.push(("Backdrop", Some("0".to_string())));
+                    }
+                }
+                "Backdrop" => {
+                    if image_tags.thumb().is_some() {
+                        candidates.push(("Thumb", None));
+                    }
+                    if image_tags.primary().is_some() {
+                        candidates.push(("Primary", None));
+                    }
+                }
+                "Banner" => {
+                    if image_tags.thumb().is_some() {
+                        candidates.push(("Thumb", None));
+                    }
+                    if image_tags.backdrop().is_some() {
+                        candidates.push(("Backdrop", Some("0".to_string())));
+                    }
+                }
+                _ => {}
+            }
+            for (fallback_type, fallback_tag) in candidates {
+                if fallback_type != image_type {
+                    fallbacks.push(PictureSource::item(id, fallback_type, fallback_tag));
+                }
+            }
+        }
+        fallbacks
+    }
 }
 
 pub trait TuItemOverlay: TuItemBasic + TuItemOverlayPrelude {
@@ -91,27 +142,35 @@ where
 {
     fn set_picture(&self) {
         let item = self.item();
-        let source = if let Some(url) = item.image_url().filter(|url| !url.trim().is_empty()) {
-            PictureSource::Url {
-                image_type: "Primary".to_string(),
-                url,
-            }
-        } else {
-            let (image_type, tag, id) = self.get_image_type_and_tag(&item);
-            PictureSource::Item {
-                id,
-                image_type: image_type.to_string(),
-                tag,
-            }
-        };
+        let (source, fallbacks) =
+            if let Some(url) = item.image_url().filter(|url| !url.trim().is_empty()) {
+                (
+                    PictureSource::Url {
+                        image_type: "Primary".to_string(),
+                        url,
+                    },
+                    Vec::new(),
+                )
+            } else {
+                let (image_type, tag, id) = self.get_image_type_and_tag(&item);
+                let fallbacks = self.fallback_sources(&item, image_type, &id);
+                (
+                    PictureSource::Item {
+                        id,
+                        image_type: image_type.to_string(),
+                        tag,
+                    },
+                    fallbacks,
+                )
+            };
         let overlay = self.overlay();
 
         if let Some(picture_loader) = overlay.child().and_downcast::<PictureLoader>() {
-            picture_loader.reload_source(source);
+            picture_loader.reload_source_with_fallbacks(source, fallbacks);
             return;
         }
 
-        let picture_loader = PictureLoader::new_for_source(source);
+        let picture_loader = PictureLoader::new_for_source_with_fallbacks(source, fallbacks);
         picture_loader.add_css_class("inbox");
         overlay.set_child(Some(&picture_loader));
     }

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -178,84 +178,106 @@ fn album_primary_source(item: &TuItem) -> Option<PictureSource> {
     )
 }
 
+pub fn select_picture_source(item: &TuItem, options: CardOptions) -> Option<PictureSource> {
+    if let Some(url) = item.image_url().filter(|url| !url.trim().is_empty()) {
+        return Some(PictureSource::Url {
+            image_type: "Primary".to_string(),
+            url,
+        });
+    }
+
+    let CardOptions {
+        shape: card_shape,
+        prefer_thumb,
+        prefer_banner,
+        prefer_parent_poster,
+    } = options;
+
+    if prefer_thumb && let Some(source) = current_source(item, "Thumb", None) {
+        return Some(source);
+    }
+
+    if (prefer_banner || card_shape == CardShape::Banner)
+        && let Some(source) = current_source(item, "Banner", None)
+    {
+        return Some(source);
+    }
+
+    if prefer_thumb && let Some(source) = series_thumb_source(item) {
+        return Some(source);
+    }
+
+    if prefer_thumb && let Some(source) = parent_thumb_source(item) {
+        return Some(source);
+    }
+
+    if prefer_thumb && let Some(source) = current_source(item, "Backdrop", Some(0)) {
+        return Some(source);
+    }
+
+    if prefer_thumb
+        && item.item_type() == EPISODE
+        && let Some(source) = parent_backdrop_source(item)
+    {
+        return Some(source);
+    }
+
+    if prefer_parent_poster
+        && !prefer_thumb
+        && item.item_type() == EPISODE
+        && let Some(source) = parent_primary_source(item).or_else(|| series_primary_source(item))
+    {
+        return Some(source);
+    }
+
+    if (item.item_type() != EPISODE || item.imp().child_count.get() != Some(0))
+        && let Some(source) = current_source(item, "Primary", None)
+    {
+        return Some(source);
+    }
+
+    let skip_episode_parent_poster = item.item_type() == EPISODE && card_shape.is_wide();
+
+    if !skip_episode_parent_poster && let Some(source) = series_primary_source(item) {
+        return Some(source);
+    }
+
+    if let Some(source) = primary_image_source(item) {
+        return Some(source);
+    }
+
+    if !skip_episode_parent_poster && let Some(source) = parent_primary_source(item) {
+        return Some(source);
+    }
+
+    if let Some(source) = album_primary_source(item) {
+        return Some(source);
+    }
+
+    if item.item_type() == SEASON
+        && let Some(source) = current_source(item, "Thumb", None)
+    {
+        return Some(source);
+    }
+
+    current_source(item, "Backdrop", Some(0))
+        .or_else(|| current_source(item, "Thumb", None))
+        .or_else(|| series_thumb_source(item))
+        .or_else(|| parent_thumb_source(item))
+        .or_else(|| parent_backdrop_source(item))
+}
+
 pub trait TuItemOverlayPrelude {
     fn get_image_source(&self, item: &TuItem) -> Option<PictureSource> {
-        let card_shape = self.card_shape_ext(item);
-        let prefer_thumb = self.prefer_thumb_ext();
-
-        if prefer_thumb && let Some(source) = current_source(item, "Thumb", None) {
-            return Some(source);
-        }
-
-        if (self.prefer_banner_ext() || card_shape == CardShape::Banner)
-            && let Some(source) = current_source(item, "Banner", None)
-        {
-            return Some(source);
-        }
-
-        if prefer_thumb && let Some(source) = series_thumb_source(item) {
-            return Some(source);
-        }
-
-        if prefer_thumb && let Some(source) = parent_thumb_source(item) {
-            return Some(source);
-        }
-
-        if prefer_thumb && let Some(source) = current_source(item, "Backdrop", Some(0)) {
-            return Some(source);
-        }
-
-        if prefer_thumb
-            && item.item_type() == EPISODE
-            && let Some(source) = parent_backdrop_source(item)
-        {
-            return Some(source);
-        }
-
-        if self.prefer_parent_poster_ext()
-            && !prefer_thumb
-            && item.item_type() == EPISODE
-            && let Some(source) =
-                parent_primary_source(item).or_else(|| series_primary_source(item))
-        {
-            return Some(source);
-        }
-
-        if (item.item_type() != EPISODE || item.imp().child_count.get() != Some(0))
-            && let Some(source) = current_source(item, "Primary", None)
-        {
-            return Some(source);
-        }
-
-        let skip_episode_parent_poster = item.item_type() == EPISODE && card_shape.is_wide();
-
-        if !skip_episode_parent_poster && let Some(source) = series_primary_source(item) {
-            return Some(source);
-        }
-
-        if let Some(source) = primary_image_source(item) {
-            return Some(source);
-        }
-
-        if !skip_episode_parent_poster && let Some(source) = parent_primary_source(item) {
-            return Some(source);
-        }
-
-        if let Some(source) = album_primary_source(item) {
-            return Some(source);
-        }
-
-        if item.item_type() == SEASON
-            && let Some(source) = current_source(item, "Thumb", None)
-        {
-            return Some(source);
-        }
-
-        current_source(item, "Backdrop", Some(0))
-            .or_else(|| current_source(item, "Thumb", None))
-            .or_else(|| series_thumb_source(item))
-            .or_else(|| parent_thumb_source(item))
-            .or_else(|| parent_backdrop_source(item))
+        select_picture_source(
+            item,
+            CardOptions {
+                shape: self.card_shape_ext(item),
+                prefer_thumb: self.prefer_thumb_ext(),
+                prefer_banner: self.prefer_banner_ext(),
+                prefer_parent_poster: self.prefer_parent_poster_ext(),
+            },
+        )
     }
 
     fn overlay(&self) -> gtk::Overlay;
@@ -281,15 +303,7 @@ where
         let item = self.item();
         let overlay = self.overlay();
 
-        let Some(source) = item
-            .image_url()
-            .filter(|url| !url.trim().is_empty())
-            .map(|url| PictureSource::Url {
-                image_type: "Primary".to_string(),
-                url,
-            })
-            .or_else(|| self.get_image_source(&item))
-        else {
+        let Some(source) = self.get_image_source(&item) else {
             return;
         };
 

--- a/src/ui/widgets/tu_item/overlay.rs
+++ b/src/ui/widgets/tu_item/overlay.rs
@@ -1,135 +1,272 @@
-use gtk::prelude::*;
+use gst::glib::subclass::types::ObjectSubclassIsExt;
+use gtk::{
+    glib,
+    prelude::*,
+};
 
-use crate::ui::{
-    provider::tu_item::{
-        PreferPoster,
-        TuItem,
-    },
-    widgets::{
-        picture_loader::{
+use crate::{
+    client::structs::SimpleListItem,
+    ui::{
+        provider::tu_item::{
+            TuItem,
+            item_type::{
+                EPISODE,
+                SEASON,
+            },
+        },
+        widgets::picture_loader::{
             PictureLoader,
             PictureSource,
         },
-        tu_list_item::imp::PosterType,
     },
 };
 
 use super::TuItemBasic;
 
+#[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
+#[repr(u32)]
+#[enum_type(name = "CardShape")]
+pub enum CardShape {
+    #[default]
+    Auto,
+    Backdrop,
+    Banner,
+    Portrait,
+    Square,
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub struct CardOptions {
+    pub shape: CardShape,
+    pub prefer_thumb: bool,
+    pub prefer_banner: bool,
+    pub prefer_parent_poster: bool,
+}
+
+impl CardShape {
+    fn is_wide(self) -> bool {
+        matches!(self, Self::Backdrop | Self::Banner)
+    }
+
+    pub fn resolve(self, items: &[SimpleListItem]) -> Self {
+        if self != Self::Auto {
+            return self;
+        }
+        let mut ratios = items
+            .iter()
+            .filter_map(|item| item.primary_image_aspect_ratio)
+            .filter(|ratio| *ratio != 0.0)
+            .collect::<Vec<_>>();
+
+        ratios.sort_by(f64::total_cmp);
+        let ratio = match ratios.len() {
+            0 => return Self::Square,
+            n if n % 2 == 1 => ratios[n / 2],
+            n => (ratios[n / 2 - 1] + ratios[n / 2]) / 2.0,
+        };
+
+        let ratio = if (2.0 / 3.0 - ratio).abs() <= 0.15 {
+            2.0 / 3.0
+        } else if (16.0 / 9.0 - ratio).abs() <= 0.2 {
+            16.0 / 9.0
+        } else if (1.0 - ratio).abs() <= 0.15 {
+            1.0
+        } else if (4.0 / 3.0 - ratio).abs() <= 0.15 {
+            4.0 / 3.0
+        } else {
+            ratio
+        };
+
+        if ratio >= 3.0 {
+            Self::Banner
+        } else if ratio >= 1.33 {
+            Self::Backdrop
+        } else if ratio > 0.8 {
+            Self::Square
+        } else {
+            Self::Portrait
+        }
+    }
+}
+
+fn tagged_source(
+    id: Option<String>, tag: Option<String>, image_type: &str, image_index: Option<u8>,
+) -> Option<PictureSource> {
+    let (id, tag) = (id?, tag?);
+    Some(PictureSource::Item {
+        id,
+        tag: Some(tag),
+        image_type: image_type.to_string(),
+        image_index,
+    })
+}
+
+fn current_source(
+    item: &TuItem, image_type: &str, image_index: Option<u8>,
+) -> Option<PictureSource> {
+    let image_tags = item.image_tags()?;
+    let tag = match image_type {
+        "Primary" => image_tags.primary(),
+        "Thumb" => image_tags.thumb(),
+        "Backdrop" => image_tags.backdrop(),
+        "Banner" => image_tags.banner(),
+        _ => None,
+    };
+    tagged_source(Some(item.id()), tag, image_type, image_index)
+}
+
+fn parent_thumb_source(item: &TuItem) -> Option<PictureSource> {
+    tagged_source(
+        item.parent_thumb_item_id(),
+        item.parent_thumb_image_tag(),
+        "Thumb",
+        None,
+    )
+}
+
+fn parent_backdrop_source(item: &TuItem) -> Option<PictureSource> {
+    tagged_source(
+        item.parent_backdrop_item_id(),
+        item.parent_backdrop_image_tag(),
+        "Backdrop",
+        Some(0),
+    )
+}
+
+fn primary_image_source(item: &TuItem) -> Option<PictureSource> {
+    tagged_source(
+        Some(item.primary_image_item_id().unwrap_or_else(|| item.id())),
+        item.primary_image_tag(),
+        "Primary",
+        None,
+    )
+}
+
+fn parent_primary_source(item: &TuItem) -> Option<PictureSource> {
+    tagged_source(
+        item.parent_primary_image_item_id(),
+        item.parent_primary_image_tag(),
+        "Primary",
+        None,
+    )
+}
+
+fn series_primary_source(item: &TuItem) -> Option<PictureSource> {
+    tagged_source(
+        item.series_id(),
+        item.series_primary_image_tag(),
+        "Primary",
+        None,
+    )
+}
+
+fn series_thumb_source(item: &TuItem) -> Option<PictureSource> {
+    tagged_source(
+        item.series_id(),
+        item.series_thumb_image_tag(),
+        "Thumb",
+        None,
+    )
+}
+
+fn album_primary_source(item: &TuItem) -> Option<PictureSource> {
+    tagged_source(
+        item.album_id(),
+        item.album_primary_image_tag(),
+        "Primary",
+        None,
+    )
+}
+
 pub trait TuItemOverlayPrelude {
-    fn get_image_type_and_index(&self, item: &TuItem) -> (&str, Option<u8>, String) {
-        if self.poster_type_ext() != PosterType::Poster
-            && let Some(imag_tags) = item.image_tags()
+    fn get_image_source(&self, item: &TuItem) -> Option<PictureSource> {
+        let card_shape = self.card_shape_ext(item);
+        let prefer_thumb = self.prefer_thumb_ext();
+
+        if prefer_thumb && let Some(source) = current_source(item, "Thumb", None) {
+            return Some(source);
+        }
+
+        if (self.prefer_banner_ext() || card_shape == CardShape::Banner)
+            && let Some(source) = current_source(item, "Banner", None)
         {
-            match self.poster_type_ext() {
-                PosterType::Banner => {
-                    if imag_tags.banner().is_some() {
-                        return ("Banner", None, item.id());
-                    } else if imag_tags.thumb().is_some() {
-                        return ("Thumb", None, item.id());
-                    } else if imag_tags.backdrop().is_some() {
-                        return ("Backdrop", Some(0), item.id());
-                    }
-                }
-                PosterType::Backdrop => {
-                    if imag_tags.backdrop().is_some() {
-                        return ("Backdrop", Some(0), item.id());
-                    } else if imag_tags.thumb().is_some() {
-                        return ("Thumb", None, item.id());
-                    }
-                }
-                _ => {}
-            }
+            return Some(source);
         }
-        match item.prefer_poster() {
-            // Continue Watching, use parent video poster if possible
-            PreferPoster::ParentVideo => {
-                if let Some(parent_thumb_item_id) = item.parent_thumb_item_id() {
-                    ("Thumb", None, parent_thumb_item_id)
-                } else if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id() {
-                    ("Backdrop", Some(0), parent_backdrop_item_id)
-                } else {
-                    ("Backdrop", Some(0), item.id())
-                }
-            }
-            // Latest, use parent primary image if possible, this is for latest episodes
-            PreferPoster::ParentPost
-                if let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id() =>
-            {
-                ("Primary", None, parent_backdrop_item_id)
-            }
-            _ => {
-                if let Some(img_tags) = item.primary_image_item_id() {
-                    // use primary image if possible
-                    ("Primary", None, img_tags)
-                } else if item.image_tags().is_none_or(|t| t.all_none())
-                    && let Some(parent_backdrop_item_id) = item.parent_backdrop_item_id()
-                {
-                    // fallback to parent backdrop if no image tags and parent backdrop exists, this
-                    // is for some season items that don't have image tags
-                    ("Primary", None, parent_backdrop_item_id)
-                } else {
-                    // finally fallback to primary image with item id
-                    ("Primary", None, item.id())
-                }
-            }
+
+        if prefer_thumb && let Some(source) = series_thumb_source(item) {
+            return Some(source);
         }
+
+        if prefer_thumb && let Some(source) = parent_thumb_source(item) {
+            return Some(source);
+        }
+
+        if prefer_thumb && let Some(source) = current_source(item, "Backdrop", Some(0)) {
+            return Some(source);
+        }
+
+        if prefer_thumb
+            && item.item_type() == EPISODE
+            && let Some(source) = parent_backdrop_source(item)
+        {
+            return Some(source);
+        }
+
+        if self.prefer_parent_poster_ext()
+            && !prefer_thumb
+            && item.item_type() == EPISODE
+            && let Some(source) =
+                parent_primary_source(item).or_else(|| series_primary_source(item))
+        {
+            return Some(source);
+        }
+
+        if (item.item_type() != EPISODE || item.imp().child_count.get() != Some(0))
+            && let Some(source) = current_source(item, "Primary", None)
+        {
+            return Some(source);
+        }
+
+        let skip_episode_parent_poster = item.item_type() == EPISODE && card_shape.is_wide();
+
+        if !skip_episode_parent_poster && let Some(source) = series_primary_source(item) {
+            return Some(source);
+        }
+
+        if let Some(source) = primary_image_source(item) {
+            return Some(source);
+        }
+
+        if !skip_episode_parent_poster && let Some(source) = parent_primary_source(item) {
+            return Some(source);
+        }
+
+        if let Some(source) = album_primary_source(item) {
+            return Some(source);
+        }
+
+        if item.item_type() == SEASON
+            && let Some(source) = current_source(item, "Thumb", None)
+        {
+            return Some(source);
+        }
+
+        current_source(item, "Backdrop", Some(0))
+            .or_else(|| current_source(item, "Thumb", None))
+            .or_else(|| series_thumb_source(item))
+            .or_else(|| parent_thumb_source(item))
+            .or_else(|| parent_backdrop_source(item))
     }
 
     fn overlay(&self) -> gtk::Overlay;
 
-    fn poster_type_ext(&self) -> PosterType;
+    fn card_shape_ext(&self, item: &TuItem) -> CardShape;
 
-    fn fallback_sources(&self, item: &TuItem, image_type: &str, id: &str) -> Vec<PictureSource> {
-        let mut fallbacks = Vec::new();
-        if let Some(image_tags) = item.image_tags() {
-            let mut candidates: Vec<(&str, Option<u8>)> = Vec::new();
-            match image_type {
-                "Primary" => {
-                    if image_tags.thumb().is_some() {
-                        candidates.push(("Thumb", None));
-                    }
-                    if image_tags.backdrop().is_some() {
-                        candidates.push(("Backdrop", Some(0)));
-                    }
-                    if image_tags.banner().is_some() {
-                        candidates.push(("Banner", None));
-                    }
-                }
-                "Thumb" => {
-                    if image_tags.primary().is_some() {
-                        candidates.push(("Primary", None));
-                    }
-                    if image_tags.backdrop().is_some() {
-                        candidates.push(("Backdrop", Some(0)));
-                    }
-                }
-                "Backdrop" => {
-                    if image_tags.thumb().is_some() {
-                        candidates.push(("Thumb", None));
-                    }
-                    if image_tags.primary().is_some() {
-                        candidates.push(("Primary", None));
-                    }
-                }
-                "Banner" => {
-                    if image_tags.thumb().is_some() {
-                        candidates.push(("Thumb", None));
-                    }
-                    if image_tags.backdrop().is_some() {
-                        candidates.push(("Backdrop", Some(0)));
-                    }
-                }
-                _ => {}
-            }
-            for (fallback_type, fallback_image_index) in candidates {
-                if fallback_type != image_type {
-                    fallbacks.push(PictureSource::item(id, fallback_type, fallback_image_index));
-                }
-            }
-        }
-        fallbacks
-    }
+    fn prefer_thumb_ext(&self) -> bool;
+
+    fn prefer_banner_ext(&self) -> bool;
+
+    fn prefer_parent_poster_ext(&self) -> bool;
 }
 
 pub trait TuItemOverlay: TuItemBasic + TuItemOverlayPrelude {
@@ -142,35 +279,26 @@ where
 {
     fn set_picture(&self) {
         let item = self.item();
-        let (source, fallbacks) =
-            if let Some(url) = item.image_url().filter(|url| !url.trim().is_empty()) {
-                (
-                    PictureSource::Url {
-                        image_type: "Primary".to_string(),
-                        url,
-                    },
-                    Vec::new(),
-                )
-            } else {
-                let (image_type, image_index, id) = self.get_image_type_and_index(&item);
-                let fallbacks = self.fallback_sources(&item, image_type, &id);
-                (
-                    PictureSource::Item {
-                        id,
-                        image_type: image_type.to_string(),
-                        image_index,
-                    },
-                    fallbacks,
-                )
-            };
         let overlay = self.overlay();
 
+        let Some(source) = item
+            .image_url()
+            .filter(|url| !url.trim().is_empty())
+            .map(|url| PictureSource::Url {
+                image_type: "Primary".to_string(),
+                url,
+            })
+            .or_else(|| self.get_image_source(&item))
+        else {
+            return;
+        };
+
         if let Some(picture_loader) = overlay.child().and_downcast::<PictureLoader>() {
-            picture_loader.reload_source_with_fallbacks(source, fallbacks);
+            picture_loader.reload_source(source);
             return;
         }
 
-        let picture_loader = PictureLoader::new_for_source_with_fallbacks(source, fallbacks);
+        let picture_loader = PictureLoader::new_for_source(source);
         picture_loader.add_css_class("inbox");
         overlay.set_child(Some(&picture_loader));
     }

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 
 use super::tu_item::{
+    CardOptions,
     CardShape,
     TuItemBasic,
     TuItemMenuPrelude,
@@ -61,7 +62,7 @@ pub mod imp {
         },
     };
 
-    use super::CardShape;
+    use super::CardOptions;
 
     pub struct BackdropNodeCache {
         node: gsk::RenderNode,
@@ -76,12 +77,7 @@ pub mod imp {
     pub struct TuListItem {
         #[property(get, set = Self::set_item)]
         pub item: RefCell<TuItem>,
-        #[property(get, set, builder(CardShape::default()))]
-        pub card_shape: Cell<CardShape>,
-        #[property(get, set, default = false)]
-        pub prefer_thumb: Cell<bool>,
-        #[property(get, set, default = false)]
-        pub prefer_parent_poster: Cell<bool>,
+        pub card_options: Cell<CardOptions>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
         pub content_box: TemplateChild<gtk::Box>,
@@ -372,16 +368,11 @@ impl TuItemOverlayPrelude for TuListItem {
         self.imp().overlay.get()
     }
 
-    fn card_shape_ext(&self, item: &TuItem) -> CardShape {
-        self.effective_card_shape(item)
-    }
-
-    fn prefer_thumb_ext(&self) -> bool {
-        self.prefer_thumb()
-    }
-
-    fn prefer_parent_poster_ext(&self) -> bool {
-        self.prefer_parent_poster()
+    fn card_options_ext(&self, item: &TuItem) -> CardOptions {
+        CardOptions {
+            shape: self.effective_card_shape(item),
+            ..self.card_options()
+        }
     }
 }
 
@@ -407,6 +398,14 @@ impl Default for TuListItem {
 impl TuListItem {
     pub fn new(item: TuItem) -> Self {
         Object::builder().property("item", item).build()
+    }
+
+    pub fn set_card_options(&self, options: CardOptions) {
+        self.imp().card_options.set(options);
+    }
+
+    fn card_options(&self) -> CardOptions {
+        self.imp().card_options.get()
     }
 
     fn update_title(&self) {
@@ -466,7 +465,7 @@ impl TuListItem {
     }
 
     fn effective_card_shape(&self, item: &TuItem) -> CardShape {
-        match self.card_shape() {
+        match self.card_options().shape {
             CardShape::Auto => match item.item_type().as_str() {
                 MOVIE | SERIES | BOX_SET | ACTOR | PERSON | DIRECTOR | WRITER | PRODUCER
                 | GUEST_STAR | SEASON => CardShape::Portrait,

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -81,8 +81,6 @@ pub mod imp {
         #[property(get, set, default = false)]
         pub prefer_thumb: Cell<bool>,
         #[property(get, set, default = false)]
-        pub prefer_banner: Cell<bool>,
-        #[property(get, set, default = false)]
         pub prefer_parent_poster: Cell<bool>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
@@ -380,10 +378,6 @@ impl TuItemOverlayPrelude for TuListItem {
 
     fn prefer_thumb_ext(&self) -> bool {
         self.prefer_thumb()
-    }
-
-    fn prefer_banner_ext(&self) -> bool {
-        self.prefer_banner()
     }
 
     fn prefer_parent_poster_ext(&self) -> bool {

--- a/src/ui/widgets/tu_list_item.rs
+++ b/src/ui/widgets/tu_list_item.rs
@@ -1,16 +1,7 @@
 use std::cell::RefCell;
 
-use adw::prelude::*;
-use glib::Object;
-use gtk::{
-    gio,
-    glib,
-    glib::subclass::types::ObjectSubclassIsExt,
-    template_callbacks,
-};
-use imp::PosterType;
-
 use super::tu_item::{
+    CardShape,
     TuItemBasic,
     TuItemMenuPrelude,
     TuItemOverlay,
@@ -20,11 +11,24 @@ use super::tu_item::{
 };
 use crate::ui::{
     SETTINGS,
-    provider::tu_item::TuItem,
+    provider::tu_item::{
+        TuItem,
+        item_type::*,
+    },
     widgets::utils::{
         TU_ITEM_BANNER_SIZE,
+        TU_ITEM_POST_SIZE,
+        TU_ITEM_SQUARE_SIZE,
         TU_ITEM_VIDEO_SIZE,
     },
+};
+use adw::prelude::*;
+use glib::Object;
+use gtk::{
+    gio,
+    glib,
+    glib::subclass::types::ObjectSubclassIsExt,
+    template_callbacks,
 };
 
 pub mod imp {
@@ -57,16 +61,7 @@ pub mod imp {
         },
     };
 
-    #[derive(Default, Hash, Eq, PartialEq, Clone, Copy, glib::Enum, Debug)]
-    #[repr(u32)]
-    #[enum_type(name = "PosterType")]
-    pub enum PosterType {
-        Backdrop,
-        Banner,
-        #[default]
-        Poster,
-        NoRequest,
-    }
+    use super::CardShape;
 
     pub struct BackdropNodeCache {
         node: gsk::RenderNode,
@@ -81,8 +76,14 @@ pub mod imp {
     pub struct TuListItem {
         #[property(get, set = Self::set_item)]
         pub item: RefCell<TuItem>,
-        #[property(get, set, builder(PosterType::default()))]
-        pub poster_type: Cell<PosterType>,
+        #[property(get, set, builder(CardShape::default()))]
+        pub card_shape: Cell<CardShape>,
+        #[property(get, set, default = false)]
+        pub prefer_thumb: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_banner: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_parent_poster: Cell<bool>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
         pub content_box: TemplateChild<gtk::Box>,
@@ -373,8 +374,20 @@ impl TuItemOverlayPrelude for TuListItem {
         self.imp().overlay.get()
     }
 
-    fn poster_type_ext(&self) -> PosterType {
-        self.poster_type()
+    fn card_shape_ext(&self, item: &TuItem) -> CardShape {
+        self.effective_card_shape(item)
+    }
+
+    fn prefer_thumb_ext(&self) -> bool {
+        self.prefer_thumb()
+    }
+
+    fn prefer_banner_ext(&self) -> bool {
+        self.prefer_banner()
+    }
+
+    fn prefer_parent_poster_ext(&self) -> bool {
+        self.prefer_parent_poster()
     }
 }
 
@@ -430,7 +443,7 @@ impl TuListItem {
 
         self.set_picture();
 
-        let (w, h) = self.size_hint();
+        let (w, h) = self.card_size(&item);
 
         imp.overlay.set_size_request(w, h);
 
@@ -458,11 +471,26 @@ impl TuListItem {
         }
     }
 
-    fn size_hint(&self) -> (i32, i32) {
-        match self.poster_type() {
-            PosterType::Banner => TU_ITEM_BANNER_SIZE,
-            PosterType::Backdrop => TU_ITEM_VIDEO_SIZE,
-            _ => self.item().size_hint(),
+    fn effective_card_shape(&self, item: &TuItem) -> CardShape {
+        match self.card_shape() {
+            CardShape::Auto => match item.item_type().as_str() {
+                MOVIE | SERIES | BOX_SET | ACTOR | PERSON | DIRECTOR | WRITER | PRODUCER
+                | GUEST_STAR | SEASON => CardShape::Portrait,
+                VIDEO | MUSIC_VIDEO | ADULT_VIDEO | TV_CHANNEL | COLLECTION_FOLDER | EPISODE
+                | USER_VIEW => CardShape::Backdrop,
+                _ => CardShape::Square,
+            },
+            card_shape => card_shape,
+        }
+    }
+
+    fn card_size(&self, item: &TuItem) -> (i32, i32) {
+        match self.effective_card_shape(item) {
+            CardShape::Auto => unreachable!(),
+            CardShape::Backdrop => TU_ITEM_VIDEO_SIZE,
+            CardShape::Banner => TU_ITEM_BANNER_SIZE,
+            CardShape::Portrait => TU_ITEM_POST_SIZE,
+            CardShape::Square => TU_ITEM_SQUARE_SIZE,
         }
     }
 

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -13,6 +13,7 @@ use imp::ViewGroup;
 
 use super::{
     tu_item::{
+        CardOptions,
         CardShape,
         TuItemBasic,
         TuItemMenuPrelude,
@@ -58,7 +59,10 @@ pub mod imp {
 
     use crate::ui::{
         provider::tu_item::TuItem,
-        widgets::tu_item::TuItemAction,
+        widgets::tu_item::{
+            CardOptions,
+            TuItemAction,
+        },
     };
 
     // Object holding the state
@@ -74,10 +78,7 @@ pub mod imp {
         pub inline_overview: TemplateChild<gtk::Label>,
         #[property(get, set = Self::set_view_group, builder(ViewGroup::default()))]
         pub view_group: Cell<ViewGroup>,
-        #[property(get, set, default = false)]
-        pub prefer_thumb: Cell<bool>,
-        #[property(get, set, default = false)]
-        pub prefer_parent_poster: Cell<bool>,
+        pub card_options: Cell<CardOptions>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
         pub listlabel: TemplateChild<gtk::Label>,
@@ -161,20 +162,16 @@ impl TuItemOverlayPrelude for TuOverviewItem {
         self.imp().overlay.get()
     }
 
-    fn card_shape_ext(&self, item: &TuItem) -> CardShape {
-        match self.view_group() {
+    fn card_options_ext(&self, item: &TuItem) -> CardOptions {
+        let shape = match self.view_group() {
             ViewGroup::EpisodesView => CardShape::Backdrop,
             ViewGroup::ListView if item.item_type() == EPISODE => CardShape::Backdrop,
             ViewGroup::ListView => CardShape::Portrait,
+        };
+        CardOptions {
+            shape,
+            ..self.card_options()
         }
-    }
-
-    fn prefer_thumb_ext(&self) -> bool {
-        self.prefer_thumb()
-    }
-
-    fn prefer_parent_poster_ext(&self) -> bool {
-        self.prefer_parent_poster()
     }
 }
 
@@ -201,6 +198,14 @@ impl TuOverviewItem {
 
     pub fn default() -> Self {
         Object::new()
+    }
+
+    pub fn set_card_options(&self, options: CardOptions) {
+        self.imp().card_options.set(options);
+    }
+
+    fn card_options(&self) -> CardOptions {
+        self.imp().card_options.get()
     }
 
     pub fn set_up(&self) {

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -77,8 +77,6 @@ pub mod imp {
         #[property(get, set, default = false)]
         pub prefer_thumb: Cell<bool>,
         #[property(get, set, default = false)]
-        pub prefer_banner: Cell<bool>,
-        #[property(get, set, default = false)]
         pub prefer_parent_poster: Cell<bool>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
@@ -173,10 +171,6 @@ impl TuItemOverlayPrelude for TuOverviewItem {
 
     fn prefer_thumb_ext(&self) -> bool {
         self.prefer_thumb()
-    }
-
-    fn prefer_banner_ext(&self) -> bool {
-        self.prefer_banner()
     }
 
     fn prefer_parent_poster_ext(&self) -> bool {

--- a/src/ui/widgets/tu_overview_item.rs
+++ b/src/ui/widgets/tu_overview_item.rs
@@ -13,6 +13,7 @@ use imp::ViewGroup;
 
 use super::{
     tu_item::{
+        CardShape,
         TuItemBasic,
         TuItemMenuPrelude,
         TuItemOverlay,
@@ -20,14 +21,16 @@ use super::{
         TuItemProgressbarAnimation,
         TuItemProgressbarAnimationPrelude,
     },
-    tu_list_item::imp::PosterType,
     utils::{
         TU_ITEM_POST_SIZE,
         TU_ITEM_VIDEO_SIZE,
         run_time_ticks_to_label,
     },
 };
-use crate::ui::provider::tu_item::TuItem;
+use crate::ui::provider::tu_item::{
+    TuItem,
+    item_type::EPISODE,
+};
 
 pub mod imp {
     use std::cell::{
@@ -71,6 +74,12 @@ pub mod imp {
         pub inline_overview: TemplateChild<gtk::Label>,
         #[property(get, set = Self::set_view_group, builder(ViewGroup::default()))]
         pub view_group: Cell<ViewGroup>,
+        #[property(get, set, default = false)]
+        pub prefer_thumb: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_banner: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_parent_poster: Cell<bool>,
         pub popover: RefCell<Option<PopoverMenu>>,
         #[template_child]
         pub listlabel: TemplateChild<gtk::Label>,
@@ -154,11 +163,24 @@ impl TuItemOverlayPrelude for TuOverviewItem {
         self.imp().overlay.get()
     }
 
-    fn poster_type_ext(&self) -> PosterType {
+    fn card_shape_ext(&self, item: &TuItem) -> CardShape {
         match self.view_group() {
-            ViewGroup::EpisodesView => PosterType::NoRequest,
-            ViewGroup::ListView => PosterType::Poster,
+            ViewGroup::EpisodesView => CardShape::Backdrop,
+            ViewGroup::ListView if item.item_type() == EPISODE => CardShape::Backdrop,
+            ViewGroup::ListView => CardShape::Portrait,
         }
+    }
+
+    fn prefer_thumb_ext(&self) -> bool {
+        self.prefer_thumb()
+    }
+
+    fn prefer_banner_ext(&self) -> bool {
+        self.prefer_banner()
+    }
+
+    fn prefer_parent_poster_ext(&self) -> bool {
+        self.prefer_parent_poster()
     }
 }
 

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -22,23 +22,18 @@ use gtk::{
 };
 
 use super::{
-    hortu_scrolled::{
-        UnifySize,
-        resolve_prefer_size,
-    },
     single_grid::imp::ViewType,
-    tu_list_item::imp::PosterType,
+    tu_item::{
+        CardOptions,
+        CardShape,
+    },
     tu_overview_item::imp::ViewGroup,
     utils::TuItemBuildExt,
 };
 use crate::{
     client::structs::SimpleListItem,
     ui::provider::{
-        tu_item::{
-            PreferPoster,
-            PreferSize,
-            TuItem,
-        },
+        tu_item::TuItem,
         tu_object::TuObject,
     },
 };
@@ -50,10 +45,7 @@ pub(crate) mod imp {
         atomic::AtomicBool,
     };
 
-    use std::cell::{
-        Cell,
-        RefCell,
-    };
+    use std::cell::Cell;
 
     use glib::subclass::InitializingObject;
     use gtk::glib::Properties;
@@ -94,13 +86,17 @@ pub(crate) mod imp {
         pub selection: NoSelectionWrap,
         pub lock: Arc<AtomicBool>,
 
-        #[property(get, set, builder(UnifySize::default()))]
-        pub unify_size: RefCell<UnifySize>,
-        #[property(get, set, builder(PreferPoster::default()))]
-        pub prefer_poster: RefCell<PreferPoster>,
+        #[property(get, set, builder(CardShape::default()))]
+        pub card_shape: Cell<CardShape>,
+        #[property(get, set, default = false)]
+        pub prefer_thumb: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_banner: Cell<bool>,
+        #[property(get, set, default = false)]
+        pub prefer_parent_poster: Cell<bool>,
         #[property(get, set, default = false)]
         pub is_resume: Cell<bool>,
-        pub prefer_size_cache: RefCell<PreferSize>,
+        pub resolved_card_shape: Cell<CardShape>,
     }
 
     #[glib::object_subclass]
@@ -154,15 +150,11 @@ impl TuViewScrolled {
             return;
         };
 
-        let prefer_size = if C {
-            let size = resolve_prefer_size(self.unify_size(), &items);
-            self.imp().prefer_size_cache.replace(size);
-            size
-        } else {
-            *self.imp().prefer_size_cache.borrow()
-        };
+        if C {
+            imp.resolved_card_shape.set(CardShape::Auto.resolve(&items));
+            self.set_grid_factory();
+        }
 
-        let prefer_poster = self.prefer_poster();
         let is_resume = self.is_resume();
 
         let items = items
@@ -170,8 +162,6 @@ impl TuViewScrolled {
             .map(|item| {
                 let tu_item = TuItem::from_simple(item);
                 tu_item.set_is_resume(is_resume);
-                tu_item.set_prefer_poster(prefer_poster);
-                tu_item.set_prefer_size(prefer_size);
                 TuObject::new(tu_item)
             })
             .collect::<Vec<_>>();
@@ -190,16 +180,54 @@ impl TuViewScrolled {
             ViewType::GridView => {
                 imp.scrolled_window.set_child(Some(&imp.grid.get()));
                 imp.grid
-                    .set_factory(Some(factory.tu_item(PosterType::default())));
+                    .set_factory(Some(factory.tu_item(self.card_options())));
                 imp.grid.set_model(Some(&imp.selection.0));
             }
             ViewType::ListView => {
                 imp.scrolled_window.set_child(Some(&imp.list.get()));
-                imp.list
-                    .set_factory(Some(factory.tu_overview_item(ViewGroup::ListView)));
+                imp.list.set_factory(Some(
+                    factory.tu_overview_item(ViewGroup::ListView, self.card_options()),
+                ));
                 imp.list.set_model(Some(&imp.selection.0));
             }
         }
+    }
+
+    fn set_grid_factory(&self) {
+        let factory = SignalListItemFactory::new();
+        self.imp()
+            .grid
+            .set_factory(Some(factory.tu_item(self.card_options())));
+    }
+
+    fn effective_card_shape(&self) -> CardShape {
+        match self.card_shape() {
+            CardShape::Auto => self.imp().resolved_card_shape.get(),
+            card_shape => card_shape,
+        }
+    }
+
+    fn card_options(&self) -> CardOptions {
+        CardOptions {
+            shape: self.effective_card_shape(),
+            prefer_thumb: self.prefer_thumb(),
+            prefer_banner: self.prefer_banner(),
+            prefer_parent_poster: self.prefer_parent_poster(),
+        }
+    }
+
+    pub fn apply_card_shape(&self, card_shape: CardShape) {
+        self.set_card_shape(card_shape);
+        self.set_grid_factory();
+    }
+
+    pub fn apply_image_options(
+        &self, card_shape: CardShape, prefer_thumb: bool, prefer_banner: bool,
+    ) {
+        self.set_card_shape(card_shape);
+        self.set_prefer_thumb(prefer_thumb);
+        self.set_prefer_banner(prefer_banner);
+        self.set_grid_factory();
     }
 
     #[template_callback]

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -213,14 +213,10 @@ impl TuViewScrolled {
         }
     }
 
-    pub fn apply_card_shape(&self, card_shape: CardShape) {
-        self.set_card_shape(card_shape);
-        self.set_grid_factory();
-    }
-
-    pub fn apply_image_options(&self, card_shape: CardShape, prefer_thumb: bool) {
-        self.set_card_shape(card_shape);
-        self.set_prefer_thumb(prefer_thumb);
+    pub fn apply_card_options(&self, options: CardOptions) {
+        self.set_card_shape(options.shape);
+        self.set_prefer_thumb(options.prefer_thumb);
+        self.set_prefer_parent_poster(options.prefer_parent_poster);
         self.set_grid_factory();
     }
 

--- a/src/ui/widgets/tuview_scrolled.rs
+++ b/src/ui/widgets/tuview_scrolled.rs
@@ -91,8 +91,6 @@ pub(crate) mod imp {
         #[property(get, set, default = false)]
         pub prefer_thumb: Cell<bool>,
         #[property(get, set, default = false)]
-        pub prefer_banner: Cell<bool>,
-        #[property(get, set, default = false)]
         pub prefer_parent_poster: Cell<bool>,
         #[property(get, set, default = false)]
         pub is_resume: Cell<bool>,
@@ -211,7 +209,6 @@ impl TuViewScrolled {
         CardOptions {
             shape: self.effective_card_shape(),
             prefer_thumb: self.prefer_thumb(),
-            prefer_banner: self.prefer_banner(),
             prefer_parent_poster: self.prefer_parent_poster(),
         }
     }
@@ -221,12 +218,9 @@ impl TuViewScrolled {
         self.set_grid_factory();
     }
 
-    pub fn apply_image_options(
-        &self, card_shape: CardShape, prefer_thumb: bool, prefer_banner: bool,
-    ) {
+    pub fn apply_image_options(&self, card_shape: CardShape, prefer_thumb: bool) {
         self.set_card_shape(card_shape);
         self.set_prefer_thumb(prefer_thumb);
-        self.set_prefer_banner(prefer_banner);
         self.set_grid_factory();
     }
 

--- a/src/ui/widgets/utils.rs
+++ b/src/ui/widgets/utils.rs
@@ -7,10 +7,8 @@ use super::{
     filter_panel::FilterPanelDialog,
     identify::IdentifyDialog,
     image_dialog::ImageDialog,
-    tu_list_item::{
-        TuListItem,
-        imp::PosterType,
-    },
+    tu_item::CardOptions,
+    tu_list_item::TuListItem,
     tu_overview_item::{
         TuOverviewItem,
         imp::ViewGroup,
@@ -20,15 +18,18 @@ use super::{
 use crate::ui::provider::tu_object::TuObject;
 
 pub trait TuItemBuildExt {
-    fn tu_item(&self, poster: PosterType) -> &Self;
-    fn tu_overview_item(&self, view_group: ViewGroup) -> &Self;
+    fn tu_item(&self, options: CardOptions) -> &Self;
+    fn tu_overview_item(&self, view_group: ViewGroup, options: CardOptions) -> &Self;
 }
 
 impl TuItemBuildExt for SignalListItemFactory {
-    fn tu_item(&self, poster: PosterType) -> &Self {
+    fn tu_item(&self, options: CardOptions) -> &Self {
         self.connect_setup(move |_, item| {
             let tu_item = TuListItem::default();
-            tu_item.set_poster_type(poster);
+            tu_item.set_card_shape(options.shape);
+            tu_item.set_prefer_thumb(options.prefer_thumb);
+            tu_item.set_prefer_banner(options.prefer_banner);
+            tu_item.set_prefer_parent_poster(options.prefer_parent_poster);
 
             let list_item = item
                 .downcast_ref::<gtk::ListItem>()
@@ -53,10 +54,13 @@ impl TuItemBuildExt for SignalListItemFactory {
         self
     }
 
-    fn tu_overview_item(&self, view_group: ViewGroup) -> &Self {
+    fn tu_overview_item(&self, view_group: ViewGroup, options: CardOptions) -> &Self {
         self.connect_setup(move |_, item| {
             let tu_item = TuOverviewItem::default();
             tu_item.set_view_group(view_group);
+            tu_item.set_prefer_thumb(options.prefer_thumb);
+            tu_item.set_prefer_banner(options.prefer_banner);
+            tu_item.set_prefer_parent_poster(options.prefer_parent_poster);
             let list_item = item
                 .downcast_ref::<gtk::ListItem>()
                 .expect("Needs to be ListItem");

--- a/src/ui/widgets/utils.rs
+++ b/src/ui/widgets/utils.rs
@@ -26,9 +26,7 @@ impl TuItemBuildExt for SignalListItemFactory {
     fn tu_item(&self, options: CardOptions) -> &Self {
         self.connect_setup(move |_, item| {
             let tu_item = TuListItem::default();
-            tu_item.set_card_shape(options.shape);
-            tu_item.set_prefer_thumb(options.prefer_thumb);
-            tu_item.set_prefer_parent_poster(options.prefer_parent_poster);
+            tu_item.set_card_options(options);
 
             let list_item = item
                 .downcast_ref::<gtk::ListItem>()
@@ -57,8 +55,7 @@ impl TuItemBuildExt for SignalListItemFactory {
         self.connect_setup(move |_, item| {
             let tu_item = TuOverviewItem::default();
             tu_item.set_view_group(view_group);
-            tu_item.set_prefer_thumb(options.prefer_thumb);
-            tu_item.set_prefer_parent_poster(options.prefer_parent_poster);
+            tu_item.set_card_options(options);
             let list_item = item
                 .downcast_ref::<gtk::ListItem>()
                 .expect("Needs to be ListItem");

--- a/src/ui/widgets/utils.rs
+++ b/src/ui/widgets/utils.rs
@@ -28,7 +28,6 @@ impl TuItemBuildExt for SignalListItemFactory {
             let tu_item = TuListItem::default();
             tu_item.set_card_shape(options.shape);
             tu_item.set_prefer_thumb(options.prefer_thumb);
-            tu_item.set_prefer_banner(options.prefer_banner);
             tu_item.set_prefer_parent_poster(options.prefer_parent_poster);
 
             let list_item = item
@@ -59,7 +58,6 @@ impl TuItemBuildExt for SignalListItemFactory {
             let tu_item = TuOverviewItem::default();
             tu_item.set_view_group(view_group);
             tu_item.set_prefer_thumb(options.prefer_thumb);
-            tu_item.set_prefer_banner(options.prefer_banner);
             tu_item.set_prefer_parent_poster(options.prefer_parent_poster);
             let list_item = item
                 .downcast_ref::<gtk::ListItem>()

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -9,8 +9,8 @@ use gtk::{
 };
 mod imp {
     use std::cell::{
+        Cell,
         OnceCell,
-        RefCell,
     };
 
     use adw::subclass::application_window::AdwApplicationWindowImpl;
@@ -107,11 +107,11 @@ mod imp {
         pub progress_bar_animation: OnceCell<adw::TimedAnimation>,
         pub progress_bar_fade_animation: OnceCell<adw::TimedAnimation>,
 
-        pub last_content_list_selection: RefCell<Option<i32>>,
+        pub last_content_list_selection: Cell<Option<i32>>,
 
         pub mpv_playlist_selection: gtk::SingleSelection,
 
-        pub suspend_cookie: RefCell<Option<u32>>,
+        pub suspend_cookie: Cell<Option<u32>>,
 
         #[template_child]
         pub sidebar_breakpoint: TemplateChild<adw::Breakpoint>,
@@ -853,7 +853,7 @@ impl Window {
         }
 
         let pos = item.section_index() as i32;
-        let last_pos = *imp.last_content_list_selection.borrow();
+        let last_pos = imp.last_content_list_selection.get();
         if last_pos == Some(pos) {
             self.update_view(pos);
             return;

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -165,7 +165,8 @@ mod imp {
             self.mpv_playlist
                 .set_model(Some(&self.mpv_playlist_selection));
             self.mpv_playlist.set_factory(Some(
-                gtk::SignalListItemFactory::new().tu_overview_item(ViewGroup::EpisodesView),
+                gtk::SignalListItemFactory::new()
+                    .tu_overview_item(ViewGroup::EpisodesView, Default::default()),
             ));
             self.mpv_control_sidebar
                 .set_player(Some(&self.mpvnav.imp().video.get()));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -236,7 +236,9 @@ where
     Ok(CacheWrite::Written)
 }
 
-pub async fn get_image_with_cache(id: String, img_type: String, tag: Option<u8>) -> Result<String> {
+pub async fn get_image_with_cache(
+    id: String, img_type: String, tag: Option<String>,
+) -> Result<String> {
     runtime()
         .spawn(async move { JELLYFIN_CLIENT.get_image(&id, &img_type, tag).await })
         .await?

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -237,9 +237,9 @@ where
 }
 
 pub async fn get_image_with_cache(
-    id: String, img_type: String, tag: Option<String>,
+    id: String, img_type: String, image_index: Option<u8>,
 ) -> Result<String> {
     runtime()
-        .spawn(async move { JELLYFIN_CLIENT.get_image(&id, &img_type, tag).await })
+        .spawn(async move { JELLYFIN_CLIENT.get_image(&id, &img_type, image_index).await })
         .await?
 }


### PR DESCRIPTION
(**Not fully ready for review**)

This PR mainly includes:

1. Aligning cover image fallback and size selection logic with Jellyfin Web as closely as possible.
2. Clarifying the distinction between `image_tag` and `image_index`, and storing `image_tag` separately (currently unused).
3. Replacing `RefCell` with `Cell` where the inner type is clearly `Copy`.

`image_tag` is now stored but is not yet wired into image caching, requests, or storage. A follow-up PR will cover that work.