### PR TITLE
feat: add compatibility with Jellyfin 12.0

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -17,14 +17,21 @@ mod imp {
             RGBA,
         },
     };
+    use once_cell::sync::Lazy;
     use url::Url;
 
-    use crate::ui::{
-        SETTINGS,
-        match_audio_channels,
-        match_hwdec_interop,
-        match_sub_border_style,
-        match_video_upscale,
+    use crate::{
+        client::jellyfin_client::{
+            DEVICE_ID,
+            JELLYFIN_CLIENT,
+        },
+        ui::{
+            SETTINGS,
+            match_audio_channels,
+            match_hwdec_interop,
+            match_sub_border_style,
+            match_video_upscale,
+        },
     };
 
     use super::*;
@@ -89,6 +96,11 @@ mod imp {
 
         fn startup(&self) {
             self.parent_startup();
+
+            // Eagerly initialize `DEVICE_ID` and `JELLYFIN_CLIENT` because they depend on `SETTINGS`, which can only be accessed from the main thread.
+            // If either is first accessed inside `spawn_tokio`, the application will panic.
+            Lazy::force(&DEVICE_ID);
+            Lazy::force(&JELLYFIN_CLIENT);
 
             let window = crate::Window::new(&self.obj());
             window.load_window_state();

--- a/src/client/account.rs
+++ b/src/client/account.rs
@@ -6,7 +6,6 @@ use serde::{
 use crate::ui::provider::descriptor::VecSerialize;
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
-
 pub enum ServerType {
     #[default]
     Emby = 0,

--- a/src/client/account.rs
+++ b/src/client/account.rs
@@ -1,7 +1,13 @@
+use anyhow::{
+    Context,
+    Result,
+    anyhow,
+};
 use serde::{
     Deserialize,
     Serialize,
 };
+use url::Url;
 
 use crate::ui::provider::descriptor::VecSerialize;
 
@@ -35,6 +41,20 @@ pub struct Account {
     pub user_id: String,
     pub access_token: String,
     pub server_type: Option<ServerType>,
+}
+
+impl Account {
+    pub fn url(&self) -> Result<Url> {
+        build_url(&self.server, &self.port)
+    }
+}
+
+pub(super) fn build_url(url_str: &str, port: &str) -> Result<Url> {
+    let mut url = Url::parse(url_str)?;
+    let port = port.parse::<u16>().context("Invalid server port")?;
+    url.set_port(Some(port))
+        .map_err(|_| anyhow!("Failed to set port"))?;
+    Ok(url)
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -36,7 +36,10 @@ use reqwest::{
     Method,
     RequestBuilder,
     Response,
-    header::HeaderValue,
+    header::{
+        HeaderMap,
+        HeaderValue,
+    },
 };
 use serde::{
     Deserialize,
@@ -123,30 +126,15 @@ pub enum BackType {
 #[derive(Clone)]
 pub struct Session {
     pub account: Account,
-    pub url: Option<Url>,
-    pub headers: reqwest::header::HeaderMap,
+    pub url_headers: Option<(Url, HeaderMap)>,
     pub server_name_hash: String,
 }
 
 impl Session {
     fn empty() -> Self {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("Accept-Encoding", HeaderValue::from_static("gzip"));
-        headers.insert(
-            "X-Emby-authorization",
-            HeaderValue::from_str(&generate_jellyfin_authorization(
-                "",
-                CLIENT_ID,
-                &DEVICE_NAME,
-                &DEVICE_ID,
-                version(),
-            ))
-            .unwrap(),
-        );
         Self {
             account: Account::default(),
-            url: None,
-            headers,
+            url_headers: None,
             server_name_hash: String::new(),
         }
     }
@@ -165,12 +153,52 @@ struct NextUpDateKey {
     item_id: String,
 }
 
-fn generate_jellyfin_authorization(
-    user_id: &str, client: &str, device: &str, device_id: &str, version: &str,
-) -> String {
-    format!(
-        "Emby UserId={user_id},Client={client},Device={device},DeviceId={device_id},Version={version}"
-    )
+fn build_headers(
+    user_id: Option<&str>, token: Option<&str>, server_type: ServerType,
+) -> Result<HeaderMap> {
+    let mut authorization = format!(
+        "Client={},Device={},DeviceId={},Version={}",
+        CLIENT_ID,
+        *DEVICE_NAME,
+        *DEVICE_ID,
+        version()
+    );
+    if let Some(user_id) = user_id {
+        authorization.push_str(&format!(",UserId={}", user_id));
+    }
+    let mut headers = HeaderMap::new();
+    match server_type {
+        ServerType::Emby => {
+            headers.insert(
+                "X-Emby-authorization",
+                HeaderValue::from_str(&format!("Emby {authorization}"))?,
+            );
+            if let Some(token) = token {
+                headers.insert("X-Emby-Token", HeaderValue::from_str(token)?);
+            }
+        }
+        ServerType::Jellyfin => {
+            if let Some(token) = token {
+                authorization.push_str(&format!(",Token={token}"));
+            }
+            headers.insert(
+                "Authorization",
+                HeaderValue::from_str(&format!("MediaBrowser {authorization}"))?,
+            );
+        }
+    }
+    Ok(headers)
+}
+
+fn build_base_url(url_str: &str, port: &str, server_type: ServerType) -> Result<Url> {
+    let mut url = Url::parse(url_str)?;
+    let port = port.parse::<u16>().context("Invalid server port")?;
+    url.set_port(Some(port))
+        .map_err(|_| anyhow!("Failed to set port"))?;
+    match server_type {
+        ServerType::Emby => Ok(url.join("emby/")?),
+        ServerType::Jellyfin => Ok(url),
+    }
 }
 
 fn generate_hash(s: &str) -> String {
@@ -208,34 +236,16 @@ impl JellyfinClient {
     }
 
     pub async fn init(&self, account: &Account) -> Result<(), Box<dyn std::error::Error>> {
-        let url = {
-            let mut url = Url::parse(&account.server)?;
-            url.set_port(Some(account.port.parse::<u16>().unwrap_or_default()))
-                .map_err(|_| anyhow!("Failed to set port"))?;
-            url.join("emby/")?
-        };
-
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("Accept-Encoding", HeaderValue::from_static("gzip"));
-        headers.insert(
-            "X-Emby-Token",
-            HeaderValue::from_str(&account.access_token)?,
-        );
-        headers.insert(
-            "X-Emby-authorization",
-            HeaderValue::from_str(&generate_jellyfin_authorization(
-                &account.user_id,
-                CLIENT_ID,
-                &DEVICE_NAME,
-                &DEVICE_ID,
-                version(),
-            ))?,
-        );
-
+        let server_type = account.server_type.unwrap_or_default();
+        let headers = build_headers(
+            Some(&account.user_id),
+            Some(&account.access_token),
+            server_type,
+        )?;
+        let url = build_base_url(&account.server, &account.port, server_type)?;
         self.session.store(Arc::new(Session {
             account: account.clone(),
-            url: Some(url),
-            headers,
+            url_headers: Some((url, headers)),
             server_name_hash: generate_hash(&account.servername),
         }));
         self.next_up_date_cache.invalidate_all();
@@ -254,29 +264,6 @@ impl JellyfinClient {
         Ok(())
     }
 
-    pub fn header_change_url(&self, url_str: &str, port: &str) -> Result<()> {
-        let mut url = Url::parse(url_str)?;
-        url.set_port(Some(port.parse::<u16>().unwrap_or_default()))
-            .map_err(|_| anyhow!("Failed to set port"))?;
-        let url = url.join("emby/")?;
-        self.session.rcu(|current| {
-            let mut session = (**current).clone();
-            session.url = Some(url.clone());
-            Arc::new(session)
-        });
-        Ok(())
-    }
-
-    pub fn header_change_token(&self, token: &str) -> Result<()> {
-        let token = HeaderValue::from_str(token)?;
-        self.session.rcu(|current| {
-            let mut session = (**current).clone();
-            session.headers.insert("X-Emby-Token", token.clone());
-            Arc::new(session)
-        });
-        Ok(())
-    }
-
     pub async fn request<T>(&self, path: &str, params: &[(&str, &str)]) -> Result<T>
     where
         T: for<'de> Deserialize<'de> + Send + 'static,
@@ -288,9 +275,9 @@ impl JellyfinClient {
             Ok(r) => r,
             Err(e) => {
                 let Some(status) = e.status() else {
-                    return Err(anyhow!("Failed to get status"));
+                    bail!("Failed to get status");
                 };
-                return Err(anyhow!("{}", status));
+                bail!("{}", status);
             }
         };
 
@@ -353,27 +340,37 @@ impl JellyfinClient {
         &self, method: Method, path: &str, params: &[(&str, &str)],
     ) -> Result<RequestBuilder> {
         let s = self.session();
-        let url = s.url.as_ref().context("URL is not set")?.join(path)?;
+        let (url, headers) = s.url_headers.as_ref().context("URL is not set")?;
+        Ok(self
+            .client
+            .request(method, url.join(path)?)
+            .query(params)
+            .headers(headers.clone()))
+    }
+
+    fn prepare_unauthenticated_request(
+        &self, method: Method, server: &str, port: &str, server_type: ServerType, path: &str,
+    ) -> Result<RequestBuilder> {
+        let url = build_base_url(server, port, server_type)?.join(path)?;
         Ok(self
             .client
             .request(method, url)
-            .query(params)
-            .headers(s.headers.clone()))
+            .headers(build_headers(None, None, server_type)?))
     }
 
     fn prepare_request_headers(
         &self, method: Method, path: &str, params: &[(&str, &str)], content_type: &str,
     ) -> Result<RequestBuilder> {
         let s = self.session();
-        let url = s.url.as_ref().context("URL is not set")?.join(path)?;
-        let mut headers = s.headers.clone();
+        let (url, headers) = s.url_headers.as_ref().context("URL is not set")?;
+        let mut headers = headers.clone();
         headers.insert(
             reqwest::header::CONTENT_TYPE,
             HeaderValue::from_str(content_type)?,
         );
         Ok(self
             .client
-            .request(method, url)
+            .request(method, url.join(path)?)
             .query(params)
             .headers(headers))
     }
@@ -393,28 +390,51 @@ impl JellyfinClient {
         Ok(res)
     }
 
-    pub async fn login(&self, username: &str, password: &str) -> Result<LoginResponse> {
+    pub async fn login(
+        &self, server: &str, port: &str, server_type: ServerType, username: &str, password: &str,
+    ) -> Result<LoginResponse> {
         let body = json!({
             "Username": username,
             "Pw": password
         });
-        self.post_json("Users/authenticatebyname", &[], body).await
+        let request = self
+            .prepare_unauthenticated_request(
+                Method::POST,
+                server,
+                port,
+                server_type,
+                "Users/AuthenticateByName",
+            )?
+            .json(&body);
+        Ok(self
+            .send_request(request)
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
     }
 
     pub async fn get_item_stream_url(
         &self, container: &str, item_id: &str, media_source_id: &str,
     ) -> Result<String> {
         let s = self.session();
-        let Some(url) = s.url.as_ref() else {
-            bail!("URL is not set");
-        };
+        let (url, _) = s.url_headers.as_ref().context("URL is not set")?;
         let path = format!("Videos/{}/stream.{}", item_id, container);
         let mut url = url.join(&path).context("Failed to build item stream URL")?;
-        url.query_pairs_mut()
+        let mut query_pairs = url.query_pairs_mut();
+        query_pairs
             .append_pair("Static", "true")
             .append_pair("deviceId", &DEVICE_ID)
-            .append_pair("api_key", &s.account.access_token)
             .append_pair("MediaSourceId", media_source_id);
+        match self.server_type() {
+            ServerType::Emby => {
+                query_pairs.append_pair("api_key", &s.account.access_token);
+            }
+            ServerType::Jellyfin => {
+                query_pairs.append_pair("ApiKey", &s.account.access_token);
+            }
+        }
+        drop(query_pairs);
         Ok(url.to_string())
     }
 
@@ -867,7 +887,7 @@ impl JellyfinClient {
 
     pub async fn get_streaming_url(&self, path: &str) -> String {
         let s = self.session();
-        let url = s.url.as_ref().expect("URL not set");
+        let (url, _) = s.url_headers.as_ref().expect("URL not set");
         url.join(path.trim_start_matches('/')).unwrap().to_string()
     }
 
@@ -1331,8 +1351,32 @@ impl JellyfinClient {
 
     pub async fn get_song_streaming_uri(&self, id: &str) -> String {
         let s = self.session();
-        s.url.as_ref().expect("URL not set").join(&format!("Audio/{}/universal?UserId={}&DeviceId={}&MaxStreamingBitrate=4000000&Container=opus,mp3|mp3,mp2,mp3|mp2,m4a|aac,mp4|aac,flac,webma,webm,wav|PCM_S16LE,wav|PCM_S24LE,ogg&TranscodingContainer=aac&TranscodingProtocol=hls&AudioCodec=aac&api_key={}&PlaySessionId=1715006733496&StartTimeTicks=0&EnableRedirection=true&EnableRemoteMedia=false",
-        id, s.account.user_id, *DEVICE_ID, s.account.access_token, )).unwrap().to_string()
+        let (url, _) = s.url_headers.as_ref().expect("URL not set");
+        let path = format!("Audio/{}/universal", id);
+        let mut url = url.join(&path).unwrap();
+        let mut query_pairs = url.query_pairs_mut();
+        query_pairs
+            .append_pair("UserId", &s.account.user_id)
+            .append_pair("DeviceId", &DEVICE_ID)
+            .append_pair("MaxStreamingBitrate", "4000000")
+            .append_pair("Container", "opus,mp3|mp3,mp2,mp3|mp2,m4a|aac,mp4|aac,flac,webma,webm,wav|PCM_S16LE,wav|PCM_S24LE,ogg")
+            .append_pair("TranscodingContainer", "aac")
+            .append_pair("TranscodingProtocol", "hls")
+            .append_pair("AudioCodec", "aac")
+            .append_pair("PlaySessionId", "1715006733496")
+            .append_pair("StartTimeTicks", "0")
+            .append_pair("EnableRedirection", "true")
+            .append_pair("EnableRemoteMedia", "false");
+        match self.server_type() {
+            ServerType::Emby => {
+                query_pairs.append_pair("api_key", &s.account.access_token);
+            }
+            ServerType::Jellyfin => {
+                query_pairs.append_pair("ApiKey", &s.account.access_token);
+            }
+        }
+        drop(query_pairs);
+        url.to_string()
     }
 
     pub async fn get_additional(&self, id: &str) -> Result<List> {
@@ -1375,8 +1419,22 @@ impl JellyfinClient {
         self.request("System/Info", &[]).await
     }
 
-    pub async fn get_server_info_public(&self) -> Result<PublicServerInfo> {
-        self.request("System/Info/Public", &[]).await
+    pub async fn get_server_info_public(
+        &self, server: &str, port: &str, server_type: ServerType,
+    ) -> Result<PublicServerInfo> {
+        let request = self.prepare_unauthenticated_request(
+            Method::GET,
+            server,
+            port,
+            server_type,
+            "System/Info/Public",
+        )?;
+        Ok(self
+            .send_request(request)
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
     }
 
     pub async fn shut_down(&self) -> Result<Response> {
@@ -1411,7 +1469,8 @@ impl JellyfinClient {
     ) -> String {
         let s = self.session();
         let path = format!("Items/{id}/Images/{image_type}/");
-        let url = s.url.as_ref().expect("URL not set").join(&path).unwrap();
+        let (url, _) = s.url_headers.as_ref().expect("URL not set");
+        let url = url.join(&path).unwrap();
         match image_index {
             Some(index) => url.join(&index.to_string()).unwrap().to_string(),
             None => url.to_string(),
@@ -1504,8 +1563,15 @@ mod tests {
 
     #[tokio::test]
     async fn search() {
-        let _ = JELLYFIN_CLIENT.header_change_url("https://example.com", "443");
-        let result = JELLYFIN_CLIENT.login("test", "test").await;
+        let result = JELLYFIN_CLIENT
+            .login(
+                "https://example.com",
+                "443",
+                ServerType::Jellyfin,
+                "test",
+                "test",
+            )
+            .await;
         match result {
             Ok(response) => {
                 println!("{}", response.access_token);
@@ -1553,8 +1619,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_upload_image() {
-        let _ = JELLYFIN_CLIENT.header_change_url("http://127.0.0.1", "8096");
-        let result = JELLYFIN_CLIENT.login("inaha", "").await;
+        let result = JELLYFIN_CLIENT
+            .login(
+                "http://127.0.0.1",
+                "8096",
+                ServerType::Jellyfin,
+                "inaha",
+                "",
+            )
+            .await;
         match result {
             Ok(response) => {
                 println!("{}", response.access_token);

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -339,7 +339,7 @@ impl JellyfinClient {
         &self, method: Method, path: &str, params: &[(&str, &str)],
     ) -> Result<RequestBuilder> {
         let s = self.session();
-        let (url, headers) = s.url_headers.as_ref().context("URL is not set")?;
+        let (url, headers) = s.url_headers.as_ref().context("Client not initialized")?;
         Ok(self
             .client
             .request(method, url.join(path)?)
@@ -361,7 +361,7 @@ impl JellyfinClient {
         &self, method: Method, path: &str, params: &[(&str, &str)], content_type: &str,
     ) -> Result<RequestBuilder> {
         let s = self.session();
-        let (url, headers) = s.url_headers.as_ref().context("URL is not set")?;
+        let (url, headers) = s.url_headers.as_ref().context("Client not initialized")?;
         let mut headers = headers.clone();
         headers.insert(
             reqwest::header::CONTENT_TYPE,
@@ -417,7 +417,7 @@ impl JellyfinClient {
         &self, container: &str, item_id: &str, media_source_id: &str,
     ) -> Result<String> {
         let s = self.session();
-        let (url, _) = s.url_headers.as_ref().context("URL is not set")?;
+        let (url, _) = s.url_headers.as_ref().context("Client not initialized")?;
         let path = format!("Videos/{}/stream.{}", item_id, container);
         let mut url = url.join(&path).context("Failed to build item stream URL")?;
         let mut query_pairs = url.query_pairs_mut();
@@ -886,7 +886,7 @@ impl JellyfinClient {
 
     pub async fn get_streaming_url(&self, path: &str) -> String {
         let s = self.session();
-        let (url, _) = s.url_headers.as_ref().expect("URL not set");
+        let (url, _) = s.url_headers.as_ref().expect("Client not initialized");
         url.join(path.trim_start_matches('/')).unwrap().to_string()
     }
 
@@ -1350,7 +1350,7 @@ impl JellyfinClient {
 
     pub async fn get_song_streaming_uri(&self, id: &str) -> String {
         let s = self.session();
-        let (url, _) = s.url_headers.as_ref().expect("URL not set");
+        let (url, _) = s.url_headers.as_ref().expect("Client not initialized");
         let path = format!("Audio/{}/universal", id);
         let mut url = url.join(&path).unwrap();
         let mut query_pairs = url.query_pairs_mut();
@@ -1468,7 +1468,7 @@ impl JellyfinClient {
     ) -> String {
         let s = self.session();
         let path = format!("Items/{id}/Images/{image_type}/");
-        let (url, _) = s.url_headers.as_ref().expect("URL not set");
+        let (url, _) = s.url_headers.as_ref().expect("Client not initialized");
         let url = url.join(&path).unwrap();
         match image_index {
             Some(index) => url.join(&index.to_string()).unwrap().to_string(),

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -8,7 +8,10 @@ use std::{
 };
 
 use crate::{
-    client::account::ServerType,
+    client::account::{
+        ServerType,
+        build_url,
+    },
     ui::{
         PlaybackDirectMode,
         provider::tu_item::image_type::BACKDROP,
@@ -190,11 +193,7 @@ fn build_headers(
     Ok(headers)
 }
 
-fn build_base_url(url_str: &str, port: &str, server_type: ServerType) -> Result<Url> {
-    let mut url = Url::parse(url_str)?;
-    let port = port.parse::<u16>().context("Invalid server port")?;
-    url.set_port(Some(port))
-        .map_err(|_| anyhow!("Failed to set port"))?;
+fn build_base_url(url: Url, server_type: ServerType) -> Result<Url> {
     match server_type {
         ServerType::Emby => Ok(url.join("emby/")?),
         ServerType::Jellyfin => Ok(url),
@@ -242,7 +241,7 @@ impl JellyfinClient {
             Some(&account.access_token),
             server_type,
         )?;
-        let url = build_base_url(&account.server, &account.port, server_type)?;
+        let url = build_base_url(account.url()?, server_type)?;
         self.session.store(Arc::new(Session {
             account: account.clone(),
             url_headers: Some((url, headers)),
@@ -351,7 +350,7 @@ impl JellyfinClient {
     fn prepare_unauthenticated_request(
         &self, method: Method, server: &str, port: &str, server_type: ServerType, path: &str,
     ) -> Result<RequestBuilder> {
-        let url = build_base_url(server, port, server_type)?.join(path)?;
+        let url = build_base_url(build_url(server, port)?, server_type)?.join(path)?;
         Ok(self
             .client
             .request(method, url)

--- a/src/client/jellyfin_client.rs
+++ b/src/client/jellyfin_client.rs
@@ -1247,6 +1247,10 @@ impl JellyfinClient {
     }
 
     pub async fn get_included(&self, id: &str) -> Result<List> {
+        if self.is_jellyfin() {
+            // TODO: Jellyfin does not support filtering by ListItemIds, return an empty list temporarily.
+            return Ok(List::default());
+        }
         let s = self.session();
         let path = format!("Users/{}/Items", s.account.user_id);
         let params = [

--- a/src/ui/widgets/account_add.rs
+++ b/src/ui/widgets/account_add.rs
@@ -232,22 +232,16 @@ impl AccountWindow {
     }
 
     fn parse_url(&self, url: &url::Url) {
-        match url.scheme() {
-            "http" => {
-                self.imp().protocol.set_selected(0);
-            }
-            "https" => {
-                self.imp().protocol.set_selected(1);
-                if url.port().is_none() {
-                    self.imp().port_entry.set_text("443");
-                }
-            }
-            _ => {}
-        }
+        let (protocol_idx, default_port) = match url.scheme() {
+            "http" => (0, 80),
+            "https" => (1, 443),
+            _ => return,
+        };
 
-        if let Some(port) = url.port() {
-            self.imp().port_entry.set_text(&port.to_string());
-        }
+        self.imp().protocol.set_selected(protocol_idx);
+        self.imp()
+            .port_entry
+            .set_text(&url.port().unwrap_or(default_port).to_string());
 
         if let Some(host) = url.host_str() {
             self.imp().server_entry.set_text(host);

--- a/src/ui/widgets/account_add.rs
+++ b/src/ui/widgets/account_add.rs
@@ -134,7 +134,7 @@ impl AccountWindow {
 
     pub async fn add(&self) {
         let imp = self.imp();
-        let mut servername = imp.servername_entry.text().to_string();
+        let servername = imp.servername_entry.text().to_string();
         let scheme = imp.protocol.selected();
         let protocol = if scheme == 0 { "http://" } else { "https://" };
         let server = imp.server_entry.text();
@@ -149,50 +149,39 @@ impl AccountWindow {
         imp.stack.set_visible_child_name("loading");
 
         let server = format!("{protocol}{server}");
-
-        let _ = JELLYFIN_CLIENT.header_change_url(&server, &port);
-        let _ = JELLYFIN_CLIENT.header_change_token(&servername);
-        let un = username.to_string();
-        let pw = password.to_string();
-        let res =
-            match spawn_tokio(async move { JELLYFIN_CLIENT.login(&username, &password).await })
-                .await
-            {
-                Ok(res) => res,
-                Err(e) => {
-                    imp.stack.toast(e.to_user_facing());
-                    imp.stack.set_visible_child_name("entry");
-                    return;
-                }
+        let server_type = ServerType::from_index(imp.server_type.selected());
+        let account = match spawn_tokio(async move {
+            let login = JELLYFIN_CLIENT
+                .login(&server, &port, server_type, &username, &password)
+                .await?;
+            let servername = if servername.is_empty() {
+                JELLYFIN_CLIENT
+                    .get_server_info_public(&server, &port, server_type)
+                    .await?
+                    .server_name
+            } else {
+                servername
             };
 
-        if servername.is_empty() {
-            let res =
-                match spawn_tokio(async move { JELLYFIN_CLIENT.get_server_info_public().await })
-                    .await
-                {
-                    Ok(res) => res,
-                    Err(e) => {
-                        imp.stack.toast(e.to_user_facing());
-                        imp.stack.set_visible_child_name("entry");
-                        return;
-                    }
-                };
-
-            servername = res.server_name;
-        }
-
-        let server_type = ServerType::from_index(imp.server_type.selected());
-
-        let account = Account {
-            servername,
-            server,
-            username: un,
-            password: pw,
-            port: port.to_string(),
-            user_id: res.user.id,
-            access_token: res.access_token,
-            server_type: Some(server_type),
+            Ok::<_, anyhow::Error>(Account {
+                servername,
+                server,
+                username: username.to_string(),
+                password: password.to_string(),
+                port: port.to_string(),
+                user_id: login.user.id,
+                access_token: login.access_token,
+                server_type: Some(server_type),
+            })
+        })
+        .await
+        {
+            Ok(account) => account,
+            Err(e) => {
+                imp.stack.toast(e.to_user_facing());
+                imp.stack.set_visible_child_name("entry");
+                return;
+            }
         };
 
         let action_type = imp.action_type.get();

--- a/src/ui/widgets/server_action_row.rs
+++ b/src/ui/widgets/server_action_row.rs
@@ -143,8 +143,9 @@ impl ServerActionRow {
             .imp()
             .servername_entry
             .set_text(&account.servername);
-        account_window.imp().port_entry.set_text(&account.port);
-        account_window.imp().server_entry.set_text(&account.server);
+        if let Ok(url) = account.url() {
+            account_window.imp().server_entry.set_text(url.as_str());
+        }
         account_window
             .imp()
             .server_type


### PR DESCRIPTION
Closes #676.

Jellyfin 12 removed several Emby compatibility behaviors, including:
1. Authentication headers now accept only `Authorization` by default, rejecting `X-Emby-Authorization` and `X-Emby-Token`.
2. Authentication query parameters now accept only `ApiKey` by default, rejecting `api_key`.
3. The `/emby` route prefix has been removed.

Clients need to adapt to these changes.

Fortunately, Jellyfin began preparing for this migration a long time ago. All the new behavior required here was already supported by Jellyfin 10.7 at the latest, which was released five years ago. Since very few users are likely to be running anything older, we can handle compatibility based solely on `ServerType` without branching on the exact media server version.

While working on this, I found another bug: servers using non-standard ports would still have their port set to `443` on the edit page. This was caused by `server_entry`’s `on_server_entry_changed` handler unexpectedly overwriting the port, so I included a simple fix.