### PR TITLE
fix: align latest card shapes with Jellyfin Web

### DIFF
--- a/crates/tsukimi/src/ui/provider/tu_item.rs
+++ b/crates/tsukimi/src/ui/provider/tu_item.rs
@@ -25,6 +25,7 @@ pub mod item_type {
     pub const VIDEO: &str = "Video";
     pub const MUSIC_VIDEO: &str = "MusicVideo";
     pub const ADULT_VIDEO: &str = "AdultVideo";
+    pub const CHANNEL: &str = "Channel";
     pub const TV_CHANNEL: &str = "TvChannel";
     pub const COLLECTION_FOLDER: &str = "CollectionFolder";
     pub const USER_VIEW: &str = "UserView";
@@ -49,6 +50,15 @@ pub mod item_type {
     pub const SEASON: &str = "Season";
     pub const DANMAKU_ANIME: &str = "DanmakuAnime";
     pub const DANMAKU_EPISODE: &str = "DanmakuEpisode";
+}
+
+pub mod collection_type {
+    pub const MOVIES: &str = "movies";
+    pub const TV_SHOWS: &str = "tvshows";
+    pub const MUSIC: &str = "music";
+    pub const HOME_VIDEOS: &str = "homevideos";
+    pub const BOOKS: &str = "books";
+    pub const LIVE_TV: &str = "livetv";
 }
 
 pub mod image_type {

--- a/crates/tsukimi/src/ui/widgets/home.rs
+++ b/crates/tsukimi/src/ui/widgets/home.rs
@@ -33,7 +33,18 @@ use crate::{
     fraction_reset,
     ui::{
         SETTINGS,
-        provider::tu_item::TuItem,
+        provider::tu_item::{
+            TuItem,
+            collection_type::{
+                BOOKS,
+                HOME_VIDEOS,
+                LIVE_TV,
+                MOVIES,
+                MUSIC,
+                TV_SHOWS,
+            },
+            item_type::CHANNEL,
+        },
     },
     utils::{
         CacheEvent,
@@ -44,6 +55,17 @@ use crate::{
         spawn_g_timeout,
     },
 };
+
+fn latest_card_shape(item_type: &str, collection_type: Option<&str>) -> CardShape {
+    if item_type == CHANNEL {
+        return CardShape::Portrait;
+    }
+    match collection_type {
+        Some(MOVIES | BOOKS | TV_SHOWS) => CardShape::Portrait,
+        Some(MUSIC | HOME_VIDEOS) => CardShape::Square,
+        _ => CardShape::Backdrop,
+    }
+}
 
 mod imp {
 
@@ -388,6 +410,7 @@ impl HomePage {
         hortu.set_moreview(true);
 
         hortu.set_card_options(CardOptions {
+            shape: latest_card_shape(&ac_view.item_type, ac_view.collection_type.as_deref()),
             prefer_parent_poster: true,
             ..Default::default()
         });
@@ -440,7 +463,7 @@ impl HomePage {
                 CachePolicy::RefreshIfChanged
             },
             async move {
-                if collection_type.as_deref() == Some("livetv") {
+                if collection_type.as_deref() == Some(LIVE_TV) {
                     JELLYFIN_CLIENT.get_channels().await.map(|x| x.items)
                 } else {
                     JELLYFIN_CLIENT.get_latest(&view_id).await

--- a/crates/tsukimi/src/ui/widgets/list.rs
+++ b/crates/tsukimi/src/ui/widgets/list.rs
@@ -18,7 +18,10 @@ use super::{
 };
 use crate::{
     client::jellyfin_client::JELLYFIN_CLIENT,
-    ui::provider::tu_item::TuItem,
+    ui::provider::tu_item::{
+        TuItem,
+        collection_type::LIVE_TV,
+    },
 };
 mod imp {
 
@@ -110,7 +113,7 @@ impl ListPage {
 
         let stack = imp.stack.get();
 
-        if &collection_type == "livetv" {
+        if collection_type == LIVE_TV {
             let page = SingleGrid::new();
             page.connect_sort_changed_tokio(move |_, _, _| async move {
                 JELLYFIN_CLIENT.get_channels_list(0).await


### PR DESCRIPTION
I happened to notice that when there is only one album in Tsukimi, Latest defaults to the `Backdrop` card shape instead of `Square`. After checking Jellyfin Web, I realized that its card shape inference logic is not used for Latest; [Latest uses a fixed card shape based on the `item_type` and `collection_type`](https://github.com/jellyfin/jellyfin-web/blob/f1cb62945449f99dc910f6d92a0d2d50edf17ac9/src/components/homesections/sections/recentlyAdded.ts#L66-L80).