### PR TITLE
feat: enable horizontal scrolling in HortuScrolled

### DIFF
--- a/crates/tsukimi/src/ui/widgets/hortu_scrolled.rs
+++ b/crates/tsukimi/src/ui/widgets/hortu_scrolled.rs
@@ -13,7 +13,6 @@ use crate::{
     ui::{
         provider::tu_object::TuObject,
         widgets::{
-            fix::ScrolledWindowFixExt,
             hor_controls::HorControlsExt,
             lazy_diff_view::LazyDiffView,
             tu_item::{
@@ -106,10 +105,6 @@ mod imp {
             let obj = self.obj();
 
             self.diffview.set_orientation(gtk::Orientation::Horizontal);
-            self.diffview
-                .scroll()
-                .fix()
-                .set_hscrollbar_policy(gtk::PolicyType::External);
             let weak_obj = obj.downgrade();
             self.diffview.configure(
                 |tu_obj: &TuObject| tu_obj.item().key(),

--- a/crates/tsukimi/src/ui/widgets/hortu_scrolled.rs
+++ b/crates/tsukimi/src/ui/widgets/hortu_scrolled.rs
@@ -109,7 +109,7 @@ mod imp {
             self.diffview
                 .scroll()
                 .fix()
-                .set_hscrollbar_policy(gtk::PolicyType::Never);
+                .set_hscrollbar_policy(gtk::PolicyType::External);
             let weak_obj = obj.downgrade();
             self.diffview.configure(
                 |tu_obj: &TuObject| tu_obj.item().key(),

--- a/crates/tsukimi/src/ui/widgets/lazy_diff_view/mod.rs
+++ b/crates/tsukimi/src/ui/widgets/lazy_diff_view/mod.rs
@@ -699,7 +699,7 @@ impl LazyDiffView {
         let orientation = self.orientation();
         let scroll = self.scroll();
         scroll.set_hscrollbar_policy(match orientation {
-            Orientation::Horizontal => gtk::PolicyType::Automatic,
+            Orientation::Horizontal => gtk::PolicyType::External,
             _ => gtk::PolicyType::Never,
         });
         scroll.set_vscrollbar_policy(match orientation {


### PR DESCRIPTION
I'm not sure why this was explicitly set to `Never`. Use `External` instead to enable horizontal scrolling.