### PR TITLE
feat: UI improvements for MPV page (window controls, double-click fullscreen, toolbar layout)

### DIFF
--- a/crates/mutsumi/src/video/player.rs
+++ b/crates/mutsumi/src/video/player.rs
@@ -42,6 +42,7 @@ mod imp {
             let picture = gtk::Picture::new();
             picture.set_hexpand(true);
             picture.set_vexpand(true);
+            picture.set_content_fit(gtk::ContentFit::Contain);
             picture.set_paintable(Some(&self.backend));
             graphics_offload.set_child(Some(&picture));
             obj.set_child(Some(&graphics_offload));

--- a/crates/tsukimi/resources/style.css
+++ b/crates/tsukimi/resources/style.css
@@ -94,7 +94,7 @@ button.pill.ultrasmall {
       rgba(0, 0, 0, 0));
   border-radius: 0;
   color: white;
-  padding: 48px 36px 24px;
+  padding: 48px 12px 12px;
 }
 
 .mpv-play-button {

--- a/crates/tsukimi/resources/style.css
+++ b/crates/tsukimi/resources/style.css
@@ -84,7 +84,7 @@ button.pill.ultrasmall {
       rgba(0, 0, 0, 0));
   border-radius: 0;
   color: white;
-  padding: 18px 20px 42px;
+  padding: 0px 0px 42px 0px;
 }
 
 .mpv-bottom-bar {

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -14,9 +14,13 @@
         <property name="content">
           <object class="GtkOverlay">
             <child>
-              <object class="MPVPlaySink" id="video">
+              <object class="GtkWindowHandle">
                 <property name="hexpand">true</property>
                 <property name="vexpand">true</property>
+                <child>
+                  <object class="MPVPlaySink" id="video">
+                    <property name="hexpand">true</property>
+                    <property name="vexpand">true</property>
               
 <child>
               <object class="GtkGestureClick">
@@ -36,6 +40,8 @@
                 <signal name="scroll" handler="video_scroll_cb" swapped="yes"/>
               </object>
             </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child type="overlay">

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -103,9 +103,6 @@
                   <object class="AdwHeaderBar">
                     <property name="show-start-title-buttons">false</property>
                     <property name="show-end-title-buttons">true</property>
-                    <property name="title-widget">
-                      <object class="GtkBox" />
-                    </property>
                     <child type="start">
                       <object class="GtkBox">
                         <property name="orientation">horizontal</property>
@@ -123,30 +120,7 @@
                             </style>
                           </object>
                         </child>
-                        <child>
-                          <object class="GtkBox" id="title_box">
-                            <property name="orientation">vertical</property>
-                            <property name="valign">center</property>
-                            <property name="spacing">0</property>
-                            <child>
-                              <object class="GtkLabel" id="title_label1">
-                                <property name="halign">start</property>
-                                <property name="ellipsize">middle</property>
-                              <property name="max-width-chars">25</property></object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="title_label2">
-                                <property name="halign">start</property>
-                                <property name="ellipsize">middle</property>
-                                <style>
-                                  <class name="dimmed" />
-                                  <class name="caption" />
-                                </style>
-                              <property name="max-width-chars">25</property></object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
+                        </object>
                     </child>
                     <child type="end">
                       <object class="GtkBox">
@@ -228,7 +202,28 @@
                       <class name="flat" />
                       <class name="mpv-top-bar" />
                     </style>
-                  </object>
+                  <property name="title-widget"><object class="GtkBox" id="title_box">
+                            <property name="orientation">vertical</property>
+                            <property name="valign">center</property>
+                            <property name="spacing">0</property>
+                            <child>
+                              <object class="GtkLabel" id="title_label1">
+                                <property name="halign">center</property>
+                                <property name="ellipsize">middle</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="title_label2">
+                                <property name="halign">center</property>
+                                <property name="ellipsize">middle</property>
+                                <style>
+                                  <class name="dimmed" />
+                                  <class name="caption" />
+                                </style>
+                              </object>
+                            </child>
+                          </object>
+                        </property></object>
                 </child>
               </object>
             </child>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -1,12 +1,12 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template parent="AdwNavigationPage" class="MPVPage">
     <property name="title">Tsukimi</property>
     <child>
       <object class="GtkEventControllerMotion">
-        <signal name="motion" handler="on_motion" swapped="yes" />
-        <signal name="leave" handler="on_leave" swapped="yes" />
-        <signal name="enter" handler="on_enter" swapped="yes" />
+        <signal name="motion" handler="on_motion" swapped="yes"/>
+        <signal name="leave" handler="on_leave" swapped="yes"/>
+        <signal name="enter" handler="on_enter" swapped="yes"/>
       </object>
     </child>
     <child>
@@ -25,19 +25,19 @@
 <child>
               <object class="GtkGestureClick">
                 <property name="button">1</property>
-                <signal name="released" handler="left_click_cb" swapped="yes" />
+                <signal name="released" handler="left_click_cb" swapped="yes"/>
               </object>
             </child>
             <child>
               <object class="GtkGestureClick">
                 <property name="button">3</property>
-                <signal name="released" handler="right_click_cb" swapped="yes" />
+                <signal name="released" handler="right_click_cb" swapped="yes"/>
               </object>
             </child>
             <child>
               <object class="GtkEventControllerScroll">
                 <property name="flags">vertical</property>
-                <signal name="scroll" handler="video_scroll_cb" swapped="yes" />
+                <signal name="scroll" handler="video_scroll_cb" swapped="yes"/>
               </object>
             </child>
                   </object>
@@ -75,7 +75,7 @@
                     <property name="width-request">64</property>
                     <property name="margin-top">20</property>
                     <style>
-                      <class name="accent" />
+                      <class name="accent"/>
                     </style>
                   </object>
                 </child>
@@ -84,8 +84,8 @@
                     <property name="halign">center</property>
                     <property name="margin_bottom">20</property>
                     <style>
-                      <class name="accent" />
-                      <class name="speed-label" />
+                      <class name="accent"/>
+                      <class name="speed-label"/>
                     </style>
                   </object>
                 </child>
@@ -104,7 +104,7 @@
                     <property name="show-start-title-buttons">false</property>
                     <property name="show-end-title-buttons">true</property>
                     <property name="title-widget">
-                      <object class="GtkBox" />
+                      <object class="GtkBox"/>
                     </property>
                     <child type="start">
                       <object class="GtkBox">
@@ -116,10 +116,10 @@
                             <property name="tooltip_text" translatable="yes">Stop and quit</property>
                             <property name="icon-name">arrow4-left-symbolic</property>
                             <property name="valign">center</property>
-                            <signal name="clicked" handler="on_stop_clicked" swapped="yes" />
+                            <signal name="clicked" handler="on_stop_clicked" swapped="yes"/>
                             <style>
-                              <class name="flat" />
-                              <class name="circular" />
+                              <class name="flat"/>
+                              <class name="circular"/>
                             </style>
                           </object>
                         </child>
@@ -139,8 +139,8 @@
                                 <property name="halign">start</property>
                                 <property name="ellipsize">middle</property>
                                 <style>
-                                  <class name="dimmed" />
-                                  <class name="caption" />
+                                  <class name="dimmed"/>
+                                  <class name="caption"/>
                                 </style>
                               </object>
                             </child>
@@ -159,10 +159,10 @@
                             <property name="focusable">True</property>
                             <property name="receives_default">True</property>
                             <property name="tooltip_text" translatable="yes">Playlist</property>
-                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes" />
+                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes"/>
                             <style>
-                              <class name="flat" />
-                              <class name="circular" />
+                              <class name="flat"/>
+                              <class name="circular"/>
                             </style>
                           </object>
                         </child>
@@ -172,8 +172,8 @@
                             <property name="icon-name">view-more-symbolic</property>
                             <property name="tooltip_text" translatable="yes">More options</property>
                             <style>
-                              <class name="flat" />
-                              <class name="circular" />
+                              <class name="flat"/>
+                              <class name="circular"/>
                             </style>
                             <property name="popover">
                               <object class="GtkPopover">
@@ -188,7 +188,7 @@
                                     <child>
                                       <object class="GtkButton">
                                         <property name="action-name">win.show-help-overlay</property>
-                                        <style><class name="flat" /></style>
+                                        <style><class name="flat"/></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">keyboard-shortcuts-symbolic</property>
@@ -199,11 +199,11 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="network_speed_label_2">
-                                        <style><class name="flat" /></style>
+                                        <style><class name="flat"/></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">speedometer5-symbolic</property>
-                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create" />
+                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create"/>
                                           </object>
                                         </property>
                                       </object>
@@ -212,8 +212,8 @@
                                       <object class="GtkButton" id="_media_info_button">
                                         <property name="focusable">True</property>
                                         <property name="receives_default">True</property>
-                                        <signal name="clicked" handler="on_info_clicked" swapped="yes" />
-                                        <style><class name="flat" /></style>
+                                        <signal name="clicked" handler="on_info_clicked" swapped="yes"/>
+                                        <style><class name="flat"/></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">help-about-symbolic</property>
@@ -232,8 +232,8 @@
                       </object>
                     </child>
                     <style>
-                      <class name="flat" />
-                      <class name="mpv-top-bar" />
+                      <class name="flat"/>
+                      <class name="mpv-top-bar"/>
                     </style>
                   </object>
                 </child>
@@ -248,7 +248,7 @@
                 <property name="valign">end</property>
                 <property name="focusable">False</property>
                 <child>
-                  <object class="GtkWindowHandle"><object class="GtkBox">
+                  <object class="GtkBox">
                     <property name="orientation">vertical</property>
                     <property name="halign">fill</property>
                     <property name="hexpand">True</property>
@@ -267,7 +267,7 @@
                             <property name="valign">center</property>
                             <property name="label">0:00</property>
                             <attributes>
-                              <attribute name="font-features" value="tnum=1" />
+                              <attribute name="font-features" value="tnum=1"/>
                             </attributes>
                           </object>
                         </child>
@@ -279,10 +279,10 @@
                             <property name="draw_value">False</property>
                             <property name="restrict-to-fill-level">False</property>
                             <property name="show-fill-level">True</property>
-                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes" />
+                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes"/>
                             <style>
-                              <class name="accent" />
-                              <class name="mpv-seekbar" />
+                              <class name="accent"/>
+                              <class name="mpv-seekbar"/>
                             </style>
                           </object>
                         </child>
@@ -293,7 +293,7 @@
                             <property name="valign">center</property>
                             <property name="label">0:00</property>
                             <attributes>
-                              <attribute name="font-features" value="tnum=1" />
+                              <attribute name="font-features" value="tnum=1"/>
                             </attributes>
                           </object>
                         </child>
@@ -303,69 +303,16 @@
                       <object class="GtkCenterBox">
                         <child type="start">
                           <object class="GtkBox">
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">10</property>
                             <child>
-                                  <object class="GtkMenuButton" id="volume_button">
-                                    <property name="popover">volume_adj_popover</property>
-                                    <property name="icon-name">audio-volume-high-symbolic</property>
-                                    <property name="tooltip-text" translatable="yes">Adjust Volume</property>
-                                    <property name="valign">center</property>
-                                    <style>
-                                      <class name="flat" />
-                                      <class name="circular" />
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkMenuButton" id="audio_tracks_menu_button">
-                                    <property name="popover">audio_tracks_popover</property>
-                                    <property name="icon-name">audio-x-generic-symbolic</property>
-                                    <property name="tooltip-text" translatable="yes">Audio</property>
-                                    <property name="valign">center</property>
-                                    <style>
-                                      <class name="flat" />
-                                      <class name="circular" />
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkMenuButton" id="subtitle_tracks_menu_button">
-                                    <property name="popover">subtitle_tracks_popover</property>
-                                    <property name="icon-name">media-view-subtitles-symbolic</property>
-                                    <property name="tooltip-text" translatable="yes">Subtitle</property>
-                                    <property name="valign">center</property>
-                                    <style>
-                                      <class name="flat" />
-                                      <class name="circular" />
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                              <object class="GtkButton" id="playback_speed_indicator">
-                                <property name="valign">center</property>
-                                <property name="margin-end">6</property>
-                                <property name="visible">false</property>
-                                <signal name="clicked" handler="playback_speed_indicator_cb" swapped="yes" />
-                                <property name="child">
-                                  <object class="AdwButtonContent" id="playback_speed_button_content">
-                                    <property name="icon-name">playback-options-symbolic</property>
-                                  </object>
-                                </property>
-                                <style>
-                                  <class name="accent" />
-                                  <class name="monospace" />
-                                </style>
-                              </object>
-                            </child>
-                            </object>
-                        </child>
-                        <child type="center"><object class="GtkBox"><property name="orientation">horizontal</property><property name="spacing">10</property><child>
                               <object class="GtkButton" id="_previous_button">
                                 <property name="icon-name">media-skip-backward-symbolic</property>
                                 <property name="action-name">mpv.previous-video</property>
                                 <property name="valign">center</property>
                                 <style>
-                                  <class name="flat" />
-                                  <class name="circular" />
+                                  <class name="flat"/>
+                                  <class name="circular"/>
                                 </style>
                               </object>
                             </child>
@@ -383,8 +330,8 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="circular" />
-                                  <class name="flat" />
+                                  <class name="circular"/>
+                                  <class name="flat"/>
                                 </style>
                               </object>
                             </child>
@@ -396,7 +343,7 @@
                                 <property name="receives_default">True</property>
                                 <property name="valign">center</property>
                                 <property name="tooltip_text" translatable="yes">Pause</property>
-                                <signal name="clicked" handler="on_play_pause_clicked" swapped="yes" />
+                                <signal name="clicked" handler="on_play_pause_clicked" swapped="yes"/>
                                 <child>
                                   <object class="GtkImage" id="play_pause_image">
                                     <property name="icon_name">media-playback-pause-symbolic</property>
@@ -406,9 +353,9 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="flat" />
-                                  <class name="mpv-play-button" />
-                                  <class name="circular" />
+                                  <class name="flat"/>
+                                  <class name="mpv-play-button"/>
+                                  <class name="circular"/>
                                 </style>
                               </object>
                             </child>
@@ -426,8 +373,8 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="circular" />
-                                  <class name="flat" />
+                                  <class name="circular"/>
+                                  <class name="flat"/>
                                 </style>
                               </object>
                             </child>
@@ -437,22 +384,85 @@
                                 <property name="action-name">mpv.next-video</property>
                                 <property name="valign">center</property>
                                 <style>
-                                  <class name="flat" />
-                                  <class name="circular" />
+                                  <class name="flat"/>
+                                  <class name="circular"/>
                                 </style>
                               </object>
                             </child>
-                          </object></child><child type="end">
+                          </object>
+                        </child>
+                        <child type="end">
                           <object class="GtkBox">
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">6</property>
+                            <property name="valign">center</property>
                             <child>
+                              <object class="GtkButton" id="playback_speed_indicator">
+                                <property name="valign">center</property>
+                                <property name="margin-end">6</property>
+                                <property name="visible">false</property>
+                                <signal name="clicked" handler="playback_speed_indicator_cb" swapped="yes"/>
+                                <property name="child">
+                                  <object class="AdwButtonContent" id="playback_speed_button_content">
+                                    <property name="icon-name">playback-options-symbolic</property>
+                                  </object>
+                                </property>
+                                <style>
+                                  <class name="accent"/>
+                                  <class name="monospace"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="orientation">horizontal</property>
+                                <property name="spacing">2</property>
+                                <property name="valign">center</property>
+                                <child>
+                                  <object class="GtkMenuButton" id="audio_tracks_menu_button">
+                                    <property name="popover">audio_tracks_popover</property>
+                                    <property name="icon-name">audio-x-generic-symbolic</property>
+                                    <property name="tooltip-text" translatable="yes">Audio</property>
+                                    <property name="valign">center</property>
+                                    <style>
+                                      <class name="flat"/>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkMenuButton" id="subtitle_tracks_menu_button">
+                                    <property name="popover">subtitle_tracks_popover</property>
+                                    <property name="icon-name">media-view-subtitles-symbolic</property>
+                                    <property name="tooltip-text" translatable="yes">Subtitle</property>
+                                    <property name="valign">center</property>
+                                    <style>
+                                      <class name="flat"/>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkMenuButton" id="volume_button">
+                                    <property name="popover">volume_adj_popover</property>
+                                    <property name="icon-name">audio-volume-high-symbolic</property>
+                                    <property name="tooltip-text" translatable="yes">Adjust Volume</property>
+                                    <property name="valign">center</property>
+                                    <style>
+                                      <class name="flat"/>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
                                   <object class="GtkMenuButton" id="danmaku_button">
                                     <property name="popover">danmaku_popover</property>
                                     <property name="icon-name">card-bulleted-symbolic</property>
                                     <property name="tooltip-text" translatable="yes">Danmaku</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat" />
-                                      <class name="circular" />
+                                      <class name="flat"/>
+                                      <class name="circular"/>
                                     </style>
                                   </object>
                                 </child>
@@ -463,14 +473,30 @@
                                     <property name="tooltip-text" translatable="yes">Advanced settings</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat" />
-                                      <class name="circular" />
+                                      <class name="flat"/>
+                                      <class name="circular"/>
                                     </style>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create" />
+                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create|invert-boolean"/>
+                                    <property name="icon-name">view-fullscreen-symbolic</property>
+                                    <property name="action-name">win.toggle-fullscreen</property>
+                                    <property name="tooltip-text" translatable="yes">Fullscreen</property>
+                                    <property name="valign">center</property>
+                                    <accessibility>
+                                      <property name="label" translatable="yes">Fullscreen</property>
+                                    </accessibility>
+                                    <style>
+                                      <class name="flat"/>
+                                      <class name="circular"/>
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkButton">
+                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create"/>
                                     <property name="icon-name">view-restore-symbolic</property>
                                     <property name="action-name">win.toggle-fullscreen</property>
                                     <property name="valign">center</property>
@@ -479,20 +505,22 @@
                                       <property name="label" translatable="yes">Exit Fullscreen</property>
                                     </accessibility>
                                     <style>
-                                      <class name="flat" />
-                                      <class name="circular" />
+                                      <class name="flat"/>
+                                      <class name="circular"/>
                                     </style>
                                   </object>
                                 </child>
                               </object>
+                            </child>
+                          </object>
                         </child>
                       </object>
                     </child>
                     <style>
-                      <class name="mpv-bottom-bar" />
+                      <class name="mpv-bottom-bar"/>
                     </style>
                   </object>
-                </object></child>
+                </child>
               </object>
             </child>
             <child type="overlay">
@@ -506,9 +534,9 @@
                 <property name="margin-bottom">172</property>
                 <child>
                   <object class="GtkButton" id="skip_segment_button">
-                    <signal name="clicked" handler="on_skip_segment_clicked" swapped="yes" />
+                    <signal name="clicked" handler="on_skip_segment_clicked" swapped="yes"/>
                     <style>
-                      <class name="osd" />
+                      <class name="osd"/>
                     </style>
                   </object>
                 </child>
@@ -524,8 +552,8 @@
     <property name="width-request">320</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes" />
-    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
+    <signal name="map" handler="on_popover_opened" swapped="yes"/>
+    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
     <child>
       <object class="GtkScrolledWindow">
         <child>
@@ -533,7 +561,7 @@
             <property name="selection-mode">single</property>
             <property name="valign">start</property>
             <style>
-              <class name="boxed-list-separate" />
+              <class name="boxed-list-separate"/>
             </style>
           </object>
         </child>
@@ -545,8 +573,8 @@
     <property name="width-request">320</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes" />
-    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
+    <signal name="map" handler="on_popover_opened" swapped="yes"/>
+    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
     <child>
       <object class="GtkScrolledWindow">
         <child>
@@ -554,7 +582,7 @@
             <property name="selection-mode">single</property>
             <property name="valign">start</property>
             <style>
-              <class name="boxed-list-separate" />
+              <class name="boxed-list-separate"/>
             </style>
           </object>
         </child>
@@ -564,8 +592,8 @@
   <object class="GtkPopover" id="volume_adj_popover">
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes" />
-    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
+    <signal name="map" handler="on_popover_opened" swapped="yes"/>
+    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
     <child>
       <object class="GtkScale" id="volume_scale">
         <property name="adjustment">volume_adj</property>
@@ -575,9 +603,9 @@
         <property name="draw-value">false</property>
         <property name="orientation">vertical</property>
         <property name="inverted">true</property>
-        <signal name="value-changed" handler="on_volume_scale_value_changed" swapped="yes" />
+        <signal name="value-changed" handler="on_volume_scale_value_changed" swapped="yes"/>
         <style>
-          <class name="accent" />
+          <class name="accent"/>
         </style>
       </object>
     </child>
@@ -586,14 +614,14 @@
     <property name="width-request">400</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes" />
-    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
+    <signal name="map" handler="on_popover_opened" swapped="yes"/>
+    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
     <child>
       <object class="AdwClamp">
         <property name="maximum-size">400</property>
         <property name="tightening-threshold">400</property>
         <child>
-          <object class="DanmakuPopover" id="danmaku_popover_content" />
+          <object class="DanmakuPopover" id="danmaku_popover_content"/>
         </child>
       </object>
     </child>
@@ -671,19 +699,19 @@
   <object class="GtkSizeGroup">
     <property name="mode">vertical</property>
     <widgets>
-      <widget name="_play_button" />
-      <widget name="progress_time_label" />
-      <widget name="video_scale" />
-      <widget name="duration_label" />
+      <widget name="_play_button"/>
+      <widget name="progress_time_label"/>
+      <widget name="video_scale"/>
+      <widget name="duration_label"/>
     </widgets>
   </object>
   <object class="GtkSizeGroup">
     <property name="mode">vertical</property>
     <widgets>
-      <widget name="_back_button" />
-      <widget name="network_speed_label_2" />
-      <widget name="_media_info_button" />
-      <widget name="_playlist_button" />
+      <widget name="_back_button"/>
+      <widget name="network_speed_label_2"/>
+      <widget name="_media_info_button"/>
+      <widget name="_playlist_button"/>
     </widgets>
   </object>
 </interface>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -153,16 +153,16 @@
                         <property name="orientation">horizontal</property>
                         <property name="spacing">6</property>
                         <child>
-                          <object class="GtkButton" id="network_speed_label_2">
+                          <object class="GtkButton" id="_playlist_button">
                             <property name="valign">center</property>
-                            <property name="child">
-                              <object class="AdwButtonContent">
-                                <property name="icon-name">speedometer5-symbolic</property>
-                                <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create"/>
-                              </object>
-                            </property>
+                            <property name="icon-name">view-dual-symbolic</property>
+                            <property name="focusable">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Playlist</property>
+                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes"/>
                             <style>
-                              <class name="accent"/>
+                              <class name="flat"/>
+                              <class name="circular"/>
                             </style>
                           </object>
                         </child>
@@ -198,15 +198,12 @@
                                       </object>
                                     </child>
                                     <child>
-                                      <object class="GtkButton" id="_playlist_button">
-                                        <property name="focusable">True</property>
-                                        <property name="receives_default">True</property>
-                                        <signal name="clicked" handler="on_playlist_clicked" swapped="yes"/>
+                                      <object class="GtkButton" id="network_speed_label_2">
                                         <style><class name="flat"/></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
-                                            <property name="icon-name">view-dual-symbolic</property>
-                                            <property name="label" translatable="yes">Playlist</property>
+                                            <property name="icon-name">speedometer5-symbolic</property>
+                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create"/>
                                           </object>
                                         </property>
                                       </object>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
-  <child><object class="AdwBreakpoint"><condition>max-width: 650px</condition><setter object="MPVPage" property="compact-mode">true</setter></object></child><template parent="AdwNavigationPage" class="MPVPage">
+  <template parent="AdwNavigationPage" class="MPVPage">
     <property name="title">Tsukimi</property>
     <child>
       <object class="GtkEventControllerMotion">
@@ -10,7 +10,7 @@
       </object>
     </child>
     <child>
-      <object class="AdwToolbarView">
+      <object class="AdwBreakpointBin"><child><object class="AdwBreakpoint"><condition>max-width: 650px</condition><setter object="MPVPage" property="compact-mode">true</setter></object></child><property name="child"><object class="AdwToolbarView">
         <property name="content">
           <object class="GtkOverlay">
             <child>
@@ -545,7 +545,7 @@
           </object>
         </property>
       </object>
-    </child>
+    </property></object></child>
   </template>
   <object class="GtkPopover" id="subtitle_tracks_popover">
     <property name="height-request">300</property>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -427,7 +427,7 @@
                                   </object>
                                 </child>
                                 <child>
-                                  <object class="GtkMenuButton">
+                                  <object class="GtkMenuButton" id="danmaku_button">
                                     <property name="popover">danmaku_popover</property>
                                     <property name="icon-name">card-bulleted-symbolic</property>
                                     <property name="tooltip-text" translatable="yes">Danmaku</property>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -25,7 +25,7 @@
 <child>
               <object class="GtkGestureClick">
                 <property name="button">1</property>
-                <signal name="pressed" handler="left_click_cb" swapped="yes"/>
+                <signal name="released" handler="left_click_cb" swapped="yes"/>
               </object>
             </child>
             <child>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <interface>
-  <template parent="AdwNavigationPage" class="MPVPage">
+  <child><object class="AdwBreakpoint"><condition>max-width: 650px</condition><setter object="MPVPage" property="compact-mode">true</setter></object></child><template parent="AdwNavigationPage" class="MPVPage">
     <property name="title">Tsukimi</property>
     <child>
       <object class="GtkEventControllerMotion">
-        <signal name="motion" handler="on_motion" swapped="yes"/>
-        <signal name="leave" handler="on_leave" swapped="yes"/>
-        <signal name="enter" handler="on_enter" swapped="yes"/>
+        <signal name="motion" handler="on_motion" swapped="yes" />
+        <signal name="leave" handler="on_leave" swapped="yes" />
+        <signal name="enter" handler="on_enter" swapped="yes" />
       </object>
     </child>
     <child>
@@ -25,19 +25,19 @@
 <child>
               <object class="GtkGestureClick">
                 <property name="button">1</property>
-                <signal name="released" handler="left_click_cb" swapped="yes"/>
+                <signal name="released" handler="left_click_cb" swapped="yes" />
               </object>
             </child>
             <child>
               <object class="GtkGestureClick">
                 <property name="button">3</property>
-                <signal name="released" handler="right_click_cb" swapped="yes"/>
+                <signal name="released" handler="right_click_cb" swapped="yes" />
               </object>
             </child>
             <child>
               <object class="GtkEventControllerScroll">
                 <property name="flags">vertical</property>
-                <signal name="scroll" handler="video_scroll_cb" swapped="yes"/>
+                <signal name="scroll" handler="video_scroll_cb" swapped="yes" />
               </object>
             </child>
                   </object>
@@ -75,7 +75,7 @@
                     <property name="width-request">64</property>
                     <property name="margin-top">20</property>
                     <style>
-                      <class name="accent"/>
+                      <class name="accent" />
                     </style>
                   </object>
                 </child>
@@ -84,8 +84,8 @@
                     <property name="halign">center</property>
                     <property name="margin_bottom">20</property>
                     <style>
-                      <class name="accent"/>
-                      <class name="speed-label"/>
+                      <class name="accent" />
+                      <class name="speed-label" />
                     </style>
                   </object>
                 </child>
@@ -104,7 +104,7 @@
                     <property name="show-start-title-buttons">false</property>
                     <property name="show-end-title-buttons">true</property>
                     <property name="title-widget">
-                      <object class="GtkBox"/>
+                      <object class="GtkBox" />
                     </property>
                     <child type="start">
                       <object class="GtkBox">
@@ -116,10 +116,10 @@
                             <property name="tooltip_text" translatable="yes">Stop and quit</property>
                             <property name="icon-name">arrow4-left-symbolic</property>
                             <property name="valign">center</property>
-                            <signal name="clicked" handler="on_stop_clicked" swapped="yes"/>
+                            <signal name="clicked" handler="on_stop_clicked" swapped="yes" />
                             <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
+                              <class name="flat" />
+                              <class name="circular" />
                             </style>
                           </object>
                         </child>
@@ -139,8 +139,8 @@
                                 <property name="halign">start</property>
                                 <property name="ellipsize">middle</property>
                                 <style>
-                                  <class name="dimmed"/>
-                                  <class name="caption"/>
+                                  <class name="dimmed" />
+                                  <class name="caption" />
                                 </style>
                               </object>
                             </child>
@@ -159,10 +159,10 @@
                             <property name="focusable">True</property>
                             <property name="receives_default">True</property>
                             <property name="tooltip_text" translatable="yes">Playlist</property>
-                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes"/>
+                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes" />
                             <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
+                              <class name="flat" />
+                              <class name="circular" />
                             </style>
                           </object>
                         </child>
@@ -172,8 +172,8 @@
                             <property name="icon-name">view-more-symbolic</property>
                             <property name="tooltip_text" translatable="yes">More options</property>
                             <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
+                              <class name="flat" />
+                              <class name="circular" />
                             </style>
                             <property name="popover">
                               <object class="GtkPopover">
@@ -188,7 +188,7 @@
                                     <child>
                                       <object class="GtkButton">
                                         <property name="action-name">win.show-help-overlay</property>
-                                        <style><class name="flat"/></style>
+                                        <style><class name="flat" /></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">keyboard-shortcuts-symbolic</property>
@@ -199,11 +199,11 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="network_speed_label_2">
-                                        <style><class name="flat"/></style>
+                                        <style><class name="flat" /></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">speedometer5-symbolic</property>
-                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create"/>
+                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create" />
                                           </object>
                                         </property>
                                       </object>
@@ -212,8 +212,8 @@
                                       <object class="GtkButton" id="_media_info_button">
                                         <property name="focusable">True</property>
                                         <property name="receives_default">True</property>
-                                        <signal name="clicked" handler="on_info_clicked" swapped="yes"/>
-                                        <style><class name="flat"/></style>
+                                        <signal name="clicked" handler="on_info_clicked" swapped="yes" />
+                                        <style><class name="flat" /></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">help-about-symbolic</property>
@@ -232,8 +232,8 @@
                       </object>
                     </child>
                     <style>
-                      <class name="flat"/>
-                      <class name="mpv-top-bar"/>
+                      <class name="flat" />
+                      <class name="mpv-top-bar" />
                     </style>
                   </object>
                 </child>
@@ -267,7 +267,7 @@
                             <property name="valign">center</property>
                             <property name="label">0:00</property>
                             <attributes>
-                              <attribute name="font-features" value="tnum=1"/>
+                              <attribute name="font-features" value="tnum=1" />
                             </attributes>
                           </object>
                         </child>
@@ -279,10 +279,10 @@
                             <property name="draw_value">False</property>
                             <property name="restrict-to-fill-level">False</property>
                             <property name="show-fill-level">True</property>
-                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes"/>
+                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes" />
                             <style>
-                              <class name="accent"/>
-                              <class name="mpv-seekbar"/>
+                              <class name="accent" />
+                              <class name="mpv-seekbar" />
                             </style>
                           </object>
                         </child>
@@ -293,14 +293,14 @@
                             <property name="valign">center</property>
                             <property name="label">0:00</property>
                             <attributes>
-                              <attribute name="font-features" value="tnum=1"/>
+                              <attribute name="font-features" value="tnum=1" />
                             </attributes>
                           </object>
                         </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkCenterBox">
+                      <object class="GtkCenterBox" id="center_box">
                         <child type="start">
                           <object class="GtkBox">
                             <property name="orientation">horizontal</property>
@@ -311,8 +311,8 @@
                                 <property name="action-name">mpv.previous-video</property>
                                 <property name="valign">center</property>
                                 <style>
-                                  <class name="flat"/>
-                                  <class name="circular"/>
+                                  <class name="flat" />
+                                  <class name="circular" />
                                 </style>
                               </object>
                             </child>
@@ -330,8 +330,8 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="circular"/>
-                                  <class name="flat"/>
+                                  <class name="circular" />
+                                  <class name="flat" />
                                 </style>
                               </object>
                             </child>
@@ -343,7 +343,7 @@
                                 <property name="receives_default">True</property>
                                 <property name="valign">center</property>
                                 <property name="tooltip_text" translatable="yes">Pause</property>
-                                <signal name="clicked" handler="on_play_pause_clicked" swapped="yes"/>
+                                <signal name="clicked" handler="on_play_pause_clicked" swapped="yes" />
                                 <child>
                                   <object class="GtkImage" id="play_pause_image">
                                     <property name="icon_name">media-playback-pause-symbolic</property>
@@ -353,9 +353,9 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="flat"/>
-                                  <class name="mpv-play-button"/>
-                                  <class name="circular"/>
+                                  <class name="flat" />
+                                  <class name="mpv-play-button" />
+                                  <class name="circular" />
                                 </style>
                               </object>
                             </child>
@@ -373,8 +373,8 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="circular"/>
-                                  <class name="flat"/>
+                                  <class name="circular" />
+                                  <class name="flat" />
                                 </style>
                               </object>
                             </child>
@@ -384,15 +384,15 @@
                                 <property name="action-name">mpv.next-video</property>
                                 <property name="valign">center</property>
                                 <style>
-                                  <class name="flat"/>
-                                  <class name="circular"/>
+                                  <class name="flat" />
+                                  <class name="circular" />
                                 </style>
                               </object>
                             </child>
                           </object>
                         </child>
                         <child type="end">
-                          <object class="GtkBox">
+                          <object class="GtkBox" id="right_wrapper_box"><property name="orientation">horizontal</property><child><object class="GtkBox" id="right_group_box">
                             <property name="orientation">horizontal</property>
                             <property name="spacing">6</property>
                             <property name="valign">center</property>
@@ -401,15 +401,15 @@
                                 <property name="valign">center</property>
                                 <property name="margin-end">6</property>
                                 <property name="visible">false</property>
-                                <signal name="clicked" handler="playback_speed_indicator_cb" swapped="yes"/>
+                                <signal name="clicked" handler="playback_speed_indicator_cb" swapped="yes" />
                                 <property name="child">
                                   <object class="AdwButtonContent" id="playback_speed_button_content">
                                     <property name="icon-name">playback-options-symbolic</property>
                                   </object>
                                 </property>
                                 <style>
-                                  <class name="accent"/>
-                                  <class name="monospace"/>
+                                  <class name="accent" />
+                                  <class name="monospace" />
                                 </style>
                               </object>
                             </child>
@@ -425,8 +425,8 @@
                                     <property name="tooltip-text" translatable="yes">Audio</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
@@ -437,8 +437,8 @@
                                     <property name="tooltip-text" translatable="yes">Subtitle</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
@@ -449,8 +449,8 @@
                                     <property name="tooltip-text" translatable="yes">Adjust Volume</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
@@ -461,8 +461,8 @@
                                     <property name="tooltip-text" translatable="yes">Danmaku</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
@@ -473,14 +473,14 @@
                                     <property name="tooltip-text" translatable="yes">Advanced settings</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create|invert-boolean"/>
+                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create|invert-boolean" />
                                     <property name="icon-name">view-fullscreen-symbolic</property>
                                     <property name="action-name">win.toggle-fullscreen</property>
                                     <property name="tooltip-text" translatable="yes">Fullscreen</property>
@@ -489,14 +489,14 @@
                                       <property name="label" translatable="yes">Fullscreen</property>
                                     </accessibility>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create"/>
+                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create" />
                                     <property name="icon-name">view-restore-symbolic</property>
                                     <property name="action-name">win.toggle-fullscreen</property>
                                     <property name="valign">center</property>
@@ -505,19 +505,19 @@
                                       <property name="label" translatable="yes">Exit Fullscreen</property>
                                     </accessibility>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
                               </object>
                             </child>
                           </object>
-                        </child>
+                        </child><child><object class="GtkMenuButton" id="mobile_menu_button"><property name="icon-name">view-more-symbolic</property><property name="valign">center</property><property name="visible" bind-source="MPVPage" bind-property="compact-mode" bind-flags="sync-create" /><style><class name="flat" /><class name="circular" /></style><property name="popover"><object class="GtkPopover"><child><object class="GtkBox" id="mobile_popover_box"><property name="orientation">vertical</property><property name="spacing">6</property><property name="margin-top">6</property><property name="margin-bottom">6</property><property name="margin-start">6</property><property name="margin-end">6</property></object></child></object></property></object></child></object></child>
                       </object>
                     </child>
                     <style>
-                      <class name="mpv-bottom-bar"/>
+                      <class name="mpv-bottom-bar" />
                     </style>
                   </object>
                 </child>
@@ -534,9 +534,9 @@
                 <property name="margin-bottom">172</property>
                 <child>
                   <object class="GtkButton" id="skip_segment_button">
-                    <signal name="clicked" handler="on_skip_segment_clicked" swapped="yes"/>
+                    <signal name="clicked" handler="on_skip_segment_clicked" swapped="yes" />
                     <style>
-                      <class name="osd"/>
+                      <class name="osd" />
                     </style>
                   </object>
                 </child>
@@ -552,8 +552,8 @@
     <property name="width-request">320</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="GtkScrolledWindow">
         <child>
@@ -561,7 +561,7 @@
             <property name="selection-mode">single</property>
             <property name="valign">start</property>
             <style>
-              <class name="boxed-list-separate"/>
+              <class name="boxed-list-separate" />
             </style>
           </object>
         </child>
@@ -573,8 +573,8 @@
     <property name="width-request">320</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="GtkScrolledWindow">
         <child>
@@ -582,7 +582,7 @@
             <property name="selection-mode">single</property>
             <property name="valign">start</property>
             <style>
-              <class name="boxed-list-separate"/>
+              <class name="boxed-list-separate" />
             </style>
           </object>
         </child>
@@ -592,8 +592,8 @@
   <object class="GtkPopover" id="volume_adj_popover">
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="GtkScale" id="volume_scale">
         <property name="adjustment">volume_adj</property>
@@ -603,9 +603,9 @@
         <property name="draw-value">false</property>
         <property name="orientation">vertical</property>
         <property name="inverted">true</property>
-        <signal name="value-changed" handler="on_volume_scale_value_changed" swapped="yes"/>
+        <signal name="value-changed" handler="on_volume_scale_value_changed" swapped="yes" />
         <style>
-          <class name="accent"/>
+          <class name="accent" />
         </style>
       </object>
     </child>
@@ -614,14 +614,14 @@
     <property name="width-request">400</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="AdwClamp">
         <property name="maximum-size">400</property>
         <property name="tightening-threshold">400</property>
         <child>
-          <object class="DanmakuPopover" id="danmaku_popover_content"/>
+          <object class="DanmakuPopover" id="danmaku_popover_content" />
         </child>
       </object>
     </child>
@@ -699,19 +699,19 @@
   <object class="GtkSizeGroup">
     <property name="mode">vertical</property>
     <widgets>
-      <widget name="_play_button"/>
-      <widget name="progress_time_label"/>
-      <widget name="video_scale"/>
-      <widget name="duration_label"/>
+      <widget name="_play_button" />
+      <widget name="progress_time_label" />
+      <widget name="video_scale" />
+      <widget name="duration_label" />
     </widgets>
   </object>
   <object class="GtkSizeGroup">
     <property name="mode">vertical</property>
     <widgets>
-      <widget name="_back_button"/>
-      <widget name="network_speed_label_2"/>
-      <widget name="_media_info_button"/>
-      <widget name="_playlist_button"/>
+      <widget name="_back_button" />
+      <widget name="network_speed_label_2" />
+      <widget name="_media_info_button" />
+      <widget name="_playlist_button" />
     </widgets>
   </object>
 </interface>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -132,7 +132,7 @@
                               <object class="GtkLabel" id="title_label1">
                                 <property name="halign">start</property>
                                 <property name="ellipsize">middle</property>
-                              </object>
+                              <property name="max-width-chars">25</property></object>
                             </child>
                             <child>
                               <object class="GtkLabel" id="title_label2">
@@ -142,7 +142,7 @@
                                   <class name="dimmed" />
                                   <class name="caption" />
                                 </style>
-                              </object>
+                              <property name="max-width-chars">25</property></object>
                             </child>
                           </object>
                         </child>
@@ -179,7 +179,11 @@
                               <object class="GtkPopover">
                                 <child>
                                   <object class="GtkBox">
-                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkBox" id="network_speed_label_2">
+                                        <property name="orientation">horizontal</property><property name="spacing">8</property><property name="margin-start">12</property><property name="margin-end">12</property><property name="margin-top">6</property><property name="margin-bottom">6</property><property name="halign">center</property><child><object class="GtkImage"><property name="icon-name">speedometer5-symbolic</property><style><class name="dimmed" /></style></object></child><child><object class="GtkLabel"><property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create" /><style><class name="dimmed" /><class name="numeric" /></style></object></child></object>
+                                    </child>
+                                    <child><object class="GtkSeparator"><property name="margin-top">2</property><property name="margin-bottom">2</property></object></child><property name="orientation">vertical</property>
                                     <property name="spacing">4</property>
                                     <property name="margin-start">4</property>
                                     <property name="margin-end">4</property>
@@ -193,17 +197,6 @@
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">keyboard-shortcuts-symbolic</property>
                                             <property name="label" translatable="yes">Shortcuts</property>
-                                          </object>
-                                        </property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="network_speed_label_2">
-                                        <style><class name="flat" /></style>
-                                        <property name="child">
-                                          <object class="AdwButtonContent">
-                                            <property name="icon-name">speedometer5-symbolic</property>
-                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create" />
                                           </object>
                                         </property>
                                       </object>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -167,43 +167,68 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkToggleButton">
+                          <object class="GtkMenuButton">
                             <property name="valign">center</property>
-                            <property name="icon-name">keyboard-shortcuts-symbolic</property>
-                            <property name="tooltip_text" translatable="yes">Shortcuts</property>
-                            <property name="action-name">win.show-help-overlay</property>
+                            <property name="icon-name">view-more-symbolic</property>
+                            <property name="tooltip_text" translatable="yes">More options</property>
                             <style>
                               <class name="flat"/>
                               <class name="circular"/>
                             </style>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="_playlist_button">
-                            <property name="valign">center</property>
-                            <property name="icon-name">view-dual-symbolic</property>
-                            <property name="focusable">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="tooltip_text" translatable="yes">Playlist</property>
-                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes"/>
-                            <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
-                            </style>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="_media_info_button">
-                            <property name="valign">center</property>
-                            <property name="icon-name">help-about-symbolic</property>
-                            <property name="focusable">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="tooltip_text" translatable="yes">Media info (MPV)</property>
-                            <signal name="clicked" handler="on_info_clicked" swapped="yes"/>
-                            <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
-                            </style>
+                            <property name="popover">
+                              <object class="GtkPopover">
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">4</property>
+                                    <property name="margin-start">4</property>
+                                    <property name="margin-end">4</property>
+                                    <property name="margin-top">4</property>
+                                    <property name="margin-bottom">4</property>
+                                    <child>
+                                      <object class="GtkButton">
+                                        <property name="action-name">win.show-help-overlay</property>
+                                        <style><class name="flat"/></style>
+                                        <property name="child">
+                                          <object class="AdwButtonContent">
+                                            <property name="icon-name">keyboard-shortcuts-symbolic</property>
+                                            <property name="label" translatable="yes">Shortcuts</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="_playlist_button">
+                                        <property name="focusable">True</property>
+                                        <property name="receives_default">True</property>
+                                        <signal name="clicked" handler="on_playlist_clicked" swapped="yes"/>
+                                        <style><class name="flat"/></style>
+                                        <property name="child">
+                                          <object class="AdwButtonContent">
+                                            <property name="icon-name">view-dual-symbolic</property>
+                                            <property name="label" translatable="yes">Playlist</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="_media_info_button">
+                                        <property name="focusable">True</property>
+                                        <property name="receives_default">True</property>
+                                        <signal name="clicked" handler="on_info_clicked" swapped="yes"/>
+                                        <style><class name="flat"/></style>
+                                        <property name="child">
+                                          <object class="AdwButtonContent">
+                                            <property name="icon-name">help-about-symbolic</property>
+                                            <property name="label" translatable="yes">Media info</property>
+                                          </object>
+                                        </property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
                           </object>
                         </child>
 

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <interface>
   <template parent="AdwNavigationPage" class="MPVPage">
     <property name="title">Tsukimi</property>
     <child>
       <object class="GtkEventControllerMotion">
-        <signal name="motion" handler="on_motion" swapped="yes"/>
-        <signal name="leave" handler="on_leave" swapped="yes"/>
-        <signal name="enter" handler="on_enter" swapped="yes"/>
+        <signal name="motion" handler="on_motion" swapped="yes" />
+        <signal name="leave" handler="on_leave" swapped="yes" />
+        <signal name="enter" handler="on_enter" swapped="yes" />
       </object>
     </child>
     <child>
@@ -25,19 +25,19 @@
 <child>
               <object class="GtkGestureClick">
                 <property name="button">1</property>
-                <signal name="released" handler="left_click_cb" swapped="yes"/>
+                <signal name="released" handler="left_click_cb" swapped="yes" />
               </object>
             </child>
             <child>
               <object class="GtkGestureClick">
                 <property name="button">3</property>
-                <signal name="released" handler="right_click_cb" swapped="yes"/>
+                <signal name="released" handler="right_click_cb" swapped="yes" />
               </object>
             </child>
             <child>
               <object class="GtkEventControllerScroll">
                 <property name="flags">vertical</property>
-                <signal name="scroll" handler="video_scroll_cb" swapped="yes"/>
+                <signal name="scroll" handler="video_scroll_cb" swapped="yes" />
               </object>
             </child>
                   </object>
@@ -75,7 +75,7 @@
                     <property name="width-request">64</property>
                     <property name="margin-top">20</property>
                     <style>
-                      <class name="accent"/>
+                      <class name="accent" />
                     </style>
                   </object>
                 </child>
@@ -84,8 +84,8 @@
                     <property name="halign">center</property>
                     <property name="margin_bottom">20</property>
                     <style>
-                      <class name="accent"/>
-                      <class name="speed-label"/>
+                      <class name="accent" />
+                      <class name="speed-label" />
                     </style>
                   </object>
                 </child>
@@ -104,7 +104,7 @@
                     <property name="show-start-title-buttons">false</property>
                     <property name="show-end-title-buttons">true</property>
                     <property name="title-widget">
-                      <object class="GtkBox"/>
+                      <object class="GtkBox" />
                     </property>
                     <child type="start">
                       <object class="GtkBox">
@@ -116,10 +116,10 @@
                             <property name="tooltip_text" translatable="yes">Stop and quit</property>
                             <property name="icon-name">arrow4-left-symbolic</property>
                             <property name="valign">center</property>
-                            <signal name="clicked" handler="on_stop_clicked" swapped="yes"/>
+                            <signal name="clicked" handler="on_stop_clicked" swapped="yes" />
                             <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
+                              <class name="flat" />
+                              <class name="circular" />
                             </style>
                           </object>
                         </child>
@@ -139,8 +139,8 @@
                                 <property name="halign">start</property>
                                 <property name="ellipsize">middle</property>
                                 <style>
-                                  <class name="dimmed"/>
-                                  <class name="caption"/>
+                                  <class name="dimmed" />
+                                  <class name="caption" />
                                 </style>
                               </object>
                             </child>
@@ -159,10 +159,10 @@
                             <property name="focusable">True</property>
                             <property name="receives_default">True</property>
                             <property name="tooltip_text" translatable="yes">Playlist</property>
-                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes"/>
+                            <signal name="clicked" handler="on_playlist_clicked" swapped="yes" />
                             <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
+                              <class name="flat" />
+                              <class name="circular" />
                             </style>
                           </object>
                         </child>
@@ -172,8 +172,8 @@
                             <property name="icon-name">view-more-symbolic</property>
                             <property name="tooltip_text" translatable="yes">More options</property>
                             <style>
-                              <class name="flat"/>
-                              <class name="circular"/>
+                              <class name="flat" />
+                              <class name="circular" />
                             </style>
                             <property name="popover">
                               <object class="GtkPopover">
@@ -188,7 +188,7 @@
                                     <child>
                                       <object class="GtkButton">
                                         <property name="action-name">win.show-help-overlay</property>
-                                        <style><class name="flat"/></style>
+                                        <style><class name="flat" /></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">keyboard-shortcuts-symbolic</property>
@@ -199,11 +199,11 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="network_speed_label_2">
-                                        <style><class name="flat"/></style>
+                                        <style><class name="flat" /></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">speedometer5-symbolic</property>
-                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create"/>
+                                            <property name="label" bind-source="network_speed_label" bind-property="label" bind-flags="sync-create" />
                                           </object>
                                         </property>
                                       </object>
@@ -212,8 +212,8 @@
                                       <object class="GtkButton" id="_media_info_button">
                                         <property name="focusable">True</property>
                                         <property name="receives_default">True</property>
-                                        <signal name="clicked" handler="on_info_clicked" swapped="yes"/>
-                                        <style><class name="flat"/></style>
+                                        <signal name="clicked" handler="on_info_clicked" swapped="yes" />
+                                        <style><class name="flat" /></style>
                                         <property name="child">
                                           <object class="AdwButtonContent">
                                             <property name="icon-name">help-about-symbolic</property>
@@ -232,8 +232,8 @@
                       </object>
                     </child>
                     <style>
-                      <class name="flat"/>
-                      <class name="mpv-top-bar"/>
+                      <class name="flat" />
+                      <class name="mpv-top-bar" />
                     </style>
                   </object>
                 </child>
@@ -248,7 +248,7 @@
                 <property name="valign">end</property>
                 <property name="focusable">False</property>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkWindowHandle"><object class="GtkBox">
                     <property name="orientation">vertical</property>
                     <property name="halign">fill</property>
                     <property name="hexpand">True</property>
@@ -267,7 +267,7 @@
                             <property name="valign">center</property>
                             <property name="label">0:00</property>
                             <attributes>
-                              <attribute name="font-features" value="tnum=1"/>
+                              <attribute name="font-features" value="tnum=1" />
                             </attributes>
                           </object>
                         </child>
@@ -279,10 +279,10 @@
                             <property name="draw_value">False</property>
                             <property name="restrict-to-fill-level">False</property>
                             <property name="show-fill-level">True</property>
-                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes"/>
+                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes" />
                             <style>
-                              <class name="accent"/>
-                              <class name="mpv-seekbar"/>
+                              <class name="accent" />
+                              <class name="mpv-seekbar" />
                             </style>
                           </object>
                         </child>
@@ -293,7 +293,7 @@
                             <property name="valign">center</property>
                             <property name="label">0:00</property>
                             <attributes>
-                              <attribute name="font-features" value="tnum=1"/>
+                              <attribute name="font-features" value="tnum=1" />
                             </attributes>
                           </object>
                         </child>
@@ -303,16 +303,69 @@
                       <object class="GtkCenterBox">
                         <child type="start">
                           <object class="GtkBox">
-                            <property name="orientation">horizontal</property>
-                            <property name="spacing">10</property>
                             <child>
+                                  <object class="GtkMenuButton" id="volume_button">
+                                    <property name="popover">volume_adj_popover</property>
+                                    <property name="icon-name">audio-volume-high-symbolic</property>
+                                    <property name="tooltip-text" translatable="yes">Adjust Volume</property>
+                                    <property name="valign">center</property>
+                                    <style>
+                                      <class name="flat" />
+                                      <class name="circular" />
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkMenuButton" id="audio_tracks_menu_button">
+                                    <property name="popover">audio_tracks_popover</property>
+                                    <property name="icon-name">audio-x-generic-symbolic</property>
+                                    <property name="tooltip-text" translatable="yes">Audio</property>
+                                    <property name="valign">center</property>
+                                    <style>
+                                      <class name="flat" />
+                                      <class name="circular" />
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkMenuButton" id="subtitle_tracks_menu_button">
+                                    <property name="popover">subtitle_tracks_popover</property>
+                                    <property name="icon-name">media-view-subtitles-symbolic</property>
+                                    <property name="tooltip-text" translatable="yes">Subtitle</property>
+                                    <property name="valign">center</property>
+                                    <style>
+                                      <class name="flat" />
+                                      <class name="circular" />
+                                    </style>
+                                  </object>
+                                </child>
+                                <child>
+                              <object class="GtkButton" id="playback_speed_indicator">
+                                <property name="valign">center</property>
+                                <property name="margin-end">6</property>
+                                <property name="visible">false</property>
+                                <signal name="clicked" handler="playback_speed_indicator_cb" swapped="yes" />
+                                <property name="child">
+                                  <object class="AdwButtonContent" id="playback_speed_button_content">
+                                    <property name="icon-name">playback-options-symbolic</property>
+                                  </object>
+                                </property>
+                                <style>
+                                  <class name="accent" />
+                                  <class name="monospace" />
+                                </style>
+                              </object>
+                            </child>
+                            </object>
+                        </child>
+                        <child type="center"><object class="GtkBox"><property name="orientation">horizontal</property><property name="spacing">10</property><child>
                               <object class="GtkButton" id="_previous_button">
                                 <property name="icon-name">media-skip-backward-symbolic</property>
                                 <property name="action-name">mpv.previous-video</property>
                                 <property name="valign">center</property>
                                 <style>
-                                  <class name="flat"/>
-                                  <class name="circular"/>
+                                  <class name="flat" />
+                                  <class name="circular" />
                                 </style>
                               </object>
                             </child>
@@ -330,8 +383,8 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="circular"/>
-                                  <class name="flat"/>
+                                  <class name="circular" />
+                                  <class name="flat" />
                                 </style>
                               </object>
                             </child>
@@ -343,7 +396,7 @@
                                 <property name="receives_default">True</property>
                                 <property name="valign">center</property>
                                 <property name="tooltip_text" translatable="yes">Pause</property>
-                                <signal name="clicked" handler="on_play_pause_clicked" swapped="yes"/>
+                                <signal name="clicked" handler="on_play_pause_clicked" swapped="yes" />
                                 <child>
                                   <object class="GtkImage" id="play_pause_image">
                                     <property name="icon_name">media-playback-pause-symbolic</property>
@@ -353,9 +406,9 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="flat"/>
-                                  <class name="mpv-play-button"/>
-                                  <class name="circular"/>
+                                  <class name="flat" />
+                                  <class name="mpv-play-button" />
+                                  <class name="circular" />
                                 </style>
                               </object>
                             </child>
@@ -373,8 +426,8 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="circular"/>
-                                  <class name="flat"/>
+                                  <class name="circular" />
+                                  <class name="flat" />
                                 </style>
                               </object>
                             </child>
@@ -384,85 +437,22 @@
                                 <property name="action-name">mpv.next-video</property>
                                 <property name="valign">center</property>
                                 <style>
-                                  <class name="flat"/>
-                                  <class name="circular"/>
+                                  <class name="flat" />
+                                  <class name="circular" />
                                 </style>
                               </object>
                             </child>
-                          </object>
-                        </child>
-                        <child type="end">
+                          </object></child><child type="end">
                           <object class="GtkBox">
-                            <property name="orientation">horizontal</property>
-                            <property name="spacing">6</property>
-                            <property name="valign">center</property>
                             <child>
-                              <object class="GtkButton" id="playback_speed_indicator">
-                                <property name="valign">center</property>
-                                <property name="margin-end">6</property>
-                                <property name="visible">false</property>
-                                <signal name="clicked" handler="playback_speed_indicator_cb" swapped="yes"/>
-                                <property name="child">
-                                  <object class="AdwButtonContent" id="playback_speed_button_content">
-                                    <property name="icon-name">playback-options-symbolic</property>
-                                  </object>
-                                </property>
-                                <style>
-                                  <class name="accent"/>
-                                  <class name="monospace"/>
-                                </style>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="orientation">horizontal</property>
-                                <property name="spacing">2</property>
-                                <property name="valign">center</property>
-                                <child>
-                                  <object class="GtkMenuButton" id="audio_tracks_menu_button">
-                                    <property name="popover">audio_tracks_popover</property>
-                                    <property name="icon-name">audio-x-generic-symbolic</property>
-                                    <property name="tooltip-text" translatable="yes">Audio</property>
-                                    <property name="valign">center</property>
-                                    <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkMenuButton" id="subtitle_tracks_menu_button">
-                                    <property name="popover">subtitle_tracks_popover</property>
-                                    <property name="icon-name">media-view-subtitles-symbolic</property>
-                                    <property name="tooltip-text" translatable="yes">Subtitle</property>
-                                    <property name="valign">center</property>
-                                    <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkMenuButton" id="volume_button">
-                                    <property name="popover">volume_adj_popover</property>
-                                    <property name="icon-name">audio-volume-high-symbolic</property>
-                                    <property name="tooltip-text" translatable="yes">Adjust Volume</property>
-                                    <property name="valign">center</property>
-                                    <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
                                   <object class="GtkMenuButton" id="danmaku_button">
                                     <property name="popover">danmaku_popover</property>
                                     <property name="icon-name">card-bulleted-symbolic</property>
                                     <property name="tooltip-text" translatable="yes">Danmaku</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
@@ -473,30 +463,14 @@
                                     <property name="tooltip-text" translatable="yes">Advanced settings</property>
                                     <property name="valign">center</property>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkButton">
-                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create|invert-boolean"/>
-                                    <property name="icon-name">view-fullscreen-symbolic</property>
-                                    <property name="action-name">win.toggle-fullscreen</property>
-                                    <property name="tooltip-text" translatable="yes">Fullscreen</property>
-                                    <property name="valign">center</property>
-                                    <accessibility>
-                                      <property name="label" translatable="yes">Fullscreen</property>
-                                    </accessibility>
-                                    <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkButton">
-                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create"/>
+                                    <property name="visible" bind-source="MPVPage" bind-property="fullscreened" bind-flags="sync-create" />
                                     <property name="icon-name">view-restore-symbolic</property>
                                     <property name="action-name">win.toggle-fullscreen</property>
                                     <property name="valign">center</property>
@@ -505,22 +479,20 @@
                                       <property name="label" translatable="yes">Exit Fullscreen</property>
                                     </accessibility>
                                     <style>
-                                      <class name="flat"/>
-                                      <class name="circular"/>
+                                      <class name="flat" />
+                                      <class name="circular" />
                                     </style>
                                   </object>
                                 </child>
                               </object>
-                            </child>
-                          </object>
                         </child>
                       </object>
                     </child>
                     <style>
-                      <class name="mpv-bottom-bar"/>
+                      <class name="mpv-bottom-bar" />
                     </style>
                   </object>
-                </child>
+                </object></child>
               </object>
             </child>
             <child type="overlay">
@@ -534,9 +506,9 @@
                 <property name="margin-bottom">172</property>
                 <child>
                   <object class="GtkButton" id="skip_segment_button">
-                    <signal name="clicked" handler="on_skip_segment_clicked" swapped="yes"/>
+                    <signal name="clicked" handler="on_skip_segment_clicked" swapped="yes" />
                     <style>
-                      <class name="osd"/>
+                      <class name="osd" />
                     </style>
                   </object>
                 </child>
@@ -552,8 +524,8 @@
     <property name="width-request">320</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="GtkScrolledWindow">
         <child>
@@ -561,7 +533,7 @@
             <property name="selection-mode">single</property>
             <property name="valign">start</property>
             <style>
-              <class name="boxed-list-separate"/>
+              <class name="boxed-list-separate" />
             </style>
           </object>
         </child>
@@ -573,8 +545,8 @@
     <property name="width-request">320</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="GtkScrolledWindow">
         <child>
@@ -582,7 +554,7 @@
             <property name="selection-mode">single</property>
             <property name="valign">start</property>
             <style>
-              <class name="boxed-list-separate"/>
+              <class name="boxed-list-separate" />
             </style>
           </object>
         </child>
@@ -592,8 +564,8 @@
   <object class="GtkPopover" id="volume_adj_popover">
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="GtkScale" id="volume_scale">
         <property name="adjustment">volume_adj</property>
@@ -603,9 +575,9 @@
         <property name="draw-value">false</property>
         <property name="orientation">vertical</property>
         <property name="inverted">true</property>
-        <signal name="value-changed" handler="on_volume_scale_value_changed" swapped="yes"/>
+        <signal name="value-changed" handler="on_volume_scale_value_changed" swapped="yes" />
         <style>
-          <class name="accent"/>
+          <class name="accent" />
         </style>
       </object>
     </child>
@@ -614,14 +586,14 @@
     <property name="width-request">400</property>
     <property name="position">top</property>
     <property name="has-arrow">true</property>
-    <signal name="map" handler="on_popover_opened" swapped="yes"/>
-    <signal name="unmap" handler="on_popover_closed" swapped="yes"/>
+    <signal name="map" handler="on_popover_opened" swapped="yes" />
+    <signal name="unmap" handler="on_popover_closed" swapped="yes" />
     <child>
       <object class="AdwClamp">
         <property name="maximum-size">400</property>
         <property name="tightening-threshold">400</property>
         <child>
-          <object class="DanmakuPopover" id="danmaku_popover_content"/>
+          <object class="DanmakuPopover" id="danmaku_popover_content" />
         </child>
       </object>
     </child>
@@ -699,19 +671,19 @@
   <object class="GtkSizeGroup">
     <property name="mode">vertical</property>
     <widgets>
-      <widget name="_play_button"/>
-      <widget name="progress_time_label"/>
-      <widget name="video_scale"/>
-      <widget name="duration_label"/>
+      <widget name="_play_button" />
+      <widget name="progress_time_label" />
+      <widget name="video_scale" />
+      <widget name="duration_label" />
     </widgets>
   </object>
   <object class="GtkSizeGroup">
     <property name="mode">vertical</property>
     <widgets>
-      <widget name="_back_button"/>
-      <widget name="network_speed_label_2"/>
-      <widget name="_media_info_button"/>
-      <widget name="_playlist_button"/>
+      <widget name="_back_button" />
+      <widget name="network_speed_label_2" />
+      <widget name="_media_info_button" />
+      <widget name="_playlist_button" />
     </widgets>
   </object>
 </interface>

--- a/crates/tsukimi/resources/ui/mpvpage.ui
+++ b/crates/tsukimi/resources/ui/mpvpage.ui
@@ -17,19 +17,11 @@
               <object class="MPVPlaySink" id="video">
                 <property name="hexpand">true</property>
                 <property name="vexpand">true</property>
-              </object>
-            </child>
-            <child type="overlay">
-              <object class="Danmakw" id="danmakw">
-                <property name="hexpand">true</property>
-                <property name="vexpand">true</property>
-                <property name="visible">false</property>
-              </object>
-            </child>
-            <child>
+              
+<child>
               <object class="GtkGestureClick">
                 <property name="button">1</property>
-                <signal name="released" handler="left_click_cb" swapped="yes"/>
+                <signal name="pressed" handler="left_click_cb" swapped="yes"/>
               </object>
             </child>
             <child>
@@ -44,6 +36,16 @@
                 <signal name="scroll" handler="video_scroll_cb" swapped="yes"/>
               </object>
             </child>
+              </object>
+            </child>
+            <child type="overlay">
+              <object class="Danmakw" id="danmakw">
+                <property name="hexpand">true</property>
+                <property name="vexpand">true</property>
+                <property name="visible">false</property>
+              </object>
+            </child>
+            
             <child type="overlay">
               <object class="VolumeBar" id="volume_bar">
                 <property name="halign">start</property>
@@ -94,7 +96,7 @@
                 <child>
                   <object class="AdwHeaderBar">
                     <property name="show-start-title-buttons">false</property>
-                    <property name="show-end-title-buttons">false</property>
+                    <property name="show-end-title-buttons">true</property>
                     <property name="title-widget">
                       <object class="GtkBox"/>
                     </property>
@@ -198,14 +200,7 @@
                             </style>
                           </object>
                         </child>
-                        <child>
-                          <object class="GtkWindowControls">
-                            <property name="side">end</property>
-                            <style>
-                              <class name="flat"/>
-                            </style>
-                          </object>
-                        </child>
+
                       </object>
                     </child>
                     <style>
@@ -233,6 +228,49 @@
                     <property name="margin-bottom">0</property>
                     <property name="margin-start">0</property>
                     <property name="margin-end">0</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="orientation">horizontal</property>
+                        <property name="spacing">8</property>
+                        <child>
+                          <object class="GtkLabel" id="progress_time_label">
+                            <property name="focusable">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <property name="label">0:00</property>
+                            <attributes>
+                              <attribute name="font-features" value="tnum=1"/>
+                            </attributes>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="VideoScale" id="video_scale">
+                            <property name="focusable">True</property>
+                            <property name="valign">center</property>
+                            <property name="hexpand">True</property>
+                            <property name="draw_value">False</property>
+                            <property name="restrict-to-fill-level">False</property>
+                            <property name="show-fill-level">True</property>
+                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes"/>
+                            <style>
+                              <class name="accent"/>
+                              <class name="mpv-seekbar"/>
+                            </style>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="duration_label">
+                            <property name="focusable">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">center</property>
+                            <property name="label">0:00</property>
+                            <attributes>
+                              <attribute name="font-features" value="tnum=1"/>
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                     <child>
                       <object class="GtkCenterBox">
                         <child type="start">
@@ -446,49 +484,6 @@
                                 </child>
                               </object>
                             </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="orientation">horizontal</property>
-                        <property name="spacing">8</property>
-                        <child>
-                          <object class="GtkLabel" id="progress_time_label">
-                            <property name="focusable">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <property name="label">0:00</property>
-                            <attributes>
-                              <attribute name="font-features" value="tnum=1"/>
-                            </attributes>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="VideoScale" id="video_scale">
-                            <property name="focusable">True</property>
-                            <property name="valign">center</property>
-                            <property name="hexpand">True</property>
-                            <property name="draw_value">False</property>
-                            <property name="restrict-to-fill-level">False</property>
-                            <property name="show-fill-level">True</property>
-                            <signal name="value-changed" handler="on_progress_value_changed" swapped="yes"/>
-                            <style>
-                              <class name="accent"/>
-                              <class name="mpv-seekbar"/>
-                            </style>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="duration_label">
-                            <property name="focusable">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <property name="label">0:00</property>
-                            <attributes>
-                              <attribute name="font-features" value="tnum=1"/>
-                            </attributes>
                           </object>
                         </child>
                       </object>

--- a/crates/tsukimi/resources/ui/window.ui
+++ b/crates/tsukimi/resources/ui/window.ui
@@ -198,7 +198,7 @@
                                   <object class="AdwToolbarView">
                                     <child type="top">
                                       <object class="AdwHeaderBar">
-                                        <property name="show-start-title-buttons">false</property>
+                                        <property name="show-start-title-buttons">true</property>
                                         <child type="start">
                                           <object class="GtkToggleButton" id="backbutton">
                                             <property name="icon-name">system-log-out-symbolic</property>
@@ -402,7 +402,7 @@
                                   <object class="AdwToolbarView">
                                     <child type="top">
                                       <object class="AdwHeaderBar">
-                                        <property name="show-end-title-buttons">false</property>
+                                        <property name="show-end-title-buttons">true</property>
                                         <property name="title-widget">
                                           <object class="AdwViewSwitcher">
                                             <property name="stack">mpv_view_stack</property>

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -178,6 +178,8 @@ mod imp {
         pub fullscreened: Cell<bool>,
         #[property(get, set = Self::set_paused)]
         pub paused: Cell<bool>,
+        #[property(get, set = Self::set_compact_mode, explicit_notify)]
+        pub compact_mode: Cell<bool>,
         #[template_child]
         pub video: TemplateChild<MPVPlaySink>,
         #[template_child]
@@ -186,6 +188,14 @@ mod imp {
         pub danmaku_popover_content: TemplateChild<DanmakuPopover>,
         #[template_child]
         pub bottom_revealer: TemplateChild<gtk::Revealer>,
+        #[template_child]
+        pub center_box: TemplateChild<gtk::CenterBox>,
+        #[template_child]
+        pub right_group_box: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub right_wrapper_box: TemplateChild<gtk::Box>,
+        #[template_child]
+        pub mobile_popover_box: TemplateChild<gtk::Box>,
         #[template_child]
         pub top_revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
@@ -407,6 +417,26 @@ mod imp {
     impl adw::subclass::navigation_page::NavigationPageImpl for MPVPage {}
 
     impl MPVPage {
+    fn set_compact_mode(&self, compact: bool) {
+        if self.compact_mode.get() == compact {
+            return;
+        }
+        self.compact_mode.set(compact);
+        
+        let imp = self;
+        if compact {
+            imp.right_wrapper_box.remove(&*imp.right_group_box);
+            imp.mobile_popover_box.append(&*imp.right_group_box);
+            imp.right_group_box.set_orientation(gtk::Orientation::Vertical);
+        } else {
+            imp.mobile_popover_box.remove(&*imp.right_group_box);
+            imp.right_wrapper_box.prepend(&*imp.right_group_box);
+            imp.right_group_box.set_orientation(gtk::Orientation::Horizontal);
+        }
+        
+        self.obj().notify_compact_mode();
+    }
+
         fn set_fullscreened(&self, fullscreened: bool) {
             if fullscreened == self.fullscreened.get() {
                 return;

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -1789,8 +1789,19 @@ impl MPVPage {
     }
 
     #[template_callback]
-    fn left_click_cb(&self) {
-        self.imp().video.pause();
+    fn left_click_cb(&self, n_press: i32, _x: f64, _y: f64) {
+        if n_press == 1 {
+            self.imp().video.pause();
+        } else if n_press == 2 {
+            let binding = self.root();
+            if let Some(window) = binding.and_downcast_ref::<Window>() {
+                if window.is_fullscreen() {
+                    window.unfullscreen();
+                } else {
+                    window.fullscreen();
+                }
+            }
+        }
     }
 
     #[template_callback]

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -1793,6 +1793,7 @@ impl MPVPage {
         if n_press == 1 {
             self.imp().video.pause();
         } else if n_press == 2 {
+            self.imp().video.pause(); // Revert the pause from the first click
             let binding = self.root();
             if let Some(window) = binding.and_downcast_ref::<Window>() {
                 if window.is_fullscreen() {

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -209,6 +209,8 @@ mod imp {
         #[template_child]
         pub network_speed_label_2: TemplateChild<gtk::Button>,
         #[template_child]
+        pub danmaku_button: TemplateChild<gtk::MenuButton>,
+        #[template_child]
         pub playback_speed_indicator: TemplateChild<gtk::Button>,
         #[template_child]
         pub playback_speed_button_content: TemplateChild<adw::ButtonContent>,
@@ -353,6 +355,15 @@ mod imp {
             SETTINGS
                 .bind("mpv-default-volume", &self.volume_adj.get(), "value")
                 .build();
+
+            SETTINGS
+                .bind(
+                    "is-danmaku-enabled",
+                    &self.danmaku_button.get(),
+                    "visible"
+                )
+                .build();
+
 
             self.video_scale.set_player(Some(&self.video.get()));
 

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -217,7 +217,7 @@ mod imp {
         #[template_child]
         pub network_speed_label: TemplateChild<gtk::Label>,
         #[template_child]
-        pub network_speed_label_2: TemplateChild<gtk::Button>,
+        pub network_speed_label_2: TemplateChild<gtk::Box>,
         #[template_child]
         pub danmaku_button: TemplateChild<gtk::MenuButton>,
         #[template_child]


### PR DESCRIPTION
This PR introduces several quality-of-life UI improvements for the MPV playback page:
1. **Window Controls Fix:** Removed the custom `GtkWindowControls` from the bottom toolbar and enabled native `show-end-title-buttons` on the `AdwHeaderBar`. Removed excessive CSS padding that created dead zones and prevented window dragging at the edges.
2. **Double-click Fullscreen:** Added double-click-to-toggle-fullscreen functionality directly on the video player overlay.
3. **Toolbar Layout:** Swapped the vertical layout order in the bottom revealer so the timeline/progress bar appears *above* the playback controls, matching standard video player layouts.
4. **Click Event Fix:** Moved the `GtkGestureClick` controllers from the global `GtkOverlay` down into the `MPVPlaySink`. This prevents accidental pauses or fullscreen toggles when clicking on empty space inside the toolbars.