### PR TITLE
feat: prefer direct playback and add LiveTV server fallback

### DIFF
--- a/crates/tsukimi/src/client/jellyfin_client.rs
+++ b/crates/tsukimi/src/client/jellyfin_client.rs
@@ -780,7 +780,6 @@ impl JellyfinClient {
             ("IsPlayback", &is_playback.to_string()),
             ("MediaSourceId", &media_source_id.unwrap_or_default()),
             ("SubtitleStreamIndex", &subtitle_stream_index),
-            ("MaxStreamingBitrate", "2147483647"),
         ];
         let profile: Value = serde_json::from_str(PROFILE).expect("Failed to parse profile");
         self.post_json(&path, &params, profile).await

--- a/crates/tsukimi/src/client/jellyfin_client.rs
+++ b/crates/tsukimi/src/client/jellyfin_client.rs
@@ -12,10 +12,7 @@ use crate::{
         ServerType,
         build_url,
     },
-    ui::{
-        PlaybackDirectMode,
-        provider::tu_item::image_type::BACKDROP,
-    },
+    ui::provider::tu_item::image_type::BACKDROP,
 };
 use anyhow::{
     Context,
@@ -771,7 +768,7 @@ impl JellyfinClient {
 
     pub async fn get_playbackinfo(
         &self, id: &str, sub_stream_index: Option<i64>, media_source_id: Option<String>,
-        is_playback: bool, direct_mode: PlaybackDirectMode,
+        is_playback: bool,
     ) -> Result<Media> {
         let s = self.session();
         let path = format!("Items/{id}/PlaybackInfo");
@@ -784,14 +781,6 @@ impl JellyfinClient {
             ("MediaSourceId", &media_source_id.unwrap_or_default()),
             ("SubtitleStreamIndex", &subtitle_stream_index),
             ("MaxStreamingBitrate", "2147483647"),
-            (
-                "EnableDirectPlay",
-                &direct_mode.enable_direct_play.to_string(),
-            ),
-            (
-                "EnableDirectStream",
-                &direct_mode.enable_direct_stream.to_string(),
-            ),
         ];
         let profile: Value = serde_json::from_str(PROFILE).expect("Failed to parse profile");
         self.post_json(&path, &params, profile).await

--- a/crates/tsukimi/src/client/jellyfin_client.rs
+++ b/crates/tsukimi/src/client/jellyfin_client.rs
@@ -410,8 +410,8 @@ impl JellyfinClient {
             .await?)
     }
 
-    pub async fn get_item_stream_url(
-        &self, container: &str, item_id: &str, media_source_id: &str,
+    pub async fn get_item_direct_play_url(
+        &self, container: &str, item_id: &str, media_source_id: &str, play_session_id: Option<&str>,
     ) -> Result<String> {
         let s = self.session();
         let (url, _) = s.url_headers.as_ref().context("Client not initialized")?;
@@ -422,6 +422,9 @@ impl JellyfinClient {
             .append_pair("Static", "true")
             .append_pair("deviceId", &DEVICE_ID)
             .append_pair("MediaSourceId", media_source_id);
+        if let Some(play_session_id) = play_session_id {
+            query_pairs.append_pair("PlaySessionId", play_session_id);
+        }
         match self.server_type() {
             ServerType::Emby => {
                 query_pairs.append_pair("api_key", &s.account.access_token);
@@ -770,17 +773,46 @@ impl JellyfinClient {
         &self, id: &str, sub_stream_index: Option<i64>, media_source_id: Option<String>,
         is_playback: bool,
     ) -> Result<Media> {
+        self.get_playbackinfo_inner(
+            id,
+            sub_stream_index,
+            media_source_id.as_deref(),
+            None,
+            is_playback,
+            false,
+        )
+        .await
+    }
+
+    pub async fn get_fallback_playbackinfo(
+        &self, id: &str, media_source_id: &str, live_stream_id: Option<&str>,
+    ) -> Result<Media> {
+        self.get_playbackinfo_inner(id, None, Some(media_source_id), live_stream_id, true, true)
+            .await
+    }
+
+    async fn get_playbackinfo_inner(
+        &self, id: &str, sub_stream_index: Option<i64>, media_source_id: Option<&str>,
+        live_stream_id: Option<&str>, is_playback: bool, disable_direct_play: bool,
+    ) -> Result<Media> {
         let s = self.session();
         let path = format!("Items/{id}/PlaybackInfo");
         let subtitle_stream_index = sub_stream_index.map(|s| s.to_string()).unwrap_or_default();
-        let params = [
+        let is_playback = is_playback.to_string();
+        let mut params = vec![
             ("StartTimeTicks", "0"),
             ("UserId", &s.account.user_id),
             ("AutoOpenLiveStream", "true"),
-            ("IsPlayback", &is_playback.to_string()),
-            ("MediaSourceId", &media_source_id.unwrap_or_default()),
+            ("IsPlayback", &is_playback),
+            ("MediaSourceId", media_source_id.unwrap_or_default()),
             ("SubtitleStreamIndex", &subtitle_stream_index),
         ];
+        if let Some(live_stream_id) = live_stream_id {
+            params.push(("LiveStreamId", live_stream_id));
+        }
+        if disable_direct_play {
+            params.push(("EnableDirectPlay", "false"));
+        }
         let profile: Value = serde_json::from_str(PROFILE).expect("Failed to parse profile");
         self.post_json(&path, &params, profile).await
     }
@@ -872,7 +904,7 @@ impl JellyfinClient {
         self.request(&path, &params).await
     }
 
-    pub async fn get_streaming_url(&self, path: &str) -> String {
+    pub fn resolve_url(&self, path: &str) -> String {
         let s = self.session();
         let (url, _) = s.url_headers.as_ref().expect("Client not initialized");
         url.join(path.trim_start_matches('/')).unwrap().to_string()

--- a/crates/tsukimi/src/client/stream_profile.json
+++ b/crates/tsukimi/src/client/stream_profile.json
@@ -58,99 +58,20 @@
                 "Method": "External"
             }
         ],
-        "CodecProfiles": [
-            {
-                "Codec": "h264",
-                "Type": "Video",
-                "ApplyConditions": [
-                    {
-                        "Property": "IsAnamorphic",
-                        "Value": "true",
-                        "Condition": "NotEquals",
-                        "IsRequired": false
-                    },
-                    {
-                        "IsRequired": false,
-                        "Value": "high|main|baseline|constrained baseline",
-                        "Condition": "EqualsAny",
-                        "Property": "VideoProfile"
-                    },
-                    {
-                        "IsRequired": false,
-                        "Value": "80",
-                        "Condition": "LessThanEqual",
-                        "Property": "VideoLevel"
-                    },
-                    {
-                        "IsRequired": false,
-                        "Value": "true",
-                        "Condition": "NotEquals",
-                        "Property": "IsInterlaced"
-                    }
-                ]
-            },
-            {
-                "Codec": "hevc",
-                "ApplyConditions": [
-                    {
-                        "Property": "IsAnamorphic",
-                        "Value": "true",
-                        "Condition": "NotEquals",
-                        "IsRequired": false
-                    },
-                    {
-                        "IsRequired": false,
-                        "Value": "high|main|main 10",
-                        "Condition": "EqualsAny",
-                        "Property": "VideoProfile"
-                    },
-                    {
-                        "Property": "VideoLevel",
-                        "Value": "175",
-                        "Condition": "LessThanEqual",
-                        "IsRequired": false
-                    },
-                    {
-                        "IsRequired": false,
-                        "Value": "true",
-                        "Condition": "NotEquals",
-                        "Property": "IsInterlaced"
-                    }
-                ],
-                "Type": "Video"
-            }
-        ],
-        "MaxStreamingBitrate": 120000000,
+        "CodecProfiles": [],
+        "MaxStreamingBitrate": 2147483647,
         "DirectPlayProfiles": [
             {
-                "Container": "mov,fmp4,mp3,mpegts,flac,3gp,aac,flv,ogg,wav,mp4,mkv,ts,hls,webm,webma",
-                "Type": "Video",
-                "VideoCodec": "h263,av1,mpeg4,h264,mpeg1video,mpeg2video,hevc,dvhe,dvh1,h264,hevc,hev1,mpeg4,vp8,vp9",
-                "AudioCodec": "aac,mp1,alac,mp2,mp4als,mp3,vorbis,wav,ac3,eac3,mlp,flac,truehd,dts,dca,opus,pcm,pcm_s24le,pcm_s8,pcm_s16be,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,pcm_alaw,pcm_mulaw,webma"
+                "Container": "3g2,3gp,3gp2,3gpp,amv,asf,avi,divx,drc,dv,f4a,f4b,f4p,f4v,flv,gxf,iso,m1v,m2v,m2t,m2ts,m4v,mkv,mov,mp2,mp2v,mp4,mp4v,mpe,mpeg,mpeg1video,mpeg2video,mpeg4,mpg,mpv2,mts,mtv,mxf,mxg,nsv,nuv,ogg,ogm,ogv,ogx,ps,rec,rm,rmvb,rpl,thp,tod,ts,tts,txd,vob,vro,webm,wm,wmv,wtv,xesc,aac,ac3,aiff,alac,ape,dts,flac,m4a,m4b,mka,mp3,oga,ogg,opus,ra,vqf,wav,wma,wv,mov,fmp4,mp3,mpegts,flac,3gp,aac,flv,ogg,wav,mp4,mkv,ts,hls,webm,webma",
+                "Type": "Video,Audio",
+                "VideoCodec": "*",
+                "AudioCodec": "*"
             }
         ],
-        "TranscodingProfiles": [
-            {
-                "Container": "ts",
-                "AudioCodec": "aac,mp3,wav,ac3,eac3,flac,opus",
-                "VideoCodec": "hevc,h264,mpeg4",
-                "BreakOnNonKeyFrames": true,
-                "Type": "Video",
-                "MaxAudioChannels": "6",
-                "Protocol": "hls",
-                "Context": "Streaming",
-                "MinSegments": 2
-            }
-        ],
-        "ResponseProfiles": [
-            {
-                "MimeType": "video/mp4",
-                "Type": "Video",
-                "Container": "m4v"
-            }
-        ],
+        "TranscodingProfiles": [],
+        "ResponseProfiles": [],
         "ContainerProfiles": [],
         "MusicStreamingTranscodingBitrate": 120000000,
-        "MaxStaticBitrate": 120000000
+        "MaxStaticBitrate": 2147483647
     }
 }

--- a/crates/tsukimi/src/client/stream_profile.json
+++ b/crates/tsukimi/src/client/stream_profile.json
@@ -1,77 +1,93 @@
 {
-    "DeviceProfile": {
-        "SubtitleProfiles": [
-            {
-                "Method": "Embed",
-                "Format": "ass"
-            },
-            {
-                "Format": "ssa",
-                "Method": "Embed"
-            },
-            {
-                "Format": "subrip",
-                "Method": "Embed"
-            },
-            {
-                "Format": "sub",
-                "Method": "Embed"
-            },
-            {
-                "Method": "Embed",
-                "Format": "pgssub"
-            },
-            {
-                "Method": "Embed",
-                "Format": "DVDSUB"
-            },
-            {
-                "Method": "Embed",
-                "Format": "VOBSUB"
-            },
-            {
-                "Format": "subrip",
-                "Method": "External"
-            },
-            {
-                "Method": "External",
-                "Format": "sub"
-            },
-            {
-                "Method": "External",
-                "Format": "ass"
-            },
-            {
-                "Format": "ssa",
-                "Method": "External"
-            },
-            {
-                "Method": "External",
-                "Format": "vtt"
-            },
-            {
-                "Method": "External",
-                "Format": "ass"
-            },
-            {
-                "Format": "ssa",
-                "Method": "External"
-            }
-        ],
-        "CodecProfiles": [],
-        "MaxStreamingBitrate": 2147483647,
-        "DirectPlayProfiles": [
-            {
-                "Container": "3g2,3gp,3gp2,3gpp,amv,asf,avi,divx,drc,dv,f4a,f4b,f4p,f4v,flv,gxf,iso,m1v,m2v,m2t,m2ts,m4v,mkv,mov,mp2,mp2v,mp4,mp4v,mpe,mpeg,mpeg1video,mpeg2video,mpeg4,mpg,mpv2,mts,mtv,mxf,mxg,nsv,nuv,ogg,ogm,ogv,ogx,ps,rec,rm,rmvb,rpl,thp,tod,ts,tts,txd,vob,vro,webm,wm,wmv,wtv,xesc,aac,ac3,aiff,alac,ape,dts,flac,m4a,m4b,mka,mp3,oga,ogg,opus,ra,vqf,wav,wma,wv,mov,fmp4,mp3,mpegts,flac,3gp,aac,flv,ogg,wav,mp4,mkv,ts,hls,webm,webma",
-                "Type": "Video,Audio",
-                "VideoCodec": "*",
-                "AudioCodec": "*"
-            }
-        ],
-        "TranscodingProfiles": [],
-        "ResponseProfiles": [],
-        "ContainerProfiles": [],
-        "MusicStreamingTranscodingBitrate": 120000000,
-        "MaxStaticBitrate": 2147483647
-    }
+  "DeviceProfile": {
+    "SubtitleProfiles": [
+      {
+        "Format": "ass",
+        "Method": "Embed"
+      },
+      {
+        "Format": "ass",
+        "Method": "External"
+      },
+      {
+        "Format": "dvbsub",
+        "Method": "Embed"
+      },
+      {
+        "Format": "dvdsub",
+        "Method": "Embed"
+      },
+      {
+        "Format": "pgs",
+        "Method": "Embed"
+      },
+      {
+        "Format": "pgssub",
+        "Method": "Embed"
+      },
+      {
+        "Format": "smi",
+        "Method": "Embed"
+      },
+      {
+        "Format": "smi",
+        "Method": "External"
+      },
+      {
+        "Format": "srt",
+        "Method": "Embed"
+      },
+      {
+        "Format": "srt",
+        "Method": "External"
+      },
+      {
+        "Format": "ssa",
+        "Method": "Embed"
+      },
+      {
+        "Format": "ssa",
+        "Method": "External"
+      },
+      {
+        "Format": "sub",
+        "Method": "Embed"
+      },
+      {
+        "Format": "sub",
+        "Method": "External"
+      },
+      {
+        "Format": "subrip",
+        "Method": "Embed"
+      },
+      {
+        "Format": "subrip",
+        "Method": "External"
+      },
+      {
+        "Format": "vobsub",
+        "Method": "Embed"
+      },
+      {
+        "Format": "vtt",
+        "Method": "External"
+      }
+    ],
+    "CodecProfiles": [],
+    "MaxStreamingBitrate": 2147483647,
+    "DirectPlayProfiles": [
+      {
+        "Type": "Audio"
+      },
+      {
+        "Type": "Video"
+      }
+    ],
+    "TranscodingProfiles": [],
+    "ResponseProfiles": [],
+    "ContainerProfiles": [],
+    "MusicStreamingTranscodingBitrate": 120000000,
+    "MaxStaticBitrate": 2147483647
+  }
 }

--- a/crates/tsukimi/src/client/stream_profile.json
+++ b/crates/tsukimi/src/client/stream_profile.json
@@ -84,7 +84,18 @@
         "Type": "Video"
       }
     ],
-    "TranscodingProfiles": [],
+    "TranscodingProfiles": [
+      {
+        "Container": "ts",
+        "AudioCodec": "aac,ac3,eac3,mp3",
+        "VideoCodec": "h264,hevc,vp9,av1",
+        "BreakOnNonKeyFrames": true,
+        "Type": "Video",
+        "Protocol": "hls",
+        "Context": "Streaming",
+        "MinSegments": 1
+      }
+    ],
     "ResponseProfiles": [],
     "ContainerProfiles": [],
     "MusicStreamingTranscodingBitrate": 120000000,

--- a/crates/tsukimi/src/ui/mod.rs
+++ b/crates/tsukimi/src/ui/mod.rs
@@ -20,8 +20,6 @@ pub use widgets::{
     window::Window,
 };
 
-pub use mpv::page::PlaybackDirectMode;
-
 pub fn init() {
     widgets::fixed_bin::FixedBin::ensure_type();
     widgets::lazy_diff_view::LazyDiffView::ensure_type();

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -15,6 +15,7 @@ use gtk::{
 };
 use itertools::Itertools;
 use mutsumi::*;
+use url::Url;
 
 use super::{
     DanmakuPopoverStatus,
@@ -86,6 +87,11 @@ impl MpvTrackKind {
     }
 }
 
+enum MediaSourceFallback {
+    DirectPlay(String),
+    PlaybackInfo,
+}
+
 mod imp {
 
     use std::cell::{
@@ -105,6 +111,8 @@ mod imp {
 
     use mpris_server::LocalServer;
     use once_cell::sync::OnceCell;
+
+    use super::MediaSourceFallback;
 
     use crate::{
         APP_ID,
@@ -192,6 +200,7 @@ mod imp {
         pub y: Cell<f64>,
         pub last_motion_time: Cell<i64>,
         pub suburl: RefCell<Option<String>>,
+        pub(super) media_source_fallback: RefCell<Option<MediaSourceFallback>>,
         pub skippable_segments: RefCell<Option<Vec<MediaSegment>>>,
         pub current_segment_end: Cell<Option<f64>>,
         pub popover: RefCell<Option<PopoverMenu>>,
@@ -672,11 +681,18 @@ impl MPVPage {
     fn mark_stream_failed(&self) {
         let imp = self.imp();
         imp.file_loaded.set(false);
+        imp.media_source_fallback.take();
         imp.danmaku_sync.reset();
         imp.danmakw.stop_rendering();
         imp.danmakw.set_visible(false);
         imp.loading_box.set_visible(false);
         imp.spinner.set_visible(false);
+    }
+
+    fn fail_playback(&self, message: impl Into<String>) {
+        self.mark_stream_failed();
+        self.toast(message);
+        self.notify_stopped();
     }
 
     pub fn play(
@@ -689,6 +705,7 @@ impl MPVPage {
             .is_none_or(|current| current.id() != item.id());
         let imp = self.imp();
         imp.file_loaded.set(false);
+        imp.media_source_fallback.take();
         imp.danmaku_sync.reset();
         imp.danmakw.stop_rendering();
         imp.danmakw.set_visible(false);
@@ -777,9 +794,7 @@ impl MPVPage {
                 {
                     Ok(playback_info) => playback_info,
                     Err(e) => {
-                        obj.mark_stream_failed();
-                        obj.toast(e.to_user_facing());
-                        obj.notify_stopped();
+                        obj.fail_playback(e.to_user_facing());
                         return;
                     }
                 };
@@ -803,9 +818,7 @@ impl MPVPage {
                     };
 
                 let Some(media_source) = media_source else {
-                    obj.mark_stream_failed();
-                    obj.toast(gettext("No media source found"));
-                    obj.notify_stopped();
+                    obj.fail_playback(gettext("No media source found"));
                     return;
                 };
 
@@ -815,7 +828,7 @@ impl MPVPage {
                     playsessionid: playback_info.play_session_id.to_owned(),
                     mediasourceid: media_source.id.to_owned(),
                     livestreamid: media_source.live_stream_id.to_owned(),
-                    playmethod: media_source_play_method(media_source),
+                    playmethod: "DirectPlay",
                     tick: media_source.run_time_ticks.unwrap_or(0),
                     start_tick: glib::real_time() as u64 * 10,
                 };
@@ -851,7 +864,7 @@ impl MPVPage {
 
                 let sub_url = match media_stream {
                     Some(stream) if stream.is_external => match &stream.delivery_url {
-                        Some(url) => Some(JELLYFIN_CLIENT.get_streaming_url(url).await),
+                        Some(url) => Some(JELLYFIN_CLIENT.resolve_url(url)),
                         None => {
                             println!("External Subtitle without selected source");
                             imp.obj()
@@ -868,17 +881,15 @@ impl MPVPage {
 
                 imp.suburl.replace(sub_url);
 
-                let video_url = match media_source_stream_url(media_source).await {
-                    Some(video_url) => video_url,
-                    None => {
-                        obj.mark_stream_failed();
-                        obj.toast(gettext("No media source found"));
-                        obj.notify_stopped();
-                        return;
-                    }
+                let Some((primary_url, fallback)) =
+                    media_source_url(media_source, playback_info.play_session_id.as_deref()).await
+                else {
+                    obj.fail_playback(gettext("No media source found"));
+                    return;
                 };
 
-                imp.video.play(&video_url, start_seconds);
+                imp.media_source_fallback.replace(fallback);
+                imp.video.play(&primary_url, start_seconds);
             }
         ));
     }
@@ -1000,7 +1011,7 @@ impl MPVPage {
             .delivery_url
             .to_owned()?;
 
-        Some(JELLYFIN_CLIENT.get_streaming_url(&url).await)
+        Some(JELLYFIN_CLIENT.resolve_url(&url))
     }
 
     async fn set_audio_and_video_tracks_dropdown(&self, value: MpvTracks) {
@@ -1316,6 +1327,7 @@ impl MPVPage {
     fn on_file_loaded(&self) {
         let imp = self.imp();
         imp.file_loaded.set(true);
+        imp.media_source_fallback.take();
 
         if imp.danmaku_popover_content.is_enabled() && self.has_danmaku() {
             imp.danmakw.set_visible(true);
@@ -1373,9 +1385,93 @@ impl MPVPage {
     }
 
     fn on_error(&self, value: &str) {
-        self.mark_stream_failed();
-        self.toast(value);
-        self.notify_stopped();
+        if value.contains("-13")
+            && let Some(fallback) = self.imp().media_source_fallback.take()
+        {
+            tracing::info!("Direct media path failed; retrying through the media server");
+            match fallback {
+                MediaSourceFallback::DirectPlay(url) => self
+                    .imp()
+                    .video
+                    .play(&url, self.imp().last_playback_position.get()),
+                MediaSourceFallback::PlaybackInfo => {
+                    let error = value.to_owned();
+                    spawn(glib::clone!(
+                        #[weak(rename_to = obj)]
+                        self,
+                        async move {
+                            obj.retry_fallback(error).await;
+                        }
+                    ));
+                }
+            }
+            return;
+        }
+        self.fail_playback(value);
+    }
+
+    async fn retry_fallback(&self, original_error: String) {
+        let Some(back) = self.imp().back.borrow().as_ref().cloned() else {
+            self.fail_playback(&original_error);
+            return;
+        };
+        let item_id = back.id;
+        let requested_item_id = item_id.to_owned();
+        let media_source_id = back.mediasourceid;
+        let requested_media_source_id = media_source_id.to_owned();
+        let live_stream_id = back.livestreamid;
+        let playback_info = spawn_tokio(async move {
+            JELLYFIN_CLIENT
+                .get_fallback_playbackinfo(&item_id, &media_source_id, live_stream_id.as_deref())
+                .await
+        })
+        .await;
+        if self
+            .current_video()
+            .as_ref()
+            .is_none_or(|item| item.id() != requested_item_id)
+        {
+            return;
+        }
+        let playback_info = match playback_info {
+            Ok(playback_info) => playback_info,
+            Err(error) => {
+                tracing::warn!(%error, "Fallback playback negotiation failed");
+                self.fail_playback(error.to_user_facing());
+                return;
+            }
+        };
+        let Some(media_source) = playback_info
+            .media_sources
+            .into_iter()
+            .find(|source| source.id == requested_media_source_id)
+        else {
+            self.fail_playback(&original_error);
+            return;
+        };
+        let fallback = media_source
+            .transcoding_url
+            .as_deref()
+            .map(|url| (url, "Transcode"))
+            .or_else(|| {
+                media_source
+                    .direct_stream_url
+                    .as_deref()
+                    .map(|url| (url, "DirectStream"))
+            });
+        let Some((fallback_url, playmethod)) = fallback else {
+            self.fail_playback(&original_error);
+            return;
+        };
+        if let Some(back) = self.imp().back.borrow_mut().as_mut() {
+            back.playsessionid = playback_info.play_session_id;
+            back.mediasourceid = media_source.id;
+            back.livestreamid = media_source.live_stream_id;
+            back.playmethod = playmethod;
+        }
+        self.imp()
+            .video
+            .play(fallback_url, self.imp().last_playback_position.get());
     }
 
     pub fn on_pause_update(&self, value: bool) {
@@ -1554,6 +1650,7 @@ impl MPVPage {
     #[template_callback]
     pub fn on_stop_clicked(&self) {
         self.imp().file_loaded.set(false);
+        self.imp().media_source_fallback.take();
         self.imp().danmakw.set_visible(false);
         self.remove_timeout();
         self.reset_skippable_segments();
@@ -1825,50 +1922,35 @@ impl MPVPage {
     }
 }
 
-pub async fn direct_stream_url(source: &MediaSource) -> Option<String> {
+async fn direct_play_url(source: &MediaSource, play_session_id: Option<&str>) -> Option<String> {
     let container = source.container.as_deref()?;
     JELLYFIN_CLIENT
-        .get_item_stream_url(
+        .get_item_direct_play_url(
             container,
             source.item_id.as_ref().unwrap_or(&source.id),
             &source.id,
+            play_session_id,
         )
         .await
         .ok()
 }
 
-fn playable_media_source_path(source: &MediaSource) -> Option<String> {
-    let path = source.path.as_deref()?;
-
-    if path.starts_with("http://") || path.starts_with("https://") {
-        return Some(path.to_owned());
+async fn media_source_url(
+    source: &MediaSource, play_session_id: Option<&str>,
+) -> Option<(String, Option<MediaSourceFallback>)> {
+    if let Some(path) = source.path.as_deref()
+        && Url::parse(path).is_ok()
+    {
+        let fallback = if source.live_stream_id.is_some() {
+            Some(MediaSourceFallback::PlaybackInfo)
+        } else {
+            direct_play_url(source, play_session_id)
+                .await
+                .map(MediaSourceFallback::DirectPlay)
+        };
+        return Some((path.to_owned(), fallback));
     }
-
-    None
-}
-
-fn media_source_play_method(source: &MediaSource) -> &'static str {
-    if source.direct_stream_url.is_some() {
-        return "DirectStream";
-    }
-    if source.transcoding_url.is_some() {
-        return "Transcode";
-    }
-    "DirectPlay"
-}
-
-pub async fn media_source_stream_url(source: &MediaSource) -> Option<String> {
-    if let Some(direct_url) = source.direct_stream_url.to_owned() {
-        return Some(direct_url);
-    }
-
-    if let Some(transcoding_url) = source.transcoding_url.to_owned() {
-        return Some(transcoding_url);
-    }
-
-    if let Some(path) = playable_media_source_path(source) {
-        return Some(path);
-    }
-
-    direct_stream_url(source).await
+    direct_play_url(source, play_session_id)
+        .await
+        .map(|url| (url, None))
 }

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -64,48 +64,6 @@ const MIN_MOTION_TIME: i64 = 100000;
 const PREV_CHAPTER_KEY: gtk::gdk::Key = gtk::gdk::Key::Page_Down;
 const NEXT_CHAPTER_KEY: gtk::gdk::Key = gtk::gdk::Key::Page_Up;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct PlaybackDirectMode {
-    pub enable_direct_play: bool,
-    pub enable_direct_stream: bool,
-}
-
-impl Default for PlaybackDirectMode {
-    fn default() -> Self {
-        Self::direct()
-    }
-}
-
-impl PlaybackDirectMode {
-    pub const fn direct() -> Self {
-        Self {
-            enable_direct_play: true,
-            enable_direct_stream: true,
-        }
-    }
-
-    fn fallback(self) -> Option<Self> {
-        match (self.enable_direct_play, self.enable_direct_stream) {
-            (true, true) => Some(Self {
-                enable_direct_play: false,
-                enable_direct_stream: true,
-            }),
-            (false, true) => Some(Self {
-                enable_direct_play: false,
-                enable_direct_stream: false,
-            }),
-            (false, false) => None,
-            _ => unreachable!(),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct FallbackContext {
-    selected: Option<SelectedVideoSubInfo>,
-    start_seconds: f64,
-}
-
 #[derive(Clone, Copy)]
 enum MpvTrackKind {
     Audio,
@@ -264,11 +222,6 @@ mod imp {
         pub key_vaild: Cell<bool>,
 
         pub video_version_matcher: RefCell<Option<String>>,
-        pub fallback_context: RefCell<Option<super::FallbackContext>>,
-        pub playback_direct_mode: RefCell<super::PlaybackDirectMode>,
-        pub queued_playback_direct_mode: RefCell<Option<super::PlaybackDirectMode>>,
-        pub retrying_playback: Cell<bool>,
-        pub allow_fallback: Cell<bool>,
         pub last_nonzero_volume: Cell<i64>,
         pub danmaku_count: Cell<usize>,
         pub danmaku_generation: Cell<u64>,
@@ -722,64 +675,8 @@ impl MPVPage {
         imp.danmaku_sync.reset();
         imp.danmakw.stop_rendering();
         imp.danmakw.set_visible(false);
-        imp.allow_fallback.set(false);
         imp.loading_box.set_visible(false);
         imp.spinner.set_visible(false);
-    }
-
-    fn is_loading_failed(value: &str) -> bool {
-        value.contains("-13")
-    }
-
-    fn retry_fallback_playback(&self) -> bool {
-        let next_mode = {
-            let imp = self.imp();
-            if imp.retrying_playback.get() {
-                return true;
-            }
-            let Some(next_mode) = imp.playback_direct_mode.borrow().fallback() else {
-                return false;
-            };
-            imp.retrying_playback.set(true);
-            next_mode
-        };
-
-        let Some(context) = self.imp().fallback_context.take() else {
-            self.imp().retrying_playback.set(false);
-            return false;
-        };
-        let Some(item) = self.current_video() else {
-            self.imp().retrying_playback.set(false);
-            return false;
-        };
-
-        tracing::info!(
-            "Retrying playback with EnableDirectPlay={}, EnableDirectStream={}",
-            next_mode.enable_direct_play,
-            next_mode.enable_direct_stream
-        );
-
-        let episode_list = self.imp().current_episode_list.take();
-        self.imp()
-            .queued_playback_direct_mode
-            .replace(Some(next_mode));
-        self.mpv().stop();
-
-        spawn_g_timeout(glib::clone!(
-            #[weak(rename_to = obj)]
-            self,
-            async move {
-                obj.play(
-                    context.selected,
-                    item,
-                    episode_list,
-                    None,
-                    context.start_seconds,
-                );
-            }
-        ));
-
-        true
     }
 
     pub fn play(
@@ -856,20 +753,6 @@ impl MPVPage {
                 self.clear_danmaku();
             }
         }
-        self.imp().fallback_context.replace(Some(FallbackContext {
-            selected: selected.to_owned(),
-            start_seconds,
-        }));
-        let direct_mode = self
-            .imp()
-            .queued_playback_direct_mode
-            .borrow_mut()
-            .take()
-            .unwrap_or_else(PlaybackDirectMode::direct);
-        self.imp().playback_direct_mode.replace(direct_mode);
-        self.imp().retrying_playback.set(false);
-        self.imp().allow_fallback.set(true);
-
         self.load_skippable_segments(id.to_owned());
 
         spawn_g_timeout(glib::clone!(
@@ -887,13 +770,7 @@ impl MPVPage {
                 let id_clone = id.to_owned();
                 let playback_info = match spawn_tokio(async move {
                     JELLYFIN_CLIENT
-                        .get_playbackinfo(
-                            &id_clone,
-                            sub_stream_index,
-                            media_source_id,
-                            true,
-                            direct_mode,
-                        )
+                        .get_playbackinfo(&id_clone, sub_stream_index, media_source_id, true)
                         .await
                 })
                 .await
@@ -982,7 +859,6 @@ impl MPVPage {
                                     id.to_owned(),
                                     stream,
                                     media_source.id.to_owned(),
-                                    direct_mode,
                                 )
                                 .await
                         }
@@ -1102,19 +978,12 @@ impl MPVPage {
 
     async fn external_sub_url_without_selected_source(
         &self, id: String, media_stream: &MediaStream, media_source_id: String,
-        direct_mode: PlaybackDirectMode,
     ) -> Option<String> {
         let stream_index = media_stream.index;
         let media_source_id_clone = media_source_id.to_owned();
         let playback_info = spawn_tokio(async move {
             JELLYFIN_CLIENT
-                .get_playbackinfo(
-                    &id,
-                    Some(stream_index),
-                    Some(media_source_id),
-                    true,
-                    direct_mode,
-                )
+                .get_playbackinfo(&id, Some(stream_index), Some(media_source_id), true)
                 .await
         })
         .await
@@ -1452,7 +1321,6 @@ impl MPVPage {
             imp.danmakw.set_visible(true);
         }
 
-        imp.allow_fallback.set(false);
         if let Some(suburl) = imp.suburl.borrow().as_ref() {
             imp.video.add_sub(suburl);
         }
@@ -1505,13 +1373,6 @@ impl MPVPage {
     }
 
     fn on_error(&self, value: &str) {
-        if self.imp().allow_fallback.get()
-            && Self::is_loading_failed(value)
-            && self.retry_fallback_playback()
-        {
-            return;
-        }
-
         self.mark_stream_failed();
         self.toast(value);
         self.notify_stopped();

--- a/crates/tsukimi/src/ui/mpv/sink.rs
+++ b/crates/tsukimi/src/ui/mpv/sink.rs
@@ -2,7 +2,6 @@ use std::cell::Cell;
 
 use crate::{
     client::jellyfin_client::JELLYFIN_CLIENT,
-    utils::spawn,
 };
 
 use adw::{
@@ -95,24 +94,18 @@ impl MPVPlaySink {
     }
 
     pub fn play(&self, url: &str, start_seconds: f64) {
-        let url = url.to_owned();
+        let url = JELLYFIN_CLIENT.resolve_url(&url);
 
-        spawn(glib::clone!(
-            #[weak(rename_to = obj)]
-            self,
-            async move {
-                let url = JELLYFIN_CLIENT.get_streaming_url(&url).await;
+        let (imp, player) = (self.imp(), self.player());
+        info!("Now Playing: {}", url);
 
-                info!("Now Playing: {}", url);
-                obj.imp().position.set(start_seconds);
-                obj.imp().paused.set(false);
+        imp.position.set(start_seconds);
+        imp.paused.set(false);
 
-                obj.player().set_start(start_seconds);
-                obj.player().push_an_empty_texture();
-                obj.player().load_video(&url);
-                obj.player().pause(false);
-            }
-        ));
+        player.set_start(start_seconds);
+        player.push_an_empty_texture();
+        player.load_video(&url);
+        player.pause(false);
     }
 
     pub fn add_sub(&self, url: &str) {

--- a/crates/tsukimi/src/ui/provider/dropdown_factory.rs
+++ b/crates/tsukimi/src/ui/provider/dropdown_factory.rs
@@ -12,8 +12,6 @@ pub struct DropdownList {
     pub sub_lang: Option<String>,
     pub index: Option<i64>,
     pub id: Option<String>,
-    pub url: Option<String>,
-    pub is_external: Option<bool>,
 }
 
 pub fn factory<const UPBIND: bool>() -> gtk::SignalListItemFactory {

--- a/crates/tsukimi/src/ui/widgets/item.rs
+++ b/crates/tsukimi/src/ui/widgets/item.rs
@@ -21,10 +21,7 @@ use crate::{
         structs::*,
     },
     ui::{
-        mpv::page::{
-            PlaybackDirectMode,
-            media_source_stream_url,
-        },
+        mpv::page::media_source_stream_url,
         provider::{
             dropdown_factory::{
                 DropdownList,
@@ -454,13 +451,7 @@ impl ItemPage {
         let intro_id_clone = intro_id.to_owned();
         let playback = match spawn_tokio(async move {
             JELLYFIN_CLIENT
-                .get_playbackinfo(
-                    &intro_id_clone,
-                    None,
-                    None,
-                    false,
-                    PlaybackDirectMode::direct(),
-                )
+                .get_playbackinfo(&intro_id_clone, None, None, false)
                 .await
         })
         .await

--- a/crates/tsukimi/src/ui/widgets/item.rs
+++ b/crates/tsukimi/src/ui/widgets/item.rs
@@ -21,7 +21,6 @@ use crate::{
         structs::*,
     },
     ui::{
-        mpv::page::media_source_stream_url,
         provider::{
             dropdown_factory::{
                 DropdownList,
@@ -464,7 +463,7 @@ impl ItemPage {
         };
 
         self.set_current_item(Some(intro));
-        self.set_dropdown(&playback).await;
+        self.set_dropdown(&playback);
         self.set_play_session_id(playback.play_session_id.to_owned());
 
         play_button.set_sensitive(true);
@@ -702,7 +701,7 @@ impl ItemPage {
         }
     }
 
-    pub async fn set_dropdown(&self, playbackinfo: &Media) {
+    pub fn set_dropdown(&self, playbackinfo: &Media) {
         let imp = self.imp();
         let namedropdown = imp.namedropdown.get();
         let subdropdown = imp.subdropdown.get();
@@ -748,8 +747,6 @@ impl ItemPage {
                                     .line2(stream.title.to_owned())
                                     .sub_lang(stream.language.to_owned())
                                     .index(Some(stream.index))
-                                    .url(stream.delivery_url.to_owned())
-                                    .is_external(Some(stream.is_external))
                                     .build()
                                 else {
                                     continue;
@@ -780,11 +777,9 @@ impl ItemPage {
                 .bit_rate
                 .map(|bit_rate| format!("{:.2} Kbps", bit_rate as f64 / 1_000.0))
                 .unwrap_or_default();
-            let play_url = media_source_stream_url(media).await;
             let Ok(dl) = DropdownListBuilder::default()
                 .line1(Some(media.name.to_owned()))
                 .line2(Some(line2))
-                .url(play_url)
                 .id(Some(media.id.to_owned()))
                 .build()
             else {

--- a/crates/tsukimi/src/ui/widgets/other.rs
+++ b/crates/tsukimi/src/ui/widgets/other.rs
@@ -166,6 +166,15 @@ pub(crate) mod imp {
 
             self.actionbox.set_id(Some(obj.item().id()));
             self.actionbox.set_item_type(obj.item().item_type());
+            self.play_button.connect_clicked(glib::clone!(
+                #[weak]
+                obj,
+                move |_| match obj.item().item_type().as_str() {
+                    "Audio" => obj.item().play_single_audio(&obj),
+                    "TvChannel" => obj.item().play_tvchannel(&obj),
+                    _ => {}
+                }
+            ));
             self.selection.set_model(Some(&store));
             self.episode_list.set_factory(Some(
                 SignalListItemFactory::new()
@@ -280,28 +289,9 @@ impl OtherPage {
             "BoxSet" | "Playlist" => {
                 self.hortu_set_boxset_list().await;
             }
-            "Audio" => {
-                self.imp().play_button.set_visible(true);
-                self.imp().play_button.connect_clicked(glib::clone!(
-                    #[weak(rename_to = obj)]
-                    self,
-                    move |_| {
-                        obj.item().play_single_audio(&obj);
-                    }
-                ));
-            }
+            "Audio" | "TvChannel" => self.imp().play_button.set_visible(true),
             "Season" => {
                 self.hortu_set_season_episode_list().await;
-            }
-            "TvChannel" => {
-                self.imp().play_button.set_visible(true);
-                self.imp().play_button.connect_clicked(glib::clone!(
-                    #[weak(rename_to = obj)]
-                    self,
-                    move |_| {
-                        obj.item().play_tvchannel(&obj);
-                    }
-                ));
             }
             _ => {}
         }


### PR DESCRIPTION
Our previous implementation relied heavily on the values returned by `PlaybackInfo`. When `PlaybackInfo` provided a `direct_stream_url` or `transcoding_url`, we preferred that URL and treated DirectPlay as a fallback. If Jellyfin determined that the media did not match our `DirectPlayProfiles`, playback would therefore fall back to DirectStream or transcoding. In practice, with mpv, it is generally safe to assume that virtually all formats are supported, [as Findroid does](https://github.com/jarnedemeulemeester/findroid/blob/b170f7d8c5b3967ff5bdd4a6de3c5ef8433e5914/data/src/main/java/dev/jdtech/jellyfin/models/FindroidSource.kt#L25-L36). We now unconditionally prefer direct playback:

1. For `File` sources, retain the existing DirectPlay logic.
2. For URL sources, let mpv play `Path` directly, bypassing the media server.

However, we have previously received reports that some LiveTV URLs returned by the server are not directly accessible from the client and can only be accessed through Jellyfin. This is why we introduced the fallback logic.

LiveTV fallback URLs must be generated dynamically by the server and cannot be constructed directly like DirectPlay URLs for non-LiveTV media. Therefore, we still need to adjust `stream_profile.json`. This PR makes several adjustments to `stream_profile.json` based on Jellyfin Desktop’s streaming parameters and the Jellyfin source code, including:
1. Adding `vp9` and `av1` to the `VideoCodec` list in `TranscodingProfiles`.
2. Removes all restrictions from `DirectPlayProfiles`.
3. Adds missing `SubtitleProfiles` and removes duplicate entries.

The fallback flow has also been adjusted. The complete playback URL selection logic is now as follows:

1. If `Path` is a URL, try to play it directly. If playback fails, use the appropriate fallback:

   - For LiveTV, request `PlaybackInfo` again with DirectPlay disabled and use the URL returned by the server.
   - For non-LiveTV media, construct the DirectPlay URL directly.

2. If `Path` is a file path, construct the DirectPlay URL directly.

This PR also renames several functions and fixes a few miscellaneous issues, including adding the play session ID to DirectPlay URLs, renaming `get_streaming_url` to `resolve_url` and removing its unnecessary `async` marker, and preventing cached item refreshes from registering duplicate playback callbacks on the play button.