### PR TITLE
fix: improve danmaku loading and popover behavior

### DIFF
--- a/crates/tsukimi/resources/ui/danmaku_popover.ui
+++ b/crates/tsukimi/resources/ui/danmaku_popover.ui
@@ -8,6 +8,7 @@
     <property name="margin-end">6</property>
     <property name="child">
       <object class="AdwNavigationView">
+        <property name="animate-transitions">false</property>
         <child>
           <object class="AdwNavigationPage">
             <property name="title" translatable="yes">Danmaku</property>

--- a/crates/tsukimi/resources/ui/danmaku_popover.ui
+++ b/crates/tsukimi/resources/ui/danmaku_popover.ui
@@ -30,7 +30,7 @@
                         </child>
                         <child>
                           <object class="AdwActionRow" id="danmaku_status_row">
-                            <property name="subtitle" translatable="yes">Danmaku disabled</property>
+                            <property name="subtitle" translatable="yes">Disabled</property>
                             <property name="subtitle-lines">2</property>
                             <property name="subtitle-selectable">True</property>
                             <child type="prefix">
@@ -68,7 +68,8 @@
                     <child>
                       <object class="AdwPreferencesGroup">
                         <child>
-                          <object class="AdwButtonRow">
+                          <object class="AdwButtonRow" id="manual_search_button">
+                            <property name="sensitive">false</property>
                             <property name="start-icon-name">edit-find-symbolic</property>
                             <property name="title" translatable="yes">Search Manually</property>
                             <signal name="activated" handler="on_manual_search" swapped="yes"/>

--- a/crates/tsukimi/src/ui/models/settings.rs
+++ b/crates/tsukimi/src/ui/models/settings.rs
@@ -90,13 +90,11 @@ impl Settings {
     const KEY_DANMAKU_CACHE_MAP: &'static str = "danmaku-cache-map";
 
     fn bind_setting(&self, key: &str, object: &impl IsA<glib::Object>, property: &str) {
-        self.0.get_ref().bind(key, object, property).build();
+        self.bind(key, object, property).build();
     }
 
     pub fn bind_mpv_danmaku_enabled(&self, object: &impl IsA<glib::Object>, property: &str) {
-        self.0
-            .get_ref()
-            .bind(Self::KEY_MPV_DANMAKU_ENABLED, object, property)
+        self.bind(Self::KEY_MPV_DANMAKU_ENABLED, object, property)
             .no_sensitivity()
             .build();
     }

--- a/crates/tsukimi/src/ui/models/settings.rs
+++ b/crates/tsukimi/src/ui/models/settings.rs
@@ -94,7 +94,11 @@ impl Settings {
     }
 
     pub fn bind_mpv_danmaku_enabled(&self, object: &impl IsA<glib::Object>, property: &str) {
-        self.bind_setting(Self::KEY_MPV_DANMAKU_ENABLED, object, property);
+        self.0
+            .get_ref()
+            .bind(Self::KEY_MPV_DANMAKU_ENABLED, object, property)
+            .no_sensitivity()
+            .build();
     }
 
     pub fn bind_mpv_danmaku_opacity(&self, object: &impl IsA<glib::Object>, property: &str) {

--- a/crates/tsukimi/src/ui/mpv/danmaku_client.rs
+++ b/crates/tsukimi/src/ui/mpv/danmaku_client.rs
@@ -19,26 +19,23 @@ const X_APPID: &str = "e9imrhcexn";
 pub struct DanmakuClient(DanDanClient);
 
 impl DanmakuClient {
-    pub fn new() -> anyhow::Result<Self> {
-        static INIT: OnceLock<std::result::Result<(), String>> = OnceLock::new();
-        let result = INIT.get_or_init(|| {
-            let key = KEY
-                .map(str::trim)
-                .filter(|key| !key.is_empty())
-                .ok_or_else(|| "DANDANAPI_SECRET_KEY is not configured".to_string())?;
-
-            DanDanClient::init(
-                X_APPID.to_string(),
-                SecretGenerator::new(CIPHERTEXT.to_vec(), key.to_string()),
-            )
-            .map_err(|error| error.to_string())
-        });
-
-        if let Err(error) = result {
-            anyhow::bail!(error.clone());
-        }
-
-        Ok(Self(DanDanClient::instance()))
+    pub fn instance() -> Option<Self> {
+        static CLIENT: OnceLock<Option<DanmakuClient>> = OnceLock::new();
+        CLIENT
+            .get_or_init(|| {
+                let Some(key) = KEY.map(str::trim).filter(|key| !key.is_empty()) else {
+                    tracing::warn!("DANDANAPI_SECRET_KEY is not configured");
+                    return None;
+                };
+                if let Err(e) = DanDanClient::init(
+                    X_APPID.to_string(),
+                    SecretGenerator::new(CIPHERTEXT.to_vec(), key.to_string()),
+                ) {
+                    tracing::warn!("{e}");
+                }
+                Some(Self(DanDanClient::instance()))
+            })
+            .clone()
     }
 }
 

--- a/crates/tsukimi/src/ui/mpv/danmaku_client.rs
+++ b/crates/tsukimi/src/ui/mpv/danmaku_client.rs
@@ -24,14 +24,14 @@ impl DanmakuClient {
         CLIENT
             .get_or_init(|| {
                 let Some(key) = KEY.map(str::trim).filter(|key| !key.is_empty()) else {
-                    tracing::warn!("DANDANAPI_SECRET_KEY is not configured");
+                    tracing::error!("Failed to initialize danmaku client: DANDANAPI_SECRET_KEY is not configured");
                     return None;
                 };
-                if let Err(e) = DanDanClient::init(
+                if DanDanClient::init(
                     X_APPID.to_string(),
                     SecretGenerator::new(CIPHERTEXT.to_vec(), key.to_string()),
-                ) {
-                    tracing::warn!("{e}");
+                ).is_err() {
+                    tracing::warn!("DanDanClient already initialized, using existing instance...");
                 }
                 Some(Self(DanDanClient::instance()))
             })

--- a/crates/tsukimi/src/ui/mpv/danmaku_popover.rs
+++ b/crates/tsukimi/src/ui/mpv/danmaku_popover.rs
@@ -193,10 +193,12 @@ pub mod imp {
         }
 
         fn update_status_view(&self) {
-            let status = if self.danmaku_switch.is_active() {
-                self.status.borrow().clone()
-            } else {
+            let status = if *self.status.borrow() == DanmakuPopoverStatus::SecretNotExist {
+                DanmakuPopoverStatus::SecretNotExist
+            } else if !self.danmaku_switch.is_active() {
                 DanmakuPopoverStatus::Disabled
+            } else {
+                self.status.borrow().clone()
             };
             self.danmaku_status_group.set_title(&status.title());
             self.danmaku_status_row.set_title(&status.status_title());

--- a/crates/tsukimi/src/ui/mpv/danmaku_popover.rs
+++ b/crates/tsukimi/src/ui/mpv/danmaku_popover.rs
@@ -11,6 +11,7 @@ use gtk::{
 use crate::ui::{
     models::SETTINGS,
     mpv::{
+        danmaku_client::DanmakuClient,
         danmaku_search_dialog::DanmakuSearchDialog,
         page::MPVPage,
     },
@@ -26,6 +27,7 @@ pub enum DanmakuPopoverStatus {
     ManualLoaded(usize, String),
     SecretNotExist,
     #[default]
+    Idle,
     Disabled,
     Unavailable,
 }
@@ -50,6 +52,7 @@ impl DanmakuPopoverStatus {
             DanmakuPopoverStatus::SecretNotExist => {
                 gettext("This feature requires an official build")
             }
+            DanmakuPopoverStatus::Idle => gettext("Not loaded"),
             DanmakuPopoverStatus::Disabled => gettext("Disabled"),
             DanmakuPopoverStatus::Unavailable => gettext("Maybe there is something wrong"),
         }
@@ -72,9 +75,9 @@ impl DanmakuPopoverStatus {
             DanmakuPopoverStatus::Loaded(..) | DanmakuPopoverStatus::ManualLoaded(..) => {
                 "check-round-outline-symbolic"
             }
-            DanmakuPopoverStatus::NoMatching | DanmakuPopoverStatus::Disabled => {
-                "minus-circle-outline-symbolic"
-            }
+            DanmakuPopoverStatus::NoMatching
+            | DanmakuPopoverStatus::Idle
+            | DanmakuPopoverStatus::Disabled => "minus-circle-outline-symbolic",
             DanmakuPopoverStatus::SecretNotExist => "cross-small-circle-outline-symbolic",
             DanmakuPopoverStatus::Unavailable => "question-round-outline-symbolic",
         }
@@ -95,7 +98,9 @@ impl DanmakuPopoverStatus {
             DanmakuPopoverStatus::ManualLoaded(..) => &["success"],
             DanmakuPopoverStatus::NoMatching => &["warning"],
             DanmakuPopoverStatus::SecretNotExist => &["error"],
-            DanmakuPopoverStatus::Disabled | DanmakuPopoverStatus::Unavailable => &[],
+            DanmakuPopoverStatus::Idle
+            | DanmakuPopoverStatus::Disabled
+            | DanmakuPopoverStatus::Unavailable => &[],
         }
     }
 }
@@ -121,6 +126,8 @@ pub mod imp {
         pub danmaku_status_stack: TemplateChild<gtk::Stack>,
         #[template_child]
         pub danmaku_status_icon: TemplateChild<gtk::Image>,
+        #[template_child]
+        pub manual_search_button: TemplateChild<adw::ButtonRow>,
         #[template_child]
         pub danmaku_opacity_spin: TemplateChild<adw::SpinRow>,
         #[template_child]
@@ -159,14 +166,38 @@ pub mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for DanmakuPopover {}
+    impl ObjectImpl for DanmakuPopover {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            let obj = self.obj();
+            self.danmaku_switch.connect_active_notify(glib::clone!(
+                #[weak]
+                obj,
+                move |_| obj.imp().update_status_view()
+            ));
+            let client_available = DanmakuClient::instance().is_some();
+            self.danmaku_switch.set_sensitive(client_available);
+            self.manual_search_button.set_sensitive(client_available);
+            self.update_status_view();
+        }
+    }
 
     impl DanmakuPopover {
         fn set_status(&self, status: DanmakuPopoverStatus) {
             if self.status.replace(status.clone()) == status {
                 return;
             }
+            self.update_status_view();
+            self.obj().notify_status();
+        }
 
+        fn update_status_view(&self) {
+            let status = if self.danmaku_switch.is_active() {
+                self.status.borrow().clone()
+            } else {
+                DanmakuPopoverStatus::Disabled
+            };
             self.danmaku_status_group.set_title(&status.title());
             self.danmaku_status_row.set_title(&status.status_title());
             self.danmaku_status_row
@@ -177,8 +208,6 @@ pub mod imp {
                 .set_visible_child_name(status.stack_visible_child_name());
             self.danmaku_status_stack
                 .set_css_classes(status.status_css_class());
-
-            self.obj().notify_status();
         }
     }
 
@@ -250,24 +279,19 @@ impl DanmakuPopover {
             .build();
     }
 
-    pub fn set_enabled(&self, enabled: bool) {
-        self.imp().danmaku_switch.set_active(enabled);
-    }
-
-    pub fn set_switch_sensitive(&self, sensitive: bool) {
-        self.imp().danmaku_switch.set_sensitive(sensitive);
-    }
-
     pub fn is_enabled(&self) -> bool {
         self.imp().danmaku_switch.is_active()
     }
 
     #[template_callback]
     fn on_manual_search(&self) {
+        let Some(client) = DanmakuClient::instance() else {
+            return;
+        };
         let Some(page) = self.imp().page.upgrade() else {
             return;
         };
-        DanmakuSearchDialog::new(&page).present(Some(self));
+        DanmakuSearchDialog::new(&page, client).present(Some(self));
     }
 
     #[template_callback]

--- a/crates/tsukimi/src/ui/mpv/danmaku_popover.rs
+++ b/crates/tsukimi/src/ui/mpv/danmaku_popover.rs
@@ -106,7 +106,10 @@ impl DanmakuPopoverStatus {
 }
 
 pub mod imp {
-    use std::cell::RefCell;
+    use std::cell::{
+        Cell,
+        RefCell,
+    };
 
     use super::*;
     use glib::subclass::InitializingObject;
@@ -145,6 +148,8 @@ pub mod imp {
         #[template_child]
         pub shadow_spin: TemplateChild<adw::SpinRow>,
 
+        #[property(get, set = Self::set_enabled, explicit_notify)]
+        pub enabled: Cell<bool>,
         #[property(get, set = Self::set_status, explicit_notify)]
         pub status: RefCell<DanmakuPopoverStatus>,
     }
@@ -170,21 +175,27 @@ pub mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
-            let obj = self.obj();
-            self.danmaku_switch.connect_active_notify(glib::clone!(
-                #[weak]
-                obj,
-                move |_| obj.imp().update_status_view()
-            ));
-            let client_available = DanmakuClient::instance().is_some();
-            self.danmaku_switch.set_sensitive(client_available);
-            self.manual_search_button.set_sensitive(client_available);
-            self.update_status_view();
+            if DanmakuClient::instance().is_none() {
+                self.set_status(DanmakuPopoverStatus::SecretNotExist);
+            }
         }
     }
 
     impl DanmakuPopover {
+        fn set_enabled(&self, enabled: bool) {
+            if self.enabled.replace(enabled) == enabled {
+                return;
+            }
+            self.update_status_view();
+            self.obj().notify_enabled();
+        }
+
         fn set_status(&self, status: DanmakuPopoverStatus) {
+            // Controls are disabled by default, so update sensitivity even if the status is unchanged
+            let sensitive = status != DanmakuPopoverStatus::SecretNotExist;
+            self.danmaku_switch.set_sensitive(sensitive);
+            self.manual_search_button.set_sensitive(sensitive);
+
             if self.status.replace(status.clone()) == status {
                 return;
             }
@@ -195,7 +206,7 @@ pub mod imp {
         fn update_status_view(&self) {
             let status = if *self.status.borrow() == DanmakuPopoverStatus::SecretNotExist {
                 DanmakuPopoverStatus::SecretNotExist
-            } else if !self.danmaku_switch.is_active() {
+            } else if !self.enabled.get() {
                 DanmakuPopoverStatus::Disabled
             } else {
                 self.status.borrow().clone()
@@ -245,6 +256,10 @@ impl DanmakuPopover {
         SETTINGS.bind_mpv_danmaku_outline_size(&imp.outline_spin.get(), "value");
         SETTINGS.bind_mpv_danmaku_shadow_offset(&imp.shadow_spin.get(), "value");
 
+        imp.danmaku_switch
+            .bind_property("active", self, "enabled")
+            .flags(glib::BindingFlags::SYNC_CREATE)
+            .build();
         imp.danmaku_opacity_spin
             .bind_property("value", &danmakw, "opacity")
             .flags(glib::BindingFlags::SYNC_CREATE)
@@ -279,10 +294,6 @@ impl DanmakuPopover {
             .bind_property("value", &danmakw, "shadow-offset")
             .flags(glib::BindingFlags::SYNC_CREATE)
             .build();
-    }
-
-    pub fn is_enabled(&self) -> bool {
-        self.imp().danmaku_switch.is_active()
     }
 
     #[template_callback]

--- a/crates/tsukimi/src/ui/mpv/danmaku_search_dialog.rs
+++ b/crates/tsukimi/src/ui/mpv/danmaku_search_dialog.rs
@@ -1,4 +1,7 @@
-use std::cell::RefCell;
+use std::cell::{
+    OnceCell,
+    RefCell,
+};
 
 use adw::{
     prelude::*,
@@ -69,6 +72,7 @@ mod imp {
         #[template_child]
         pub toast: TemplateChild<adw::ToastOverlay>,
 
+        pub client: OnceCell<DanmakuClient>,
         pub page: glib::WeakRef<MPVPage>,
         pub episodes: RefCell<Vec<TuItem>>,
     }
@@ -115,11 +119,17 @@ glib::wrapper! {
 
 #[template_callbacks]
 impl DanmakuSearchDialog {
-    pub fn new(page: &MPVPage) -> Self {
+    pub fn new(page: &MPVPage, client: DanmakuClient) -> Self {
         let dialog: Self = glib::Object::new();
+        dialog.imp().client.get_or_init(|| client);
         dialog.imp().page.set(Some(page));
         dialog.prefill_from_current_video();
         dialog
+    }
+
+    fn client(&self) -> &DanmakuClient {
+        // SAFETY: DanmakuSearchDialog::new has already initialized the client
+        self.imp().client.get().unwrap()
     }
 
     fn prefill_from_current_video(&self) {
@@ -188,11 +198,9 @@ impl DanmakuSearchDialog {
 
         let anime_type = self.selected_anime_type();
         self.set_searching(true);
-        let result = spawn_tokio(async move {
-            let client = DanmakuClient::new()?;
-            client.search_anime_details(title, anime_type).await
-        })
-        .await;
+        let client = self.client().clone();
+        let result =
+            spawn_tokio(async move { client.search_anime_details(title, anime_type).await }).await;
         self.set_searching(false);
 
         match result {
@@ -256,12 +264,15 @@ impl DanmakuSearchDialog {
             || item.name(),
             |series_name| format!("{} - {series_name}", item.name()),
         );
-
+        let client = self.client().clone();
         spawn(glib::clone!(
             #[weak(rename_to = obj)]
             self,
             async move {
-                match page.apply_manual_danmaku(episode_id, item_name).await {
+                match page
+                    .apply_manual_danmaku(client, episode_id, item_name)
+                    .await
+                {
                     Ok(true) => {
                         let mut cache = DanmakuCacheMap::load();
                         if let Err(error) = cache.remember_manual_selection(
@@ -296,12 +307,12 @@ impl DanmakuSearchDialog {
         let anime_id = item.id();
         let anime_title = item.name();
         let episode_series_name = anime_title.clone();
+        let client = self.client().clone();
         spawn(glib::clone!(
             #[weak(rename_to = obj)]
             self,
             async move {
                 let result = spawn_tokio(async move {
-                    let client = DanmakuClient::new()?;
                     client
                         .search_animes(SearchSearchEpisodesParams {
                             anime: Some(anime_title),

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -434,7 +434,7 @@ impl MPVPage {
             .unwrap_or_else(|| item.name())
     }
 
-    fn auto_search_danmaku(&self, item: &TuItem) {
+    fn auto_search_danmaku(&self, client: DanmakuClient, item: &TuItem) {
         if let Some(cached) = DanmakuCacheMap::load().cached_danmaku(item) {
             spawn_g_timeout(glib::clone!(
                 #[weak(rename_to = obj)]
@@ -444,7 +444,7 @@ impl MPVPage {
                         return;
                     }
                     if let Err(error) = obj
-                        .apply_manual_danmaku(cached.episode_id, cached.item_name)
+                        .apply_manual_danmaku(client, cached.episode_id, cached.item_name)
                         .await
                     {
                         tracing::warn!("Failed to apply cached danmaku: {error}");
@@ -470,26 +470,12 @@ impl MPVPage {
             v2: true,
         };
 
-        let imp = self.imp();
-        imp.danmaku_count.set(0);
-        imp.danmakw.stop_rendering();
-        imp.danmakw.clear_danmaku();
-        imp.danmaku_popover_content
-            .set_status(DanmakuPopoverStatus::Searching);
+        self.clear_danmaku(DanmakuPopoverStatus::Searching);
 
         spawn_g_timeout(glib::clone!(
             #[weak(rename_to = obj)]
             self,
             async move {
-                let client = match spawn_tokio(async { DanmakuClient::new() }).await {
-                    Ok(client) => client,
-                    Err(error) => {
-                        tracing::warn!("Failed to initialize danmaku client: {error}");
-                        obj.clear_danmaku_result(DanmakuPopoverStatus::SecretNotExist);
-                        return;
-                    }
-                };
-
                 if !obj.is_current_danmaku_request(generation, &item_id) {
                     return;
                 }
@@ -505,12 +491,12 @@ impl MPVPage {
                 let (episode_id, item_name) = match search_result {
                     Ok(Some(episode_match)) => episode_match,
                     Ok(None) => {
-                        obj.clear_danmaku_result(DanmakuPopoverStatus::NoMatching);
+                        obj.clear_danmaku(DanmakuPopoverStatus::NoMatching);
                         return;
                     }
                     Err(error) => {
                         tracing::warn!("Failed to search danmaku episode: {error}");
-                        obj.clear_danmaku_result(DanmakuPopoverStatus::Unavailable);
+                        obj.clear_danmaku(DanmakuPopoverStatus::Unavailable);
                         return;
                     }
                 };
@@ -530,10 +516,12 @@ impl MPVPage {
                     Ok(Some(danmaku)) if !danmaku.is_empty() => {
                         obj.apply_danmaku(danmaku, item_name, false)
                     }
-                    Ok(_) => obj.clear_danmaku_result(DanmakuPopoverStatus::NoMatching),
+                    Ok(_) => {
+                        obj.clear_danmaku(DanmakuPopoverStatus::NoMatching);
+                    }
                     Err(error) => {
                         tracing::warn!("Failed to load danmaku comments: {error}");
-                        obj.clear_danmaku_result(DanmakuPopoverStatus::Unavailable);
+                        obj.clear_danmaku(DanmakuPopoverStatus::Unavailable);
                     }
                 }
             }
@@ -569,29 +557,21 @@ impl MPVPage {
             DanmakuPopoverStatus::Loaded(count, item_name)
         };
         imp.danmaku_popover_content.set_status(status);
-        self.set_danmaku_enabled(imp.danmaku_popover_content.is_enabled());
+        self.update_danmaku_rendering(imp.danmaku_popover_content.is_enabled());
     }
 
     pub async fn apply_manual_danmaku(
-        &self, episode_id: i64, item_name: String,
+        &self, client: DanmakuClient, episode_id: i64, item_name: String,
     ) -> anyhow::Result<bool> {
         let Some(current_item) = self.current_video() else {
             anyhow::bail!("No video is currently playing");
         };
         let item_id = current_item.id();
         let generation = self.next_danmaku_generation();
-        let imp = self.imp();
-        imp.danmaku_count.set(0);
-        imp.danmakw.stop_rendering();
-        imp.danmakw.clear_danmaku();
-        imp.danmaku_popover_content
-            .set_status(DanmakuPopoverStatus::Loading);
+        self.clear_danmaku(DanmakuPopoverStatus::Loading);
 
-        let comments_result = spawn_tokio(async move {
-            let client = DanmakuClient::new()?;
-            client.get_comments(episode_id).await
-        })
-        .await;
+        let comments_result =
+            spawn_tokio(async move { client.get_comments(episode_id).await }).await;
 
         if !self.is_current_danmaku_request(generation, &item_id) {
             anyhow::bail!("The current video changed while loading danmaku");
@@ -603,17 +583,17 @@ impl MPVPage {
                 Ok(true)
             }
             Ok(_) => {
-                self.clear_danmaku_result(DanmakuPopoverStatus::NoMatching);
+                self.clear_danmaku(DanmakuPopoverStatus::NoMatching);
                 Ok(false)
             }
             Err(error) => {
-                self.clear_danmaku_result(DanmakuPopoverStatus::Unavailable);
+                self.clear_danmaku(DanmakuPopoverStatus::Unavailable);
                 Err(error)
             }
         }
     }
 
-    fn clear_danmaku_result(&self, status: DanmakuPopoverStatus) {
+    fn clear_danmaku(&self, status: DanmakuPopoverStatus) {
         let imp = self.imp();
         imp.danmaku_count.set(0);
         imp.danmakw.clear_danmaku();
@@ -621,53 +601,39 @@ impl MPVPage {
         imp.danmaku_popover_content.set_status(status);
     }
 
-    fn clear_danmaku(&self) {
-        self.next_danmaku_generation();
-        self.clear_danmaku_result(DanmakuPopoverStatus::Disabled);
-    }
-
-    pub fn set_danmaku_enabled(&self, enabled: bool) {
+    fn update_danmaku_rendering(&self, enabled: bool) {
         let imp = self.imp();
-        let enabled = enabled && self.has_danmaku();
-        imp.danmaku_popover_content
-            .set_switch_sensitive(self.has_danmaku());
-        imp.danmaku_popover_content.set_enabled(enabled);
-        imp.danmakw.set_visible(enabled && imp.file_loaded.get());
-        if !enabled || !imp.file_loaded.get() {
+        let ready = enabled && self.has_danmaku() && imp.file_loaded.get();
+        imp.danmakw.set_visible(ready);
+        if !ready {
             imp.danmaku_sync.reset();
             imp.danmakw.stop_rendering();
+            return;
+        }
+        self.sync_danmaku_position(imp.last_playback_position.get() * 1000.0);
+        if !self.paused() && !imp.loading_box.is_visible() {
+            imp.danmakw.start_rendering();
         } else {
-            self.sync_danmaku_position(imp.last_playback_position.get() * 1000.0);
-            if !self.paused() && !imp.loading_box.is_visible() {
-                imp.danmakw.start_rendering();
-            }
+            imp.danmakw.stop_rendering();
         }
     }
 
     pub fn on_danmaku_switch_state_set(&self, state: bool) {
-        let imp = self.imp();
-
         if state && !self.has_danmaku() {
-            if let Some(item) = self.current_video() {
-                self.auto_search_danmaku(&item);
+            if let Some(item) = self.current_video()
+                && let Some(client) = DanmakuClient::instance()
+            {
+                self.auto_search_danmaku(client, &item);
             }
             return;
         }
 
         if !state && !self.has_danmaku() {
-            self.clear_danmaku();
+            self.next_danmaku_generation();
+            self.clear_danmaku(DanmakuPopoverStatus::Idle);
         }
 
-        let ready = state && self.has_danmaku() && imp.file_loaded.get();
-        imp.danmakw.set_visible(ready);
-        if ready {
-            self.sync_danmaku_position(imp.last_playback_position.get() * 1000.0);
-        }
-        if ready && !self.paused() && !imp.loading_box.is_visible() {
-            imp.danmakw.start_rendering();
-        } else {
-            imp.danmakw.stop_rendering();
-        }
+        self.update_danmaku_rendering(state);
     }
 
     fn has_danmaku(&self) -> bool {
@@ -699,10 +665,6 @@ impl MPVPage {
         &self, selected: Option<SelectedVideoSubInfo>, item: TuItem, episode_list: Vec<TuItem>,
         video_matcher: Option<String>, start_seconds: f64,
     ) {
-        let should_search_danmaku = self
-            .current_video()
-            .as_ref()
-            .is_none_or(|current| current.id() != item.id());
         let imp = self.imp();
         imp.video.player().push_an_empty_texture();
         imp.file_loaded.set(false);
@@ -761,15 +723,15 @@ impl MPVPage {
             }
         }
         self.notify_track_changed();
-        if should_search_danmaku {
-            self.imp()
-                .danmaku_popover_content
-                .set_switch_sensitive(true);
+        if let Some(client) = DanmakuClient::instance() {
             if SETTINGS.mpv_danmaku_enabled() {
-                self.auto_search_danmaku(&item);
+                self.auto_search_danmaku(client, &item);
             } else {
-                self.clear_danmaku();
+                self.next_danmaku_generation();
+                self.clear_danmaku(DanmakuPopoverStatus::Idle);
             }
+        } else {
+            self.clear_danmaku(DanmakuPopoverStatus::SecretNotExist);
         }
         self.load_skippable_segments(id.to_owned());
 
@@ -1655,7 +1617,8 @@ impl MPVPage {
         self.imp().danmakw.set_visible(false);
         self.remove_timeout();
         self.reset_skippable_segments();
-        self.clear_danmaku();
+        self.next_danmaku_generation();
+        self.clear_danmaku(DanmakuPopoverStatus::Idle);
         let current_video = self.current_video();
 
         let video = &self.imp().video;

--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -386,7 +386,7 @@ mod imp {
 
             if self.file_loaded.get()
                 && !self.loading_box.is_visible()
-                && self.danmaku_popover_content.is_enabled()
+                && self.danmaku_popover_content.enabled()
             {
                 self.danmakw.set_paused(paused);
             }
@@ -440,7 +440,7 @@ impl MPVPage {
                 #[weak(rename_to = obj)]
                 self,
                 async move {
-                    if !obj.imp().danmaku_popover_content.is_enabled() {
+                    if !obj.imp().danmaku_popover_content.enabled() {
                         return;
                     }
                     if let Err(error) = obj
@@ -557,7 +557,7 @@ impl MPVPage {
             DanmakuPopoverStatus::Loaded(count, item_name)
         };
         imp.danmaku_popover_content.set_status(status);
-        self.update_danmaku_rendering(imp.danmaku_popover_content.is_enabled());
+        self.update_danmaku_rendering(imp.danmaku_popover_content.enabled());
     }
 
     pub async fn apply_manual_danmaku(
@@ -1292,7 +1292,7 @@ impl MPVPage {
         imp.file_loaded.set(true);
         imp.media_source_fallback.take();
 
-        if imp.danmaku_popover_content.is_enabled() && self.has_danmaku() {
+        if imp.danmaku_popover_content.enabled() && self.has_danmaku() {
             imp.danmakw.set_visible(true);
         }
 
@@ -1310,7 +1310,7 @@ impl MPVPage {
         imp.loading_box.set_visible(seeking);
         imp.spinner.set_visible(seeking);
 
-        if !imp.file_loaded.get() || !imp.danmaku_popover_content.is_enabled() {
+        if !imp.file_loaded.get() || !imp.danmaku_popover_content.enabled() {
             return;
         }
 


### PR DESCRIPTION
The previous danmaku implementation had several issues:

1. In locally built versions, the danmaku toggle and manual search dialog remained accessible even though none of the functionality worked.
2. Although the client was initialized only once, returning a `Result` caused the `DANDANAPI_SECRET_KEY is not configured` error to be logged repeatedly.
3. Because of an incorrect condition, danmaku was loaded only the first time a user opened a given video. Reopening the same video would not load it again.
4. As exposed by issue 3, the danmaku status could still show `Disabled` while the toggle was on. Normally, `Disabled` should only appear when the toggle is off.
5. Navigating back from the danmaku settings page caused the popover to jump because its height changed abruptly.

This PR addresses these issues as follows:

1. The sensitivity of the toggle and manual search button is now controlled by whether the client was initialized successfully. They are sensitive only when the client is available.
2. The client accessor now returns an `Option`, and the warning is emitted only once during initialization.
3. The incorrect condition has been removed.
4. `Disabled` is now explicitly treated as a UI presentation state for when the danmaku toggle is off, while a dedicated `Idle` state is used for other cases. `SecretNotExist` still takes precedence when the client is unavailable.
5. The height jump is mitigated by disabling `animate-transitions`.