### PR TITLE
fix: prevent cursor flicker when closing player popovers

### DIFF
--- a/crates/tsukimi/src/ui/mpv/page.rs
+++ b/crates/tsukimi/src/ui/mpv/page.rs
@@ -1630,16 +1630,13 @@ impl MPVPage {
         imp.bottom_revealer.set_reveal_child(reveal);
         imp.top_revealer.set_reveal_child(reveal);
 
-        let Some(surface) = self.native().and_then(|f| f.surface()) else {
-            return;
-        };
         let cursor = if reveal {
             gtk::gdk::Cursor::from_name("default", None)
         } else {
             gtk::gdk::Cursor::from_name("none", None)
         };
 
-        surface.set_cursor(cursor.as_ref());
+        self.set_cursor(cursor.as_ref());
     }
 
     #[template_callback]


### PR DESCRIPTION
This PR fixes the cursor flicker that occurred when clicking a button in the player to open a popover and then clicking it again to close it. This also follows [the approach recommended by GTK 4](https://gnome.pages.gitlab.gnome.org/gtk/gtk4/migrating-3to4.html#adapt-to-cursor-api-changes):

> Use the new [gtk_widget_set_cursor()](https://gnome.pages.gitlab.gnome.org/gtk/gtk4/method.Widget.set_cursor.html) function to set cursors, instead of setting the cursor on the underlying window directly.

Before:

https://github.com/user-attachments/assets/aca177f9-00f6-4eed-98a5-a64ef4d03b27

After:

https://github.com/user-attachments/assets/5ef560be-bc21-4004-bf85-8ba6805c7d9b
